### PR TITLE
Add README documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 dist/
 build/
 .pytest_cache/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,213 @@
+# SkyFollower
+
+SkyFollower is a locally-hosted ADS-B aircraft tracking system. It receives
+raw 1090 MHz and 978 MHz UAT messages from one or more readsb decoders, routes
+them through RabbitMQ for processing, enriches each flight with registration and
+operator data from Redis, evaluates configurable alert rules, archives completed
+flights as gzipped JSON to AWS S3, and publishes real-time metrics and rule
+notifications over MQTT (with Home Assistant autodiscovery).
+
+## Architecture
+
+```
+RTL-SDR 1090 ──► readsb :30002 ──┐
+RTL-SDR 978  ──► readsb :30978 ──┤
+                                  ▼
+                         [ receiver ]  (Host A — Raspberry Pi)
+                         Tags: raw, icao_hex, received_at, source
+                         Routes: adsb-{int(icao_hex, 16) % PROCESSOR_COUNT}
+                                │                        │
+                     RabbitMQ available          RabbitMQ offline
+                                │                        ▼
+                                ▼                  queue.db (SQLite WAL)
+                        RabbitMQ / Redis           drains on reconnect
+                         (Host B — server)
+                                │
+                                ▼
+                      [ processor-0 ]  (Host C)
+                      SQLite in-memory active store
+                      Redis enrichment lookups
+                      Rules engine → MQTT notifications
+                               │ completed flight
+                   RabbitMQ available ──► archive queue ──► [ archive-processor ]
+                   RabbitMQ offline   ──► archive.db                │  (Host D)
+                                          (SQLite WAL)               ├─► S3 (.json.gz)
+                                                                     └─► Parquet index
+
+   Redis ◄──────────────────────────────── data runners (ofelia-scheduled)
+    │                                      standing-data, mictronics,
+    │                                      us-faa, ca-transport-canada,
+    │                                      ourairports, flightaware
+    ▼
+ [ UI ]  FastAPI backend + React frontend
+         Rules editor, Areas editor
+```
+
+## Host Topology
+
+| Host | Role | Containers |
+|------|------|------------|
+| Host A — Raspberry Pi | ADS-B reception | `receiver` |
+| Host B — Central server | Message bus + enrichment data | `rabbitmq`, `redis`, `ofelia`, data runners |
+| Host C — Processor host | Flight state + rules | `processor-0` (one per host; scale by adding hosts) |
+| Host D — Archive host | Long-term storage + UI | `archive-processor`, `ui` |
+
+## Quick Start
+
+```bash
+cp .env.example .env          # fill in credentials
+# Place component settings files in config/ (see Configuration below)
+docker compose up -d
+```
+
+## Components
+
+| Container | Description | Default port |
+|-----------|-------------|--------------|
+| `receiver` | Reads raw ADS-B frames from readsb TCP streams; routes to RabbitMQ queues | — |
+| `processor-0` | Consumes ADS-B messages, maintains flight state, enriches from Redis, runs rules engine | — |
+| `archive-processor` | Receives completed flights from RabbitMQ, writes gzipped JSON to S3 | — |
+| `rabbitmq` | Message broker between receiver, processors, and archive | 5672, 15672 (mgmt) |
+| `redis` | In-memory enrichment store (aircraft, operators, airports, flight O/D, rules, areas) | 6379 |
+| `ofelia` | Cron scheduler that runs data runner containers on a schedule | — |
+| `ui` | FastAPI backend + React frontend for rules and areas editing | 8080 |
+| `standing-data` runner | Imports VRS SDM aircraft, operator, route, and airport data into Redis | — |
+| `mictronics` runner | Imports global aircraft registration data into Redis | — |
+| `us-faa` runner | Imports US FAA detailed registration data into Redis | — |
+| `ca-transport-canada` runner | Imports Transport Canada detailed registration data into Redis | — |
+| `ourairports` runner | Imports airport metadata into Redis | — |
+| `flightaware` runner | Imports flight origin/destination data into Redis (paid; optional) | — |
+
+## Configuration
+
+Each component reads its settings from `/app/settings.json` inside the
+container. The recommended pattern is to maintain a `config/{component}/`
+directory on the host and bind-mount it into the container:
+
+```yaml
+volumes:
+  - ./config/processor:/app
+```
+
+See the component READMEs for the full list of fields:
+
+- [processor/README.md](processor/README.md)
+- [receiver/README.md](receiver/README.md)
+- [shared/README.md](shared/README.md)
+
+## Scaling Processors
+
+Each processor handles the subset of aircraft whose ICAO hex modulo
+`PROCESSOR_COUNT` equals the processor's ID. To add a second processor:
+
+1. Add a `processor-1` service to `docker-compose.yml` with `PROCESSOR_ID: "1"`.
+2. Increment `processor_count` in the receiver's `settings.json` (e.g. `"processor_count": 2`).
+3. Restart the receiver — it will pre-declare the new queue and begin routing to it.
+
+Each processor must run on a separate host (or at least with a unique
+`PROCESSOR_ID`). The processor claims its ID in Redis on startup and exits if
+the ID is already claimed by another instance.
+
+## Data Runners
+
+Data runners populate Redis with the enrichment data that processors use to
+annotate flights. Each runner downloads a dataset, normalises it, writes it to
+Redis with a TTL, and exits. They are scheduled via an `ofelia` cron container
+running alongside Redis.
+
+| Runner | Data source | Schedule | Redis TTL |
+|--------|-------------|----------|-----------|
+| `standing-data` | VRS SDM: aircraft, operators, routes, airports | Weekly (Tue) | 14 days |
+| `mictronics` | Global registration | Weekly (Tue) | 14 days |
+| `us-faa` | US FAA detailed registration | Weekly (Sat) | 14 days |
+| `ca-transport-canada` | Transport Canada detailed registration | Weekly (Sun) | 14 days |
+| `ourairports` | Airport metadata | Weekly (Mon) | 14 days |
+| `flightaware` | Flight origin/destination (paid; optional) | Every 3 days | 3 days |
+
+Each runner publishes a single MQTT message on completion with `records_imported`,
+`last_run_at`, and `last_run_status`.
+
+## Rules
+
+Rules tell SkyFollower which aircraft to alert on. They are stored in Redis
+(`config:rules`) and edited through the UI. A rule fires at most once per flight
+per rule identifier. All conditions within a rule must match simultaneously (AND
+logic).
+
+Example `rules.example.json` entry:
+
+```json
+[
+  {
+    "identifier": "heavy-arrivals",
+    "name": "Heavy aircraft arriving",
+    "description": "Any heavy aircraft descending below 5000 ft",
+    "enabled": true,
+    "conditions": [
+      { "type": "wake_turbulence_category", "operator": "equals", "value": "heavy" },
+      { "type": "altitude", "operator": "maximum", "value": 5000 },
+      { "type": "vertical_speed", "operator": "maximum", "value": -100 }
+    ]
+  }
+]
+```
+
+Available condition types: `altitude`, `heading`, `velocity`, `vertical_speed`,
+`area`, `date`, `ident`, `squawk`, `military`, `operator_airline_designator`,
+`aircraft_type_designator`, `aircraft_registration`, `aircraft_icao_hex`,
+`aircraft_powerplant_count`, `wake_turbulence_category`, `matched_rules`.
+
+See `processor/README.md` for operator and constraint details.
+
+## Areas
+
+Named geographic polygons used with the `area` condition type. Stored in Redis
+(`config:areas`) as a GeoJSON FeatureCollection and edited through the UI's map
+editor.
+
+Example `areas.example.json`:
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "name": "Airport Approach" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-84.45, 33.60],
+          [-84.35, 33.60],
+          [-84.35, 33.70],
+          [-84.45, 33.70],
+          [-84.45, 33.60]
+        ]]
+      }
+    }
+  ]
+}
+```
+
+## Home Assistant
+
+When MQTT is configured, all components publish Home Assistant autodiscovery
+payloads on connect. Each processor, receiver, archive processor, and data
+runner appears as a device in Home Assistant with sensor entities for its key
+metrics.
+
+Rule notifications are published to `SkyFollower/rule/{identifier}` as JSON
+payloads containing the flight's current state. These can be consumed by Home
+Assistant automations directly.
+
+Full MQTT topic documentation is in `specs/asyncapi.yml`.
+
+## Development
+
+Run the test suite:
+
+```bash
+python -m pytest
+```
+
+Tests live under `processor/tests/`, `receiver/tests/`, and `shared/tests/`.

--- a/processor/README.md
+++ b/processor/README.md
@@ -1,0 +1,118 @@
+# SkyFollower Message Processor
+
+The message processor consumes raw ADS-B and UAT messages from a RabbitMQ
+queue, maintains per-aircraft flight state in an in-memory SQLite database,
+enriches each flight with registration and operator data from Redis, evaluates
+the configured rules engine, publishes MQTT notifications when rules match, and
+routes completed flights to the archive queue (or a local SQLite fallback when
+RabbitMQ is unavailable). One container equals one processor instance; scale
+horizontally by adding processor containers on separate hosts.
+
+## Configuration (`settings.json`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rabbitmq.host` | string | — | RabbitMQ hostname or IP |
+| `rabbitmq.port` | integer | `5672` | RabbitMQ AMQP port |
+| `rabbitmq.username` | string | — | RabbitMQ username |
+| `rabbitmq.password` | string | — | RabbitMQ password |
+| `redis.host` | string | — | Redis hostname or IP |
+| `redis.port` | integer | `6379` | Redis port |
+| `mqtt.host` | string | — | MQTT broker hostname (omit key to disable MQTT) |
+| `mqtt.port` | integer | `1883` | MQTT broker port |
+| `flight_ttl_seconds` | integer | `300` | Seconds of silence before a flight is considered complete and sent to the archive queue. Too short fragments flights; too long merges back-to-back flights on quick-turn aircraft. |
+| `telemetry_interval_seconds` | integer | `30` | How often (seconds) the processor publishes MQTT statistic messages and refreshes its Redis heartbeat key. |
+| `home_latitude` | float | — | Receiver home latitude (decimal degrees). Required for single-message CPR position decoding (DF 17, TC 5–18). Omit if position decoding is not needed. |
+| `home_longitude` | float | — | Receiver home longitude (decimal degrees). |
+| `data_dir` | string | `"/app/data"` | Host-mounted directory where `archive.db` (the RabbitMQ offline fallback) is written. |
+| `log_level` | string | `"info"` | Log verbosity. Set to `"debug"` for verbose output. |
+
+### `PROCESSOR_ID` Environment Variable
+
+`PROCESSOR_ID` is a required integer environment variable set in the Docker
+Compose service definition. It must match one of the queue names declared by
+the receiver (`adsb-0`, `adsb-1`, …). The processor consumes from
+`adsb-{PROCESSOR_ID}`.
+
+On startup the processor attempts to claim a Redis key
+`processor:{PROCESSOR_ID}:heartbeat` using `SET NX`. If the key already exists
+(i.e., another instance with the same ID is running), the process exits
+immediately to prevent duplicate-ID conflicts.
+
+Example:
+
+```yaml
+environment:
+  PROCESSOR_ID: "0"
+```
+
+## Redis Key Dependencies
+
+### Keys read
+
+| Key pattern | Purpose |
+|-------------|---------|
+| `icao_hex:{ICAO_HEX}` | Aircraft registration and type enrichment (read once per new flight) |
+| `operator:{DESIGNATOR}` | Airline operator enrichment (read once per flight when ident is first seen) |
+| `flight:{IDENT}` | Origin/destination enrichment (read once per flight when ident is first seen) |
+| `config:rules:version` | SHA-256 hash polled every 5 s; triggers rule reload when changed |
+| `config:rules` | JSON rules array; loaded when version changes |
+| `config:areas:version` | SHA-256 hash polled every 5 s; triggers area reload when changed |
+| `config:areas` | GeoJSON FeatureCollection; loaded when version changes |
+
+### Keys written
+
+| Key pattern | Purpose |
+|-------------|---------|
+| `processor:{ID}:heartbeat` | Liveness key; claimed with `NX` on startup, TTL refreshed every `telemetry_interval_seconds × 2` |
+| `registration:{REGISTRATION}` | Reverse-lookup index (registration → ICAO hex); written `NX` when aircraft enrichment is found and a registration exists |
+| `metrics:processor:{ID}:registration_misses:{hour\|today\|lifetime}` | Incremented each time an `icao_hex:` or `operator:` lookup returns no result |
+| `metrics:processor:{ID}:aircraft_type_misses:{hour\|today\|lifetime}` | Incremented each time an aircraft type lookup returns no result |
+
+## MQTT Topics Published
+
+All topics use the root `SkyFollower`.
+
+| Topic | Payload | Retained |
+|-------|---------|----------|
+| `SkyFollower/processor/{ID}/status` | `ONLINE` or `OFFLINE` | Yes |
+| `SkyFollower/processor/{ID}/statistic/started_at` | ISO 8601 UTC timestamp | Yes |
+| `SkyFollower/processor/{ID}/statistic/messages_per_second` | float | No |
+| `SkyFollower/processor/{ID}/statistic/avg_processing_time_ms` | float | No |
+| `SkyFollower/processor/{ID}/statistic/rules_engine_hwm_ms` | integer (resets each interval) | No |
+| `SkyFollower/processor/{ID}/statistic/rabbitmq_input_queue_depth` | integer (`-1` on error) | No |
+| `SkyFollower/processor/{ID}/statistic/local_archive_queue_depth` | integer | No |
+| `SkyFollower/processor/{ID}/statistic/registration_misses_hour` | integer | No |
+| `SkyFollower/processor/{ID}/statistic/registration_misses_today` | integer | No |
+| `SkyFollower/processor/{ID}/statistic/aircraft_type_misses_hour` | integer | No |
+| `SkyFollower/processor/{ID}/statistic/aircraft_type_misses_today` | integer | No |
+| `SkyFollower/processor/{ID}/statistic/active_flights` | integer | No |
+| `SkyFollower/rule/{IDENTIFIER}` | JSON flight snapshot (no positions/velocities) with `rule` key | No |
+
+Home Assistant autodiscovery payloads are published to
+`homeassistant/sensor/SkyFollower_processor_{ID}_{name}/config` on MQTT
+connect.
+
+## Fault Tolerance
+
+When RabbitMQ is unavailable at startup or during operation, completed flights
+are written to `archive.db` (SQLite WAL mode) in `data_dir`. On the next
+successful RabbitMQ reconnect, the fallback queue is drained oldest-first
+before new messages are consumed. Redis and MQTT failures are handled
+gracefully and logged; enrichment lookups that fail leave the flight partially
+enriched rather than dropping it.
+
+## Rules Engine
+
+Rules and areas are loaded from Redis (`config:rules` / `config:areas`) and
+hot-reloaded every 5 seconds when the corresponding version hash keys change.
+The rules engine is implemented in `processor/rules_engine.py`.
+
+Each rule must have a unique `identifier`, an `enabled` boolean, and a
+non-empty `conditions` array. All conditions within a rule are ANDed together.
+A rule fires at most once per flight per identifier (the identifier is added to
+`flight.matched_rules` on first match, and subsequent evaluations skip it).
+
+Conditions are sorted by evaluation cost before each evaluation pass — cheap
+field comparisons run before expensive geographic checks. See the top-level
+README for the full condition type reference.

