### PR TITLE
Add mictronics data runner

### DIFF
--- a/data-runners/mictronics/Dockerfile
+++ b/data-runners/mictronics/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY shared/requirements.txt shared_requirements.txt
+COPY data-runners/mictronics/requirements.txt .
+RUN pip install --no-cache-dir -r shared_requirements.txt -r requirements.txt
+
+COPY shared/ ./shared/
+COPY data-runners/mictronics/ ./mictronics/
+
+ENV PYTHONPATH=/app
+ENV SETTINGS_PATH=/app/settings.json
+
+CMD ["python", "mictronics/main.py"]

--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""
+SkyFollower Mictronics Data Runner
+
+Downloads the Mictronics IndexedDB aircraft database, parses the aircraft,
+operators, and types JSON files, stages records in local SQLite, writes
+enrichment data to Redis with a 14-day TTL, publishes MQTT completion stats,
+then exits.
+
+Data source: https://www.mictronics.de/aircraft-database/indexedDB.php
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import sqlite3
+import sys
+import zipfile
+from datetime import datetime, timezone
+from typing import Optional
+
+import paho.mqtt.client as mqtt
+import redis as redis_lib
+import requests
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from shared.redis_keys import icao_hex_key, registration_key
+
+logger = logging.getLogger("mictronics")
+
+DOWNLOAD_URL = "https://www.mictronics.de/aircraft-database/indexedDB.php"
+REDIS_TTL = 14 * 86400  # 14 days in seconds
+MQTT_ROOT = "SkyFollower/runner/mictronics"
+
+# ---------------------------------------------------------------------------
+# SQLite schema for local staging
+# ---------------------------------------------------------------------------
+_SCHEMA = """
+CREATE TABLE aircraft (
+    icao_hex        TEXT PRIMARY KEY,
+    registration    TEXT,
+    type_designator TEXT,
+    military        INTEGER
+);
+CREATE TABLE operators (
+    airline_designator TEXT PRIMARY KEY,
+    name               TEXT,
+    country            TEXT,
+    callsign           TEXT
+);
+CREATE TABLE types (
+    type_designator        TEXT PRIMARY KEY,
+    manufacturer_model     TEXT,
+    powerplant             TEXT,
+    category               TEXT,
+    wake_turbulence_category TEXT
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+def download_and_extract(url: str) -> dict[str, bytes]:
+    """Download the Mictronics ZIP and return a mapping of filename → bytes."""
+    logger.info("Downloading Mictronics database from %s", url)
+    response = requests.get(url, timeout=120)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Download failed with HTTP {response.status_code}"
+        )
+    logger.info("Download complete (%d bytes); extracting ZIP.", len(response.content))
+    files: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        for name in zf.namelist():
+            files[name.lower()] = zf.read(name)
+    logger.info("Extracted %d files: %s", len(files), list(files.keys()))
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _decode_wtc(wtc: str) -> Optional[str]:
+    mapping = {
+        "J": "Super",
+        "H": "Heavy",
+        "M": "Medium",
+        "L": "Light",
+        "M/L": "Medium/Light",
+        "-": "Unknown/None",
+    }
+    return mapping.get(wtc, "Unknown" if wtc else None)
+
+
+def _split_manufacturer_model(manufacturer_model: str) -> tuple[Optional[str], Optional[str]]:
+    """
+    Mictronics stores 'Manufacturer Model' as a single string like 'Boeing 737-800'.
+    Split on first space to get manufacturer and model.
+    """
+    if not manufacturer_model:
+        return None, None
+    parts = manufacturer_model.split(" ", 1)
+    manufacturer = parts[0].strip() or None
+    model = parts[1].strip() if len(parts) > 1 else None
+    return manufacturer, model
+
+
+# ---------------------------------------------------------------------------
+# SQLite staging
+# ---------------------------------------------------------------------------
+
+def stage_data(
+    files: dict[str, bytes],
+    db_path: str,
+) -> sqlite3.Connection:
+    """Parse all JSON files and stage rows into a SQLite database."""
+    logger.info("Opening staging database at %s", db_path)
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+
+    # --- operators.json ---
+    if "operators.json" in files:
+        operators_data = json.loads(files["operators.json"].decode("utf-8"))
+        logger.info("Staging %d operators.", len(operators_data))
+        cur = conn.cursor()
+        for designator, values in operators_data.items():
+            # values: [name, country, callsign]
+            cur.execute(
+                "INSERT OR REPLACE INTO operators "
+                "(airline_designator, name, country, callsign) VALUES (?,?,?,?)",
+                (
+                    str(designator).strip(),
+                    str(values[0]).strip() if values[0] else None,
+                    str(values[1]).strip() if values[1] else None,
+                    str(values[2]).strip() if len(values) > 2 and values[2] else None,
+                ),
+            )
+        conn.commit()
+    else:
+        logger.warning("operators.json not found in download.")
+
+    # --- types.json ---
+    if "types.json" in files:
+        types_data = json.loads(files["types.json"].decode("utf-8"))
+        logger.info("Staging %d types.", len(types_data))
+        cur = conn.cursor()
+        for designator, values in types_data.items():
+            # values: [manufacturer_model, description, wtc]
+            manufacturer_model = str(values[0]).strip() if values[0] else None
+            wtc = _decode_wtc(str(values[2]).strip()) if len(values) > 2 and values[2] else None
+            cur.execute(
+                "INSERT OR REPLACE INTO types "
+                "(type_designator, manufacturer_model, wake_turbulence_category) VALUES (?,?,?)",
+                (
+                    str(designator).strip(),
+                    manufacturer_model,
+                    wtc,
+                ),
+            )
+        conn.commit()
+    else:
+        logger.warning("types.json not found in download.")
+
+    # --- aircrafts.json ---
+    if "aircrafts.json" in files:
+        aircraft_data = json.loads(files["aircrafts.json"].decode("utf-8"))
+        logger.info("Staging %d aircraft.", len(aircraft_data))
+        cur = conn.cursor()
+        for icao_hex, values in aircraft_data.items():
+            # values: [registration, type_designator, [military_flag, interesting_flag]]
+            registration = str(values[0]).strip() if values[0] else None
+            type_designator = str(values[1]).strip() if values[1] else None
+            if type_designator == "":
+                type_designator = None
+            military = 0
+            if len(values) > 2 and isinstance(values[2], list) and len(values[2]) > 0:
+                try:
+                    military = int(values[2][0])
+                except (ValueError, TypeError):
+                    military = 0
+            cur.execute(
+                "INSERT OR REPLACE INTO aircraft "
+                "(icao_hex, registration, type_designator, military) VALUES (?,?,?,?)",
+                (
+                    str(icao_hex).strip().upper(),
+                    registration,
+                    type_designator,
+                    military,
+                ),
+            )
+        conn.commit()
+    else:
+        logger.warning("aircrafts.json not found in download.")
+
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Build Redis record
+# ---------------------------------------------------------------------------
+
+def build_aircraft_record(row: sqlite3.Row, types_row: Optional[sqlite3.Row]) -> dict:
+    """Build the icao_hex:{hex} JSON record from staged rows."""
+    icao_hex = row["icao_hex"]
+    registration = row["registration"] or None
+    type_designator = row["type_designator"] or None
+    military = bool(row["military"]) if row["military"] else False
+
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    if types_row and types_row["manufacturer_model"]:
+        manufacturer, model = _split_manufacturer_model(types_row["manufacturer_model"])
+
+    return {
+        "icao_hex": icao_hex,
+        "registration": registration,
+        "type_designator": type_designator,
+        "manufacturer": manufacturer,
+        "model": model,
+        "is_private_operator": None,
+        "operator": None,
+        "airline_code": None,
+        "serial_number": None,
+        "year_built": None,
+        "source": "mictronics",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Write to Redis
+# ---------------------------------------------------------------------------
+
+def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> int:
+    """Write all staged aircraft records to Redis. Returns count of records written."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT a.icao_hex, a.registration, a.type_designator, a.military,
+               t.manufacturer_model, t.wake_turbulence_category
+        FROM aircraft a
+        LEFT JOIN types t ON a.type_designator = t.type_designator
+        """
+    )
+    rows = cur.fetchall()
+    logger.info("Writing %d aircraft records to Redis.", len(rows))
+
+    count = 0
+    pipe = r.pipeline()
+    for row in rows:
+        types_row = None
+        if row["manufacturer_model"] is not None:
+            # Simulate a types row as a dict-like object
+            types_row = row
+        record = build_aircraft_record(row, types_row if row["manufacturer_model"] else None)
+        key = icao_hex_key(record["icao_hex"])
+        pipe.set(key, json.dumps(record), ex=ttl)
+
+        # Write registration reverse-index (NX — don't overwrite more-authoritative source)
+        if record["registration"]:
+            reg_key = registration_key(record["registration"])
+            pipe.set(reg_key, record["icao_hex"], nx=True, ex=ttl)
+
+        count += 1
+        if count % 10000 == 0:
+            pipe.execute()
+            pipe = r.pipeline()
+            logger.info("  ... %d records written.", count)
+
+    pipe.execute()
+    logger.info("Finished writing %d aircraft records to Redis.", count)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# MQTT
+# ---------------------------------------------------------------------------
+
+def publish_completion_stats(
+    cfg: dict,
+    records_imported: int,
+    status: str,
+) -> None:
+    """Publish completion statistics to MQTT and HA autodiscovery."""
+    mc = cfg.get("mqtt")
+    if not mc:
+        logger.info("No MQTT config; skipping stats publish.")
+        return
+
+    run_at = datetime.now(timezone.utc).isoformat()
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    connected = False
+
+    def _on_connect(c, userdata, flags, reason_code, properties):
+        nonlocal connected
+        connected = True
+
+    client.on_connect = _on_connect
+
+    try:
+        client.connect(mc["host"], port=mc.get("port", 1883), keepalive=60)
+        client.loop_start()
+
+        # Wait briefly for connection
+        import time
+        deadline = time.monotonic() + 5
+        while not connected and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        if not connected:
+            logger.warning("MQTT connect timed out; skipping stats publish.")
+            client.loop_stop()
+            return
+
+        base = MQTT_ROOT + "/statistic"
+        client.publish(f"{base}/records_imported", str(records_imported), retain=True)
+        client.publish(f"{base}/last_run_at", run_at, retain=True)
+        client.publish(f"{base}/last_run_status", status, retain=True)
+
+        _publish_ha_autodiscovery(client)
+
+        # Allow publishes to flush
+        time.sleep(0.5)
+        client.loop_stop()
+        client.disconnect()
+        logger.info("MQTT stats published (status=%s, records=%d).", status, records_imported)
+
+    except Exception as exc:
+        logger.warning("MQTT publish failed: %s", exc)
+        try:
+            client.loop_stop()
+        except Exception:
+            pass
+
+
+def _publish_ha_autodiscovery(client: mqtt.Client) -> None:
+    device = {
+        "ids": "SkyFollower_runner_mictronics",
+        "name": "SkyFollower Mictronics Runner",
+        "manufacturer": "P5Software, LLC",
+    }
+    stats = [
+        ("records_imported", "Mictronics Records Imported", "mdi:airplane", "total_increasing", None),
+        ("last_run_at", "Mictronics Last Run At", "mdi:clock", None, None),
+        ("last_run_status", "Mictronics Last Run Status", "mdi:check-circle", None, None),
+    ]
+    for name, friendly_name, icon, state_class, unit in stats:
+        payload: dict = {
+            "state_topic": f"{MQTT_ROOT}/statistic/{name}",
+            "name": friendly_name,
+            "unique_id": f"SkyFollower_runner_mictronics_{name}",
+            "object_id": f"SkyFollower_runner_mictronics_{name}",
+            "device": device,
+            "icon": icon,
+        }
+        if state_class:
+            payload["state_class"] = state_class
+        if unit:
+            payload["unit_of_measurement"] = unit
+        client.publish(
+            f"homeassistant/sensor/SkyFollower_runner_mictronics_{name}/config",
+            json.dumps(payload),
+            retain=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    path = os.environ.get("SETTINGS_PATH", "/app/settings.json")
+    with open(path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+        stream=sys.stdout,
+    )
+
+    try:
+        cfg = _load_config()
+    except FileNotFoundError as exc:
+        logger.critical("Settings file not found: %s", exc)
+        sys.exit(1)
+
+    rc = cfg["redis"]
+    r = redis_lib.Redis(
+        host=rc["host"],
+        port=rc.get("port", 6379),
+        decode_responses=True,
+    )
+
+    ttl_days = cfg.get("redis_ttl_days", 14)
+    ttl = ttl_days * 86400
+
+    db_path = "/app/data/staging.db"
+
+    status = "failure"
+    records_imported = 0
+
+    try:
+        # 1. Download and extract
+        files = download_and_extract(DOWNLOAD_URL)
+
+        # 2. Stage in SQLite
+        conn = stage_data(files, db_path)
+
+        # 3. Write to Redis
+        records_imported = write_to_redis(conn, r, ttl)
+        conn.close()
+
+        status = "success"
+        logger.info("Mictronics runner completed successfully. Records imported: %d", records_imported)
+
+    except Exception as exc:
+        logger.error("Mictronics runner failed: %s", exc, exc_info=True)
+        status = "failure"
+
+    finally:
+        # 4. Publish MQTT stats regardless of success/failure
+        try:
+            publish_completion_stats(cfg, records_imported, status)
+        except Exception as exc:
+            logger.warning("Failed to publish MQTT stats: %s", exc)
+
+    if status != "success":
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/data-runners/mictronics/requirements.txt
+++ b/data-runners/mictronics/requirements.txt
@@ -1,0 +1,5 @@
+pydantic>=2.0
+uuid7>=0.1.0
+redis>=5.0
+paho-mqtt>=2.0
+requests>=2.31

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -1,0 +1,465 @@
+"""
+Tests for the Mictronics data runner.
+
+Covers:
+- Parsing logic (using sample input data)
+- Redis key construction
+- MQTT completion logic (mocked)
+"""
+
+from __future__ import annotations
+
+import io
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import zipfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import helper
+# ---------------------------------------------------------------------------
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNNER_DIR = os.path.dirname(_HERE)          # data-runners/mictronics/
+_REPO_ROOT = os.path.abspath(os.path.join(_RUNNER_DIR, "..", ".."))
+
+# Ensure shared/ is importable
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _load_main():
+    """Load data-runners/mictronics/main.py as a top-level module."""
+    spec = importlib.util.spec_from_file_location(
+        "mictronics_main",
+        os.path.join(_RUNNER_DIR, "main.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["mictronics_main"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_main()
+
+# Convenience aliases
+_decode_wtc = _mod._decode_wtc
+_split_manufacturer_model = _mod._split_manufacturer_model
+build_aircraft_record = _mod.build_aircraft_record
+stage_data = _mod.stage_data
+write_to_redis = _mod.write_to_redis
+publish_completion_stats = _mod.publish_completion_stats
+REDIS_TTL = _mod.REDIS_TTL
+MQTT_ROOT = _mod.MQTT_ROOT
+
+
+# ---------------------------------------------------------------------------
+# Sample data fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_AIRCRAFTS = {
+    "A8AE7F": ["N659DL", "B763", [0, 0]],
+    "AA0001": ["N12345", "C172", [0, 0]],
+    "AA0002": ["MILCRAFT", "F16", [1, 0]],
+    "AA0003": ["", "", [0, 0]],
+}
+
+SAMPLE_OPERATORS = {
+    "DAL": ["Delta Air Lines", "United States", "DELTA"],
+    "AAL": ["American Airlines", "United States", "AMERICAN"],
+}
+
+SAMPLE_TYPES = {
+    "B763": ["Boeing 767-332ER", "L2J", "H"],
+    "C172": ["Cessna 172 Skyhawk", "L1P", "L"],
+    "F16": ["Lockheed Martin F-16", "L1J", "M"],
+}
+
+
+def _make_zip_files(aircrafts=None, operators=None, types=None) -> dict[str, bytes]:
+    """Build the files dict that stage_data expects."""
+    files: dict[str, bytes] = {}
+    if aircrafts is not None:
+        files["aircrafts.json"] = json.dumps(aircrafts).encode()
+    if operators is not None:
+        files["operators.json"] = json.dumps(operators).encode()
+    if types is not None:
+        files["types.json"] = json.dumps(types).encode()
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_wtc
+# ---------------------------------------------------------------------------
+
+class TestDecodeWtc:
+    def test_heavy(self):
+        assert _decode_wtc("H") == "Heavy"
+
+    def test_light(self):
+        assert _decode_wtc("L") == "Light"
+
+    def test_medium(self):
+        assert _decode_wtc("M") == "Medium"
+
+    def test_super(self):
+        assert _decode_wtc("J") == "Super"
+
+    def test_medium_light(self):
+        assert _decode_wtc("M/L") == "Medium/Light"
+
+    def test_dash_is_unknown_none(self):
+        assert _decode_wtc("-") == "Unknown/None"
+
+    def test_empty_returns_none(self):
+        assert _decode_wtc("") is None
+
+    def test_unknown_code_returns_unknown(self):
+        assert _decode_wtc("X") == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _split_manufacturer_model
+# ---------------------------------------------------------------------------
+
+class TestSplitManufacturerModel:
+    def test_normal_split(self):
+        mfr, mdl = _split_manufacturer_model("Boeing 767-332ER")
+        assert mfr == "Boeing"
+        assert mdl == "767-332ER"
+
+    def test_single_word(self):
+        mfr, mdl = _split_manufacturer_model("Airbus")
+        assert mfr == "Airbus"
+        assert mdl is None
+
+    def test_empty_string(self):
+        mfr, mdl = _split_manufacturer_model("")
+        assert mfr is None
+        assert mdl is None
+
+    def test_multi_word_model(self):
+        mfr, mdl = _split_manufacturer_model("Cessna 172 Skyhawk")
+        assert mfr == "Cessna"
+        assert mdl == "172 Skyhawk"
+
+
+# ---------------------------------------------------------------------------
+# Tests: stage_data (parsing)
+# ---------------------------------------------------------------------------
+
+class TestStageData:
+    def test_aircraft_count(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM aircraft")
+            assert cur.fetchone()[0] == len(SAMPLE_AIRCRAFTS)
+            conn.close()
+
+    def test_aircraft_fields(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT icao_hex, registration, type_designator, military "
+                "FROM aircraft WHERE icao_hex = 'A8AE7F'"
+            )
+            row = cur.fetchone()
+            assert row[0] == "A8AE7F"
+            assert row[1] == "N659DL"
+            assert row[2] == "B763"
+            assert row[3] == 0
+            conn.close()
+
+    def test_military_flag(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT military FROM aircraft WHERE icao_hex = 'AA0002'")
+            assert cur.fetchone()[0] == 1
+            conn.close()
+
+    def test_empty_type_becomes_null(self):
+        aircrafts = {"AAAAAA": ["N00001", "", [0, 0]]}
+        files = _make_zip_files(aircrafts=aircrafts, operators={}, types={})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT type_designator FROM aircraft WHERE icao_hex = 'AAAAAA'")
+            assert cur.fetchone()[0] is None
+            conn.close()
+
+    def test_operators_staged(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM operators")
+            assert cur.fetchone()[0] == len(SAMPLE_OPERATORS)
+            conn.close()
+
+    def test_types_staged_with_wtc(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT manufacturer_model, wake_turbulence_category "
+                "FROM types WHERE type_designator = 'B763'"
+            )
+            row = cur.fetchone()
+            assert row[0] == "Boeing 767-332ER"
+            assert row[1] == "Heavy"
+            conn.close()
+
+    def test_icao_hex_uppercased(self):
+        aircrafts = {"a8ae7f": ["N659DL", "B763", [0, 0]]}
+        files = _make_zip_files(aircrafts=aircrafts, operators={}, types={})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT icao_hex FROM aircraft")
+            row = cur.fetchone()
+            assert row[0] == "A8AE7F"
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_aircraft_record
+# ---------------------------------------------------------------------------
+
+class TestBuildAircraftRecord:
+    def _row(self, icao_hex, registration, type_designator, military, manufacturer_model=None):
+        return {
+            "icao_hex": icao_hex,
+            "registration": registration,
+            "type_designator": type_designator,
+            "military": military,
+            "manufacturer_model": manufacturer_model,
+        }
+
+    def test_full_record_shape(self):
+        row = self._row("A8AE7F", "N659DL", "B763", 0, "Boeing 767-332ER")
+        record = build_aircraft_record(row, row)
+
+        assert record["icao_hex"] == "A8AE7F"
+        assert record["registration"] == "N659DL"
+        assert record["type_designator"] == "B763"
+        assert record["manufacturer"] == "Boeing"
+        assert record["model"] == "767-332ER"
+        assert record["source"] == "mictronics"
+
+    def test_null_fields_present(self):
+        """Fields unavailable from Mictronics must be null, not omitted."""
+        row = self._row("A8AE7F", "N659DL", "B763", 0, "Boeing 767-332ER")
+        record = build_aircraft_record(row, row)
+
+        for field in ("is_private_operator", "operator", "airline_code", "serial_number", "year_built"):
+            assert field in record, f"Missing field: {field!r}"
+            assert record[field] is None, f"Field {field!r} should be None"
+
+    def test_no_types_row(self):
+        row = self._row("A8AE7F", "N659DL", "B763", 0)
+        record = build_aircraft_record(row, None)
+        assert record["manufacturer"] is None
+        assert record["model"] is None
+
+    def test_empty_registration_becomes_none(self):
+        row = self._row("AA0003", "", None, 0)
+        record = build_aircraft_record(row, None)
+        assert record["registration"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Redis key construction
+# ---------------------------------------------------------------------------
+
+class TestRedisKeys:
+    def test_icao_hex_key_format(self):
+        from shared.redis_keys import icao_hex_key
+        assert icao_hex_key("a8ae7f") == "icao_hex:A8AE7F"
+
+    def test_icao_hex_key_already_upper(self):
+        from shared.redis_keys import icao_hex_key
+        assert icao_hex_key("A8AE7F") == "icao_hex:A8AE7F"
+
+    def test_registration_key_format(self):
+        from shared.redis_keys import registration_key
+        assert registration_key("n659dl") == "registration:N659DL"
+
+
+# ---------------------------------------------------------------------------
+# Tests: write_to_redis
+# ---------------------------------------------------------------------------
+
+class TestWriteToRedis:
+    def _make_db(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(_mod._SCHEMA)
+        conn.execute(
+            "INSERT INTO aircraft (icao_hex, registration, type_designator, military) "
+            "VALUES ('A8AE7F', 'N659DL', 'B763', 0)"
+        )
+        conn.execute(
+            "INSERT INTO aircraft (icao_hex, registration, type_designator, military) "
+            "VALUES ('AA0001', 'N12345', 'C172', 0)"
+        )
+        conn.execute(
+            "INSERT INTO types (type_designator, manufacturer_model, wake_turbulence_category) "
+            "VALUES ('B763', 'Boeing 767-332ER', 'Heavy')"
+        )
+        conn.commit()
+        return conn
+
+    def _mock_redis(self):
+        r = MagicMock()
+        pipe = MagicMock()
+        r.pipeline.return_value = pipe
+        pipe.execute.return_value = []
+        pipe.set.return_value = pipe
+        return r, pipe
+
+    def test_count_matches_aircraft(self):
+        conn = self._make_db()
+        r, _ = self._mock_redis()
+        assert write_to_redis(conn, r, REDIS_TTL) == 2
+        conn.close()
+
+    def test_icao_hex_key_written(self):
+        conn = self._make_db()
+        r, pipe = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        keys = [c.args[0] for c in pipe.set.call_args_list]
+        assert "icao_hex:A8AE7F" in keys
+        conn.close()
+
+    def test_registration_nx_written(self):
+        conn = self._make_db()
+        r, pipe = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        nx_keys = [c.args[0] for c in pipe.set.call_args_list if c.kwargs.get("nx")]
+        assert "registration:N659DL" in nx_keys
+        conn.close()
+
+    def test_all_registration_writes_use_nx(self):
+        """Every registration reverse-index write must use NX."""
+        conn = self._make_db()
+        r, pipe = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        for c in pipe.set.call_args_list:
+            if c.args[0].startswith("registration:"):
+                assert c.kwargs.get("nx") is True
+        conn.close()
+
+    def test_correct_ttl(self):
+        conn = self._make_db()
+        r, pipe = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        for c in pipe.set.call_args_list:
+            assert c.kwargs.get("ex") == REDIS_TTL
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: MQTT completion stats (mocked)
+# ---------------------------------------------------------------------------
+
+class TestMqttCompletionStats:
+    def _setup_mock_client(self):
+        mock_client = MagicMock()
+
+        def fake_connect(host, port, keepalive):
+            # Trigger on_connect callback synchronously
+            mock_client.on_connect(mock_client, None, None, 0, None)
+
+        mock_client.connect.side_effect = fake_connect
+        return mock_client
+
+    def test_publishes_records_imported(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("mictronics_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 42, "success")
+        topics = [c.args[0] for c in mc.publish.call_args_list]
+        assert f"{MQTT_ROOT}/statistic/records_imported" in topics
+
+    def test_records_imported_value(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("mictronics_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 99, "success")
+        calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
+        assert calls[f"{MQTT_ROOT}/statistic/records_imported"] == "99"
+
+    def test_publishes_last_run_at(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("mictronics_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 0, "success")
+        topics = [c.args[0] for c in mc.publish.call_args_list]
+        assert f"{MQTT_ROOT}/statistic/last_run_at" in topics
+
+    def test_publishes_last_run_status(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("mictronics_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 0, "failure")
+        calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
+        assert calls[f"{MQTT_ROOT}/statistic/last_run_status"] == "failure"
+
+    def test_no_mqtt_config_skips(self):
+        cfg = {}
+        mc = self._setup_mock_client()
+        with patch("mictronics_main.mqtt.Client", return_value=mc):
+            publish_completion_stats(cfg, 0, "success")
+        mc.connect.assert_not_called()
+
+    def test_ha_autodiscovery_three_sensors(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("mictronics_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 100, "success")
+        ha_topics = [
+            c.args[0] for c in mc.publish.call_args_list
+            if c.args[0].startswith("homeassistant/")
+        ]
+        assert len(ha_topics) == 3
+        assert "homeassistant/sensor/SkyFollower_runner_mictronics_records_imported/config" in ha_topics
+        assert "homeassistant/sensor/SkyFollower_runner_mictronics_last_run_at/config" in ha_topics
+        assert "homeassistant/sensor/SkyFollower_runner_mictronics_last_run_status/config" in ha_topics


### PR DESCRIPTION
## Summary

- Downloads the Mictronics IndexedDB ZIP from https://www.mictronics.de/aircraft-database/indexedDB.php
- Parses `aircrafts.json`, `operators.json`, and `types.json` from the ZIP
- Stages records in local SQLite at `/app/data/staging.db`
- Writes `icao_hex:{hex}` JSON records to Redis with 14-day TTL
- Writes `registration:{reg}` reverse-index keys with NX flag (preserves more-authoritative sources)
- Publishes MQTT completion stats (`records_imported`, `last_run_at`, `last_run_status`) with HA autodiscovery
- Container exits cleanly after import

## Test plan

- [ ] Run `pytest data-runners/mictronics/tests/ -v` — all 37 tests pass
- [ ] WTC decoding (Heavy/Light/Medium/Super/Medium-Light/Unknown)
- [ ] Manufacturer/model splitting from Mictronics combined string
- [ ] SQLite staging: aircraft count, field values, military flag, empty type → null, uppercase ICAO hex
- [ ] `build_aircraft_record`: null fields present for unavailable data, no types row handled
- [ ] Redis key format: `icao_hex:A8AE7F`, `registration:N659DL`
- [ ] Redis writes: correct count, correct TTL, NX flag on registration keys
- [ ] MQTT: all three stat topics published, HA autodiscovery for 3 sensors, no-config skips silently

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/claude-code)