### PR TITLE
Add RECEIVER_ID and publish receiver stats as single JSON payload

### DIFF
--- a/docker-compose.receiver.yaml
+++ b/docker-compose.receiver.yaml
@@ -6,6 +6,8 @@ services:
     volumes:
       - ./config/receiver/settings.json:/app/settings.json:ro
       - receiver-queue:/app/data
+    environment:
+      RECEIVER_ID: "0"
 
 volumes:
   receiver-queue:

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -57,6 +57,15 @@ Example with two sources:
 | `host` | string | — | MQTT broker hostname or IP. |
 | `port` | integer | `1883` | MQTT broker port. |
 
+## `RECEIVER_ID` Environment Variable
+
+`RECEIVER_ID` is an optional integer environment variable (default `0`). It distinguishes multiple receiver containers publishing to the same MQTT broker and is included in every MQTT topic published by the receiver.
+
+```yaml
+environment:
+  RECEIVER_ID: "0"
+```
+
 ## Routing
 
 Each incoming message is routed to a durable RabbitMQ queue named
@@ -99,11 +108,12 @@ All topics use the root `SkyFollower`.
 | `rabbitmq_connected` | boolean | `true` when an active RabbitMQ connection is held |
 | `started_at` | string | UTC ISO-8601 timestamp of process start |
 
-Rates are computed as messages received since last report ÷ elapsed seconds. Telemetry is published
-every `telemetry_interval_seconds`.
+All statistics are published as a single retained JSON payload. Telemetry is published every `telemetry_interval_seconds`.
 
 Home Assistant autodiscovery payloads are published to
-`homeassistant/sensor/SkyFollower_receiver_{name}/config` on MQTT connect.
+`homeassistant/sensor/SkyFollower_receiver_{receiver_id}_{field}/config` on MQTT connect.
+Each sensor uses `state_topic: SkyFollower/receiver/{receiver_id}/statistics` with a
+`value_template` to extract its field.
 
 ## Adding or Changing readsb Sources
 

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -574,7 +574,12 @@ def _load_config() -> dict:
 
 
 def main() -> None:
-    receiver_id = int(os.environ.get("RECEIVER_ID", "0"))
+    receiver_id_str = os.environ.get("RECEIVER_ID", "0")
+    try:
+        receiver_id = int(receiver_id_str)
+    except ValueError:
+        print(f"RECEIVER_ID must be an integer, got: {receiver_id_str!r}", file=sys.stderr)
+        sys.exit(1)
     config = _load_config()
     receiver = Receiver(config, receiver_id)
 

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -176,8 +176,9 @@ class _FallbackQueue:
 
 class Receiver:
 
-    def __init__(self, config: dict) -> None:
+    def __init__(self, config: dict, receiver_id: int = 0) -> None:
         self._cfg = config
+        self._id = receiver_id
         self._started_at = datetime.now(timezone.utc).isoformat()
         self._shutdown = threading.Event()
 
@@ -428,7 +429,9 @@ class Receiver:
             return
 
         self._mqtt = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
-        self._mqtt.will_set("SkyFollower/receiver/status", "OFFLINE", retain=True)
+        self._mqtt.will_set(
+            f"SkyFollower/receiver/{self._id}/status", "OFFLINE", retain=True
+        )
         self._mqtt.on_connect = self._on_mqtt_connect
         self._mqtt.on_disconnect = self._on_mqtt_disconnect
         try:
@@ -441,11 +444,8 @@ class Receiver:
         self, client, userdata, flags, reason_code, properties
     ) -> None:
         self._mqtt_connected = True
-        client.publish("SkyFollower/receiver/status", "ONLINE", retain=True)
         client.publish(
-            "SkyFollower/receiver/statistic/started_at",
-            self._started_at,
-            retain=True,
+            f"SkyFollower/receiver/{self._id}/status", "ONLINE", retain=True
         )
         self._publish_ha_autodiscovery()
         logger.info("MQTT connected.")
@@ -454,10 +454,6 @@ class Receiver:
         self, client, userdata, flags, reason_code, properties
     ) -> None:
         self._mqtt_connected = False
-
-    def _mqtt_publish(self, topic: str, value) -> None:
-        if self._mqtt and self._mqtt_connected:
-            self._mqtt.publish(topic, str(value))
 
     # ------------------------------------------------------------------
     # Telemetry
@@ -470,22 +466,23 @@ class Receiver:
             self._publish_telemetry()
 
     def _publish_telemetry(self) -> None:
-        base = "SkyFollower/receiver/statistic"
+        if not (self._mqtt and self._mqtt_connected):
+            return
 
         with self._rmq_lock:
             rmq_connected = self._rmq_connected
 
-        # Build per-source message rates
-        stats: dict[str, object] = {}
+        payload: dict = {"started_at": self._started_at}
         for source, tracker in self._rates.items():
-            stat_name = f"messages_{source}_per_second"
-            stats[stat_name] = round(tracker.rate(), 2)
+            payload[f"messages_{source}_per_second"] = round(tracker.rate(), 2)
+        payload["local_queue_depth"] = self._fallback.depth()
+        payload["rabbitmq_connected"] = rmq_connected
 
-        stats["local_queue_depth"] = self._fallback.depth()
-        stats["rabbitmq_connected"] = "true" if rmq_connected else "false"
-
-        for name, value in stats.items():
-            self._mqtt_publish(f"{base}/{name}", value)
+        self._mqtt.publish(
+            f"SkyFollower/receiver/{self._id}/statistics",
+            json.dumps(payload),
+            retain=True,
+        )
 
     # ------------------------------------------------------------------
     # HA autodiscovery
@@ -495,40 +492,39 @@ class Receiver:
         if not (self._mqtt and self._mqtt_connected):
             return
 
+        rid = self._id
+        stats_topic = f"SkyFollower/receiver/{rid}/statistics"
         device = {
-            "ids": "SkyFollower_receiver",
-            "name": "SkyFollower Receiver",
+            "ids": f"SkyFollower_receiver_{rid}",
+            "name": f"SkyFollower Receiver {rid}",
             "manufacturer": "P5Software, LLC",
         }
         availability = {
-            "availability_topic": "SkyFollower/receiver/status",
+            "availability_topic": f"SkyFollower/receiver/{rid}/status",
             "payload_available": "ONLINE",
             "payload_not_available": "OFFLINE",
         }
 
-        # Build list of stat sensors from configured sources
-        stats = []
+        sensors = []
         for source in self._rates:
-            stat_name = f"messages_{source}_per_second"
-            stats.append((
-                stat_name,
-                f"Messages {source} per Second",
-                "mdi:broadcast",
-                "measurement",
-                "msg/s",
-            ))
-        stats += [
-            ("local_queue_depth", "Local Queue Depth", "mdi:tray-full", "measurement", None),
-            ("rabbitmq_connected", "RabbitMQ Connected", "mdi:rabbit", None, None),
+            field = f"messages_{source}_per_second"
+            sensors.append((field, f"Receiver {rid} — {source} Messages/sec",
+                             "mdi:broadcast", "measurement", "msg/s"))
+        sensors += [
+            ("local_queue_depth", f"Receiver {rid} — Local Queue Depth",
+             "mdi:tray-full", "measurement", None),
+            ("rabbitmq_connected", f"Receiver {rid} — RabbitMQ Connected",
+             "mdi:rabbit", None, None),
         ]
 
-        for name, desc, icon, state_class, unit in stats:
+        for field, desc, icon, state_class, unit in sensors:
             payload: dict = {
                 **availability,
-                "state_topic": f"SkyFollower/receiver/statistic/{name}",
+                "state_topic": stats_topic,
+                "value_template": f"{{{{ value_json.{field} }}}}",
                 "name": desc,
-                "unique_id": f"SkyFollower_receiver_{name}",
-                "object_id": f"SkyFollower_receiver_{name}",
+                "unique_id": f"SkyFollower_receiver_{rid}_{field}",
+                "object_id": f"SkyFollower_receiver_{rid}_{field}",
                 "device": device,
                 "icon": icon,
             }
@@ -538,7 +534,7 @@ class Receiver:
                 payload["unit_of_measurement"] = unit
 
             self._mqtt.publish(
-                f"homeassistant/sensor/SkyFollower_receiver_{name}/config",
+                f"homeassistant/sensor/SkyFollower_receiver_{rid}_{field}/config",
                 json.dumps(payload),
                 retain=True,
             )
@@ -552,7 +548,9 @@ class Receiver:
         self._shutdown.set()
 
         if self._mqtt:
-            self._mqtt.publish("SkyFollower/receiver/status", "OFFLINE", retain=True)
+            self._mqtt.publish(
+                f"SkyFollower/receiver/{self._id}/status", "OFFLINE", retain=True
+            )
             self._mqtt.loop_stop()
 
         with self._rmq_lock:
@@ -576,8 +574,9 @@ def _load_config() -> dict:
 
 
 def main() -> None:
+    receiver_id = int(os.environ.get("RECEIVER_ID", "0"))
     config = _load_config()
-    receiver = Receiver(config)
+    receiver = Receiver(config, receiver_id)
 
     def _handle_signal(sig, frame):
         receiver.shutdown()

--- a/receiver/tests/test_receiver.py
+++ b/receiver/tests/test_receiver.py
@@ -131,7 +131,7 @@ class TestIcaoRoutingIntegration:
     Receiver._handle_message internals (using mocked publishing).
     """
 
-    def _make_receiver(self, processor_count: int = 4):
+    def _make_receiver(self, processor_count: int = 4, receiver_id: int = 0):
         """Build a Receiver with a stub config (no real connections)."""
         from receiver.main import Receiver
         cfg = {
@@ -141,7 +141,7 @@ class TestIcaoRoutingIntegration:
             "telemetry_interval_seconds": 30,
             "data_dir": tempfile.mkdtemp(),
         }
-        return Receiver(cfg)
+        return Receiver(cfg, receiver_id)
 
     def test_queue_name_from_icao_modulo(self):
         """Queue is adsb-{int(icao_hex, 16) % processor_count}."""
@@ -370,3 +370,138 @@ class TestRateTracker:
             t.join()
 
         assert errors == [], f"Thread safety errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# RECEIVER_ID and MQTT topic structure
+# ---------------------------------------------------------------------------
+
+class TestReceiverIdAndTopics:
+    """Tests for RECEIVER_ID env var and resulting MQTT topic naming."""
+
+    def _make_receiver(self, receiver_id: int = 0):
+        import tempfile
+        from receiver.main import Receiver
+        cfg = {
+            "sources": [{"host": "localhost", "port": 30002, "source": "1090"}],
+            "processor_count": 1,
+            "rabbitmq": {"host": "localhost", "username": "u", "password": "p"},
+            "data_dir": tempfile.mkdtemp(),
+        }
+        return Receiver(cfg, receiver_id)
+
+    def test_default_receiver_id_is_zero(self):
+        r = self._make_receiver()
+        assert r._id == 0
+
+    def test_receiver_id_set_correctly(self):
+        r = self._make_receiver(receiver_id=3)
+        assert r._id == 3
+
+    def test_main_reads_receiver_id_from_env(self):
+        import os
+        from unittest.mock import patch, MagicMock
+        with patch.dict(os.environ, {"RECEIVER_ID": "2"}):
+            with patch("receiver.main._load_config", return_value={
+                "sources": [], "rabbitmq": {"host": "x", "username": "u", "password": "p"},
+                "data_dir": tempfile.mkdtemp(),
+            }):
+                with patch("receiver.main.Receiver") as mock_cls:
+                    mock_cls.return_value.start = MagicMock()
+                    import receiver.main as rm
+                    rm.main()
+                    args = mock_cls.call_args
+                    assert args[0][1] == 2  # receiver_id positional arg
+
+
+# ---------------------------------------------------------------------------
+# Telemetry — single JSON payload
+# ---------------------------------------------------------------------------
+
+class TestTelemetryPayload:
+    """Tests for _publish_telemetry() single-JSON-payload behaviour."""
+
+    def _make_receiver(self, receiver_id: int = 0):
+        import tempfile
+        from receiver.main import Receiver
+        cfg = {
+            "sources": [
+                {"host": "localhost", "port": 30002, "source": "1090"},
+                {"host": "localhost", "port": 30978, "source": "978"},
+            ],
+            "processor_count": 1,
+            "rabbitmq": {"host": "localhost", "username": "u", "password": "p"},
+            "data_dir": tempfile.mkdtemp(),
+        }
+        return Receiver(cfg, receiver_id)
+
+    def test_publish_telemetry_single_publish_call(self):
+        r = self._make_receiver(receiver_id=1)
+        mock_mqtt = MagicMock()
+        r._mqtt = mock_mqtt
+        r._mqtt_connected = True
+        r._publish_telemetry()
+        assert mock_mqtt.publish.call_count == 1
+
+    def test_publish_telemetry_correct_topic(self):
+        r = self._make_receiver(receiver_id=2)
+        mock_mqtt = MagicMock()
+        r._mqtt = mock_mqtt
+        r._mqtt_connected = True
+        r._publish_telemetry()
+        topic = mock_mqtt.publish.call_args[0][0]
+        assert topic == "SkyFollower/receiver/2/statistics"
+
+    def test_publish_telemetry_retained(self):
+        r = self._make_receiver()
+        mock_mqtt = MagicMock()
+        r._mqtt = mock_mqtt
+        r._mqtt_connected = True
+        r._publish_telemetry()
+        kwargs = mock_mqtt.publish.call_args[1]
+        assert kwargs.get("retain") is True
+
+    def test_publish_telemetry_payload_fields(self):
+        r = self._make_receiver()
+        mock_mqtt = MagicMock()
+        r._mqtt = mock_mqtt
+        r._mqtt_connected = True
+        r._publish_telemetry()
+        import json
+        payload = json.loads(mock_mqtt.publish.call_args[0][1])
+        assert "messages_1090_per_second" in payload
+        assert "messages_978_per_second" in payload
+        assert "local_queue_depth" in payload
+        assert "rabbitmq_connected" in payload
+        assert "started_at" in payload
+
+    def test_rabbitmq_connected_is_boolean(self):
+        r = self._make_receiver()
+        mock_mqtt = MagicMock()
+        r._mqtt = mock_mqtt
+        r._mqtt_connected = True
+        r._publish_telemetry()
+        import json
+        payload = json.loads(mock_mqtt.publish.call_args[0][1])
+        assert isinstance(payload["rabbitmq_connected"], bool)
+
+    def test_no_publish_when_mqtt_not_connected(self):
+        r = self._make_receiver()
+        mock_mqtt = MagicMock()
+        r._mqtt = mock_mqtt
+        r._mqtt_connected = False
+        r._publish_telemetry()
+        mock_mqtt.publish.assert_not_called()
+
+    def test_ha_autodiscovery_uses_value_template(self):
+        r = self._make_receiver(receiver_id=0)
+        mock_mqtt = MagicMock()
+        r._mqtt = mock_mqtt
+        r._mqtt_connected = True
+        r._publish_ha_autodiscovery()
+        import json
+        for call in mock_mqtt.publish.call_args_list:
+            if call[0][0].startswith("homeassistant/"):
+                cfg_payload = json.loads(call[0][1])
+                assert "value_template" in cfg_payload
+                assert cfg_payload["state_topic"] == "SkyFollower/receiver/0/statistics"

--- a/receiver/tests/test_receiver.py
+++ b/receiver/tests/test_receiver.py
@@ -398,6 +398,18 @@ class TestReceiverIdAndTopics:
         r = self._make_receiver(receiver_id=3)
         assert r._id == 3
 
+    def test_main_exits_on_non_integer_receiver_id(self):
+        import os
+        with patch.dict(os.environ, {"RECEIVER_ID": "notanint"}):
+            with patch("receiver.main._load_config", return_value={
+                "sources": [], "rabbitmq": {"host": "x", "username": "u", "password": "p"},
+                "data_dir": tempfile.mkdtemp(),
+            }):
+                import receiver.main as rm
+                with pytest.raises(SystemExit) as exc_info:
+                    rm.main()
+                assert exc_info.value.code == 1
+
     def test_main_reads_receiver_id_from_env(self):
         import os
         from unittest.mock import patch, MagicMock


### PR DESCRIPTION
## Summary

- Reads `RECEIVER_ID` env var (default `0`) at startup — same pattern as `PROCESSOR_ID`
- All MQTT topics now include `{receiver_id}`: `SkyFollower/receiver/{id}/status` and `SkyFollower/receiver/{id}/statistics`
- Replaces N per-stat topic publishes with a single retained JSON payload on `.../statistics` each telemetry interval
- `started_at` included in every stats payload (no longer published separately on connect)
- `rabbitmq_connected` published as native boolean (was `"true"`/`"false"` strings)
- HA autodiscovery updated: single `state_topic` pointing to `.../statistics` with `value_template` per sensor
- `docker-compose.receiver.yaml` updated with `RECEIVER_ID: "0"` environment entry

## Test plan

- [ ] `pytest receiver/tests/ -v` — all 41 tests pass
- [ ] `RECEIVER_ID` defaults to `0`; set to non-zero and topics change accordingly
- [ ] Stats payload published as single JSON with retain=True
- [ ] Payload contains `messages_1090_per_second`, `messages_978_per_second`, `local_queue_depth`, `rabbitmq_connected` (bool), `started_at`
- [ ] No publish when MQTT not connected
- [ ] HA autodiscovery sensors all reference `.../statistics` with `value_template`

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/claude-code)