--- a/processor/README.md
+++ b/processor/README.md
@@ -66,8 +66,8 @@ environment:
 |-------------|---------|
 | `processor:{ID}:heartbeat` | Liveness key; claimed with `NX` on startup, TTL refreshed every `telemetry_interval_seconds × 2` |
 | `registration:{REGISTRATION}` | Reverse-lookup index (registration → ICAO hex); written `NX` when aircraft enrichment is found and a registration exists |
-| `metrics:processor:{ID}:registration_misses:{hour\|today\|lifetime}` | Incremented each time an `icao_hex:` or `operator:` lookup returns no result |
-| `metrics:processor:{ID}:aircraft_type_misses:{hour\|today\|lifetime}` | Incremented each time an aircraft type lookup returns no result |
+| `metrics:processor:{ID}:registration_misses:{hour\|today\|lifetime}` | Incremented each time an `icao_hex:` or `operator:` lookup returns no result. The `_hour` key has a 3600 s TTL; `_today` expires at the next UTC midnight. Both are set on first write via `INCR` + `EXPIREAT`/`EXPIRE`. `_lifetime` has no TTL. |
+| `metrics:processor:{ID}:aircraft_type_misses:{hour\|today\|lifetime}` | Incremented each time an aircraft type lookup returns no result. Same TTL scheme as above. |
 
 ## MQTT Topics Published
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -78,7 +78,7 @@ All topics use the root `SkyFollower`.
 | `SkyFollower/processor/{ID}/status` | `ONLINE` or `OFFLINE` | Yes |
 | `SkyFollower/processor/{ID}/statistic/started_at` | ISO 8601 UTC timestamp | Yes |
 | `SkyFollower/processor/{ID}/statistic/messages_per_second` | float | No |
-| `SkyFollower/processor/{ID}/statistic/avg_processing_time_ms` | float | No |
+| `SkyFollower/processor/{ID}/statistic/processing_time_hwm_ms` | float; resets on publish | No |
 | `SkyFollower/processor/{ID}/statistic/rules_engine_hwm_ms` | integer (resets each interval) | No |
 | `SkyFollower/processor/{ID}/statistic/rabbitmq_input_queue_depth` | integer (`-1` on error) | No |
 | `SkyFollower/processor/{ID}/statistic/local_archive_queue_depth` | integer | No |

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -1,0 +1,108 @@
+# SkyFollower Receiver
+
+The receiver connects to one or more readsb TCP streams (raw ADS-B format),
+parses each frame to extract the ICAO hex identifier, wraps the message in a
+typed `InboundMessage` envelope, and routes it to the appropriate RabbitMQ
+queue based on a modulo-bucketing scheme. When RabbitMQ is unavailable the
+receiver writes to a local SQLite fallback queue and drains it automatically on
+reconnect. One receiver container handles all configured sources concurrently
+(one thread per source).
+
+## Configuration (`settings.json`)
+
+### Top-level fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sources` | array | — | List of readsb source objects (see below). At least one is required. |
+| `processor_count` | integer | `1` | Total number of processor containers. Must match the number of active processor services. Used to compute `queue_name = adsb-{int(icao_hex, 16) % processor_count}`. Increment this when adding a processor. |
+| `rabbitmq` | object | — | RabbitMQ connection settings (see below). |
+| `mqtt` | object | — | MQTT broker settings (see below). Omit the key entirely to disable MQTT. |
+| `telemetry_interval_seconds` | integer | `30` | How often (seconds) the receiver publishes MQTT statistic messages. |
+| `data_dir` | string | `"/app/data"` | Host-mounted directory where `queue.db` (the RabbitMQ offline fallback) is written. |
+| `log_level` | string | `"info"` | Log verbosity. Set to `"debug"` for verbose output. |
+
+### `sources[]` object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | Hostname or IP of the readsb instance. |
+| `port` | integer | TCP port of the readsb raw output (e.g. `30002` for 1090 MHz, `30978` for 978 MHz UAT). |
+| `source` | string | Tag applied to every message from this stream. One of `"1090"`, `"978"`, or `"mlat"`. |
+
+Example with two sources:
+
+```json
+{
+  "sources": [
+    { "host": "192.168.1.10", "port": 30002, "source": "1090" },
+    { "host": "192.168.1.10", "port": 30978, "source": "978" }
+  ]
+}
+```
+
+### `rabbitmq` object
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | string | — | RabbitMQ hostname or IP. |
+| `port` | integer | `5672` | RabbitMQ AMQP port. |
+| `username` | string | — | RabbitMQ username. |
+| `password` | string | — | RabbitMQ password. |
+
+### `mqtt` object
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `host` | string | — | MQTT broker hostname or IP. |
+| `port` | integer | `1883` | MQTT broker port. |
+
+## Routing
+
+Each incoming message is routed to a durable RabbitMQ queue named
+`adsb-{n}` where:
+
+```
+n = int(icao_hex, 16) % processor_count
+```
+
+This ensures all messages for a given aircraft always go to the same processor,
+preserving per-aircraft flight state without coordination between processors.
+On RabbitMQ connect the receiver pre-declares all queues (`adsb-0` through
+`adsb-{processor_count - 1}`).
+
+## Fault Tolerance
+
+When RabbitMQ is unavailable (at startup or after a disconnect), messages are
+written to `queue.db` (SQLite WAL mode) in `data_dir`. Each row stores the
+target `queue_name`, the JSON payload, and the `received_at` timestamp. When
+the RabbitMQ connection is re-established, the fallback queue is drained
+oldest-first before new messages are forwarded. If RabbitMQ drops mid-drain,
+draining stops cleanly and resumes on the next reconnect.
+
+## MQTT Topics Published
+
+All topics use the root `SkyFollower`.
+
+| Topic | Payload | Retained |
+|-------|---------|----------|
+| `SkyFollower/receiver/status` | `ONLINE` or `OFFLINE` | Yes |
+| `SkyFollower/receiver/statistic/started_at` | ISO 8601 UTC timestamp | Yes |
+| `SkyFollower/receiver/statistic/messages_{source}_per_second` | float (one per configured source, e.g. `messages_1090_per_second`) | No |
+| `SkyFollower/receiver/statistic/local_queue_depth` | integer | No |
+| `SkyFollower/receiver/statistic/rabbitmq_connected` | `"true"` or `"false"` | No |
+
+Rates are computed over a 30-second rolling window. Telemetry is published
+every `telemetry_interval_seconds`.
+
+Home Assistant autodiscovery payloads are published to
+`homeassistant/sensor/SkyFollower_receiver_{name}/config` on MQTT connect.
+
+## Adding or Changing readsb Sources
+
+1. Update the `sources` array in `settings.json` — add, remove, or edit entries.
+2. Restart the receiver container.
+
+Each source runs in its own thread; adding a source does not affect others.
+The `source` tag you choose is stamped on every message and carried through to
+the archived flight record.

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -86,13 +86,20 @@ All topics use the root `SkyFollower`.
 
 | Topic | Payload | Retained |
 |-------|---------|----------|
-| `SkyFollower/receiver/status` | `ONLINE` or `OFFLINE` | Yes |
-| `SkyFollower/receiver/statistic/started_at` | ISO 8601 UTC timestamp | Yes |
-| `SkyFollower/receiver/statistic/messages_{source}_per_second` | float (one per configured source, e.g. `messages_1090_per_second`) | No |
-| `SkyFollower/receiver/statistic/local_queue_depth` | integer | No |
-| `SkyFollower/receiver/statistic/rabbitmq_connected` | `"true"` or `"false"` | No |
+| `SkyFollower/receiver/{receiver_id}/status` | `ONLINE` or `OFFLINE` | Yes |
+| `SkyFollower/receiver/{receiver_id}/statistics` | JSON (see fields below) | Yes |
 
-Rates are computed over a 30-second rolling window. Telemetry is published
+**Statistics payload fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `messages_1090_per_second` | float | Average 1090 MHz message rate since last report |
+| `messages_978_per_second` | float | Average 978 MHz UAT message rate since last report; `0.0` if no UAT source configured |
+| `local_queue_depth` | integer | Messages queued in the local SQLite fallback (`queue.db`) |
+| `rabbitmq_connected` | boolean | `true` when an active RabbitMQ connection is held |
+| `started_at` | string | UTC ISO-8601 timestamp of process start |
+
+Rates are computed as messages received since last report ÷ elapsed seconds. Telemetry is published
 every `telemetry_interval_seconds`.
 
 Home Assistant autodiscovery payloads are published to

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,41 @@
+# shared
+
+The `shared` package contains the Pydantic data models and Redis key name
+functions used by all SkyFollower components. Keeping these in one place
+ensures that the message envelope format and Redis key naming stay consistent
+across the receiver, processor, archive processor, data runners, and UI
+backend. Components that run in their own containers install the package at
+build time via a relative path reference in their `requirements.txt`.
+
+## Contents
+
+- **`models.py`** — Pydantic models for the RabbitMQ message envelope
+  (`InboundMessage`), in-flight telemetry (`Position`, `Velocity`), Redis
+  enrichment records (`AircraftRecord`, `OperatorRecord`, `AirportRecord`,
+  `FlightEnrichment`), and the completed flight record published to the archive
+  queue (`CompletedFlight`). Also exports `generate_flight_id()` which returns
+  a UUID-v7 string used as the `_id` of each archived flight.
+
+- **`redis_keys.py`** — Functions (not string constants) for every Redis key
+  used in the system. Using functions makes key parameters explicit and allows
+  the type checker to catch typos.
+
+## Usage
+
+```python
+from shared.models import InboundMessage, CompletedFlight, AircraftRecord
+
+# Parse a message received from RabbitMQ
+msg = InboundMessage.model_validate_json(body)
+print(msg.icao_hex, msg.source)
+```
+
+```python
+from shared.redis_keys import icao_hex_key, config_rules_key
+
+# Build a Redis key for a specific aircraft
+key = icao_hex_key("A8AE7F")          # → "icao_hex:A8AE7F"
+
+# Get the key for the active rules configuration
+rules_key = config_rules_key()         # → "config:rules"
+```


### PR DESCRIPTION
## Files created

- `README.md` — Top-level project README covering architecture diagram, host topology, quick start, components table, configuration overview, scaling processors, data runners, rules, areas, Home Assistant integration, and development instructions.
- `processor/README.md` — Full configuration reference for the message processor: all `settings.json` fields, `PROCESSOR_ID` env var, Redis key dependencies, MQTT topics, fault tolerance, and rules engine notes.
- `receiver/README.md` — Full configuration reference for the receiver: all `settings.json` fields including `sources[]`, routing scheme, fallback queue behavior, and MQTT topics.
- `shared/README.md` — Brief description of the shared package and two import examples.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)