### PR TITLE
Add US FAA runner, RedisJSON migration, and mictronics updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 build/
 .pytest_cache/
 CLAUDE.md
+*.local.json

--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -28,7 +28,10 @@ import requests
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from shared.redis_keys import icao_hex_key, registration_key
+from redis.commands.search.field import TagField
+from redis.commands.search.index_definition import IndexDefinition, IndexType
+
+from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
 
 logger = logging.getLogger("mictronics")
 
@@ -44,7 +47,8 @@ CREATE TABLE aircraft (
     icao_hex        TEXT PRIMARY KEY,
     registration    TEXT,
     type_designator TEXT,
-    military        INTEGER
+    military        INTEGER,
+    interesting     INTEGER
 );
 CREATE TABLE operators (
     airline_designator TEXT PRIMARY KEY,
@@ -176,25 +180,27 @@ def stage_data(
         logger.info("Staging %d aircraft.", len(aircraft_data))
         cur = conn.cursor()
         for icao_hex, values in aircraft_data.items():
-            # values: [registration, type_designator, [military_flag, interesting_flag]]
+            # values: [registration, type_designator, flags]
+            # flags is a 2-char string: flags[0]="1" → military, flags[1]="1" → interesting
             registration = str(values[0]).strip() if values[0] else None
             type_designator = str(values[1]).strip() if values[1] else None
             if type_designator == "":
                 type_designator = None
-            military = 0
-            if len(values) > 2 and isinstance(values[2], list) and len(values[2]) > 0:
-                try:
-                    military = int(values[2][0])
-                except (ValueError, TypeError):
-                    military = 0
+            military = False
+            interesting = False
+            if len(values) > 2 and values[2]:
+                flags = str(values[2])
+                military = len(flags) > 0 and flags[0] == "1"
+                interesting = len(flags) > 1 and flags[1] == "1"
             cur.execute(
                 "INSERT OR REPLACE INTO aircraft "
-                "(icao_hex, registration, type_designator, military) VALUES (?,?,?,?)",
+                "(icao_hex, registration, type_designator, military, interesting) VALUES (?,?,?,?,?)",
                 (
                     str(icao_hex).strip().upper(),
                     registration,
                     type_designator,
                     military,
+                    interesting,
                 ),
             )
         conn.commit()
@@ -213,12 +219,16 @@ def build_aircraft_record(row: sqlite3.Row, types_row: Optional[sqlite3.Row]) ->
     icao_hex = row["icao_hex"]
     registration = row["registration"] or None
     type_designator = row["type_designator"] or None
-    military = bool(row["military"]) if row["military"] else False
+    military = bool(row["military"])
+    interesting = bool(row["interesting"])
 
     manufacturer: Optional[str] = None
     model: Optional[str] = None
+    wake_turbulence_category: Optional[str] = None
     if types_row and types_row["manufacturer_model"]:
         manufacturer, model = _split_manufacturer_model(types_row["manufacturer_model"])
+    if types_row:
+        wake_turbulence_category = types_row["wake_turbulence_category"] or None
 
     return {
         "icao_hex": icao_hex,
@@ -226,6 +236,9 @@ def build_aircraft_record(row: sqlite3.Row, types_row: Optional[sqlite3.Row]) ->
         "type_designator": type_designator,
         "manufacturer": manufacturer,
         "model": model,
+        "wake_turbulence_category": wake_turbulence_category,
+        "military": military,
+        "interesting": interesting,
         "is_private_operator": None,
         "operator": None,
         "airline_code": None,
@@ -233,6 +246,25 @@ def build_aircraft_record(row: sqlite3.Row, types_row: Optional[sqlite3.Row]) ->
         "year_built": None,
         "source": "mictronics",
     }
+
+
+# ---------------------------------------------------------------------------
+# Search index
+# ---------------------------------------------------------------------------
+
+def _ensure_search_index(r: redis_lib.Redis) -> None:
+    """Create the aircraft JSON search index if it does not already exist."""
+    try:
+        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+    except Exception:
+        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+            fields=[
+                TagField("$.icao_hex", as_name="icao_hex"),
+                TagField("$.registration", as_name="registration"),
+            ],
+            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+        )
+        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +276,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     cur = conn.cursor()
     cur.execute(
         """
-        SELECT a.icao_hex, a.registration, a.type_designator, a.military,
+        SELECT a.icao_hex, a.registration, a.type_designator, a.military, a.interesting,
                t.manufacturer_model, t.wake_turbulence_category
         FROM aircraft a
         LEFT JOIN types t ON a.type_designator = t.type_designator
@@ -256,18 +288,11 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     count = 0
     pipe = r.pipeline()
     for row in rows:
-        types_row = None
-        if row["manufacturer_model"] is not None:
-            # Simulate a types row as a dict-like object
-            types_row = row
-        record = build_aircraft_record(row, types_row if row["manufacturer_model"] else None)
+        types_row = row if row["manufacturer_model"] is not None else None
+        record = build_aircraft_record(row, types_row)
         key = icao_hex_key(record["icao_hex"])
-        pipe.set(key, json.dumps(record), ex=ttl)
-
-        # Write registration reverse-index (NX — don't overwrite more-authoritative source)
-        if record["registration"]:
-            reg_key = registration_key(record["registration"])
-            pipe.set(reg_key, record["icao_hex"], nx=True, ex=ttl)
+        pipe.json().set(key, "$", record)
+        pipe.expire(key, ttl)
 
         count += 1
         if count % 10000 == 0:
@@ -422,7 +447,8 @@ def main() -> None:
         # 2. Stage in SQLite
         conn = stage_data(files, db_path)
 
-        # 3. Write to Redis
+        # 3. Ensure search index exists, then write to Redis
+        _ensure_search_index(r)
         records_imported = write_to_redis(conn, r, ttl)
         conn.close()
 

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -64,10 +64,12 @@ MQTT_ROOT = _mod.MQTT_ROOT
 # ---------------------------------------------------------------------------
 
 SAMPLE_AIRCRAFTS = {
-    "A8AE7F": ["N659DL", "B763", [0, 0]],
-    "AA0001": ["N12345", "C172", [0, 0]],
-    "AA0002": ["MILCRAFT", "F16", [1, 0]],
-    "AA0003": ["", "", [0, 0]],
+    "A8AE7F": ["N659DL", "B763", "00"],   # not military, not interesting
+    "AA0001": ["N12345", "C172", "00"],
+    "AA0002": ["MILCRAFT", "F16", "10"],   # military, not interesting
+    "AA0003": ["", "", "00"],
+    "AA0004": ["N99999", "B763", "01"],   # not military, interesting
+    "AA0005": ["N88888", "F16", "11"],    # military and interesting
 }
 
 SAMPLE_OPERATORS = {
@@ -198,7 +200,48 @@ class TestStageData:
             conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
             cur = conn.cursor()
             cur.execute("SELECT military FROM aircraft WHERE icao_hex = 'AA0002'")
-            assert cur.fetchone()[0] == 1
+            assert bool(cur.fetchone()[0]) is True
+            conn.close()
+
+    def test_not_military_flag(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT military FROM aircraft WHERE icao_hex = 'A8AE7F'")
+            assert bool(cur.fetchone()[0]) is False
+            conn.close()
+
+    def test_interesting_flag(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT interesting FROM aircraft WHERE icao_hex = 'AA0004'")
+            assert bool(cur.fetchone()[0]) is True
+            conn.close()
+
+    def test_military_and_interesting_flags(self):
+        files = _make_zip_files(
+            aircrafts=SAMPLE_AIRCRAFTS,
+            operators=SAMPLE_OPERATORS,
+            types=SAMPLE_TYPES,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(files, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT military, interesting FROM aircraft WHERE icao_hex = 'AA0005'")
+            row = cur.fetchone()
+            assert bool(row[0]) is True
+            assert bool(row[1]) is True
             conn.close()
 
     def test_empty_type_becomes_null(self):
@@ -259,17 +302,19 @@ class TestStageData:
 # ---------------------------------------------------------------------------
 
 class TestBuildAircraftRecord:
-    def _row(self, icao_hex, registration, type_designator, military, manufacturer_model=None):
+    def _row(self, icao_hex, registration, type_designator, military, interesting=False, manufacturer_model=None):
         return {
             "icao_hex": icao_hex,
             "registration": registration,
             "type_designator": type_designator,
             "military": military,
+            "interesting": interesting,
             "manufacturer_model": manufacturer_model,
+            "wake_turbulence_category": None,
         }
 
     def test_full_record_shape(self):
-        row = self._row("A8AE7F", "N659DL", "B763", 0, "Boeing 767-332ER")
+        row = self._row("A8AE7F", "N659DL", "B763", False, manufacturer_model="Boeing 767-332ER")
         record = build_aircraft_record(row, row)
 
         assert record["icao_hex"] == "A8AE7F"
@@ -279,9 +324,24 @@ class TestBuildAircraftRecord:
         assert record["model"] == "767-332ER"
         assert record["source"] == "mictronics"
 
+    def test_military_true(self):
+        row = self._row("AA0002", "MILCRAFT", "F16", True)
+        record = build_aircraft_record(row, None)
+        assert record["military"] is True
+
+    def test_military_false(self):
+        row = self._row("A8AE7F", "N659DL", "B763", False)
+        record = build_aircraft_record(row, None)
+        assert record["military"] is False
+
+    def test_interesting_true(self):
+        row = self._row("AA0004", "N99999", "B763", False, interesting=True)
+        record = build_aircraft_record(row, None)
+        assert record["interesting"] is True
+
     def test_null_fields_present(self):
         """Fields unavailable from Mictronics must be null, not omitted."""
-        row = self._row("A8AE7F", "N659DL", "B763", 0, "Boeing 767-332ER")
+        row = self._row("A8AE7F", "N659DL", "B763", False, manufacturer_model="Boeing 767-332ER")
         record = build_aircraft_record(row, row)
 
         for field in ("is_private_operator", "operator", "airline_code", "serial_number", "year_built"):
@@ -313,9 +373,9 @@ class TestRedisKeys:
         from shared.redis_keys import icao_hex_key
         assert icao_hex_key("A8AE7F") == "icao_hex:A8AE7F"
 
-    def test_registration_key_format(self):
-        from shared.redis_keys import registration_key
-        assert registration_key("n659dl") == "registration:N659DL"
+    def test_aircraft_search_index_name(self):
+        from shared.redis_keys import AIRCRAFT_SEARCH_INDEX
+        assert AIRCRAFT_SEARCH_INDEX == "idx:aircraft"
 
 
 # ---------------------------------------------------------------------------
@@ -328,12 +388,12 @@ class TestWriteToRedis:
         conn.row_factory = sqlite3.Row
         conn.executescript(_mod._SCHEMA)
         conn.execute(
-            "INSERT INTO aircraft (icao_hex, registration, type_designator, military) "
-            "VALUES ('A8AE7F', 'N659DL', 'B763', 0)"
+            "INSERT INTO aircraft (icao_hex, registration, type_designator, military, interesting) "
+            "VALUES ('A8AE7F', 'N659DL', 'B763', 0, 0)"
         )
         conn.execute(
-            "INSERT INTO aircraft (icao_hex, registration, type_designator, military) "
-            "VALUES ('AA0001', 'N12345', 'C172', 0)"
+            "INSERT INTO aircraft (icao_hex, registration, type_designator, military, interesting) "
+            "VALUES ('AA0001', 'N12345', 'C172', 0, 0)"
         )
         conn.execute(
             "INSERT INTO types (type_designator, manufacturer_model, wake_turbulence_category) "
@@ -345,49 +405,51 @@ class TestWriteToRedis:
     def _mock_redis(self):
         r = MagicMock()
         pipe = MagicMock()
+        pipe_json = MagicMock()
         r.pipeline.return_value = pipe
+        pipe.json.return_value = pipe_json
         pipe.execute.return_value = []
-        pipe.set.return_value = pipe
-        return r, pipe
+        return r, pipe, pipe_json
 
     def test_count_matches_aircraft(self):
         conn = self._make_db()
-        r, _ = self._mock_redis()
+        r, _, _ = self._mock_redis()
         assert write_to_redis(conn, r, REDIS_TTL) == 2
         conn.close()
 
-    def test_icao_hex_key_written(self):
+    def test_icao_hex_json_set_written(self):
         conn = self._make_db()
-        r, pipe = self._mock_redis()
+        r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
-        keys = [c.args[0] for c in pipe.set.call_args_list]
+        keys = [c.args[0] for c in pipe_json.set.call_args_list]
         assert "icao_hex:A8AE7F" in keys
         conn.close()
 
-    def test_registration_nx_written(self):
+    def test_json_set_uses_root_path(self):
         conn = self._make_db()
-        r, pipe = self._mock_redis()
+        r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
-        nx_keys = [c.args[0] for c in pipe.set.call_args_list if c.kwargs.get("nx")]
-        assert "registration:N659DL" in nx_keys
+        for c in pipe_json.set.call_args_list:
+            assert c.args[1] == "$"
         conn.close()
 
-    def test_all_registration_writes_use_nx(self):
-        """Every registration reverse-index write must use NX."""
+    def test_expire_called_with_correct_ttl(self):
         conn = self._make_db()
-        r, pipe = self._mock_redis()
+        r, pipe, _ = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
-        for c in pipe.set.call_args_list:
-            if c.args[0].startswith("registration:"):
-                assert c.kwargs.get("nx") is True
+        expire_ttls = [c.args[1] for c in pipe.expire.call_args_list]
+        assert all(ttl == REDIS_TTL for ttl in expire_ttls)
         conn.close()
 
-    def test_correct_ttl(self):
+    def test_no_registration_key_written(self):
         conn = self._make_db()
-        r, pipe = self._mock_redis()
+        r, pipe, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
-        for c in pipe.set.call_args_list:
-            assert c.kwargs.get("ex") == REDIS_TTL
+        all_keys = (
+            [c.args[0] for c in pipe.set.call_args_list]
+            + [c.args[0] for c in pipe_json.set.call_args_list]
+        )
+        assert not any(k.startswith("registration:") for k in all_keys)
         conn.close()
 
 

--- a/data-runners/us-faa/Dockerfile
+++ b/data-runners/us-faa/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY shared/requirements.txt shared_requirements.txt
+COPY data-runners/us-faa/requirements.txt .
+RUN pip install --no-cache-dir -r shared_requirements.txt -r requirements.txt
+
+COPY shared/ ./shared/
+COPY data-runners/us-faa/ ./us-faa/
+
+ENV PYTHONPATH=/app
+ENV SETTINGS_PATH=/app/settings.json
+
+CMD ["python", "us-faa/main.py"]

--- a/data-runners/us-faa/main.py
+++ b/data-runners/us-faa/main.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""
+SkyFollower US FAA Data Runner
+
+Downloads the FAA Releasable Aircraft Database, parses aircraft reference and
+registration CSV files, stages records in local SQLite, writes enrichment data
+to Redis with a 14-day TTL, publishes MQTT completion stats, then exits.
+
+Data source: https://registry.faa.gov/database/ReleasableAircraft.zip
+Supports 2017+ extracts (column layout changed in 2017).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import os
+import sqlite3
+import sys
+import zipfile
+from datetime import datetime, timezone
+from typing import Optional
+
+import paho.mqtt.client as mqtt
+import redis as redis_lib
+import requests
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from redis.commands.search.field import TagField
+from redis.commands.search.index_definition import IndexDefinition, IndexType
+
+from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+
+logger = logging.getLogger("us-faa")
+
+DOWNLOAD_URL = "https://registry.faa.gov/database/ReleasableAircraft.zip"
+REDIS_TTL = 14 * 86400  # 14 days in seconds
+MQTT_ROOT = "SkyFollower/runner/us-faa"
+
+# ---------------------------------------------------------------------------
+# Decode helpers
+# ---------------------------------------------------------------------------
+
+_ENGINE_TYPES: dict[str, str] = {
+    "0": "None",
+    "1": "Piston",
+    "2": "Turbo-prop",
+    "3": "Turbo-shaft",
+    "4": "Turbo-jet",
+    "5": "Turbo-fan",
+    "6": "Ramjet",
+    "7": "2 Cycle",
+    "8": "4 Cycle",
+    "9": "Unknown",
+    "10": "Electric",
+    "11": "Rotary",
+}
+
+_THRUST_ENGINE_TYPES = frozenset({"Turbo-jet", "Turbo-fan", "Ramjet"})
+_HP_ENGINE_TYPES = frozenset({"Piston", "Turbo-prop", "Turbo-shaft", "2 Cycle", "4 Cycle", "Rotary"})
+
+_REGISTRANT_TYPES: dict[str, str] = {
+    "1": "Individual",
+    "2": "Partnership",
+    "3": "Corporation",
+    "4": "Co-Owned",
+    "5": "Government",
+    "7": "LLC",
+    "8": "Non-Citizen Corporation",
+    "9": "Non-Citizen Co-Owned",
+    "": "None",
+}
+
+
+_AIRCRAFT_TYPES: dict[str, str] = {
+    "1": "Glider",
+    "2": "Balloon",
+    "3": "Blimp/Dirigible",
+    "4": "Airplane",
+    "5": "Airplane",
+    "6": "Rotorcraft",
+    "7": "Weight-Shift-Control",
+    "8": "Powered Parachute",
+    "9": "Gyroplane",
+}
+
+_AIRCRAFT_CLASSES: dict[str, str] = {
+    "1": "Land",
+    "2": "Sea",
+    "3": "Amphibian",
+}
+
+
+def _decode_engine_type(code: str) -> Optional[str]:
+    """Map FAA engine type code to a human-readable string."""
+    return _ENGINE_TYPES.get(code.strip())
+
+
+def _decode_registrant_type(code: str) -> str:
+    """Map FAA registrant type code to a human-readable string."""
+    return _REGISTRANT_TYPES.get(code.strip(), "Unknown")
+
+
+def _decode_aircraft_type(code: str) -> Optional[str]:
+    """Map FAA aircraft type code to a human-readable string."""
+    return _AIRCRAFT_TYPES.get(code.strip())
+
+
+def _decode_aircraft_class(code: str) -> Optional[str]:
+    """Map FAA aircraft class code to a human-readable string."""
+    return _AIRCRAFT_CLASSES.get(code.strip())
+
+
+# ---------------------------------------------------------------------------
+# SQLite schema for local staging
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE aircraft (
+    code          TEXT PRIMARY KEY,
+    aircraft_type TEXT,
+    manufacturer  TEXT,
+    model         TEXT,
+    seats         INTEGER,
+    category      TEXT,
+    engine_type   TEXT,
+    engine_count  INTEGER
+);
+CREATE TABLE engines (
+    code          TEXT PRIMARY KEY,
+    manufacturer  TEXT,
+    model         TEXT,
+    engine_type   TEXT,
+    horsepower    INTEGER,
+    thrust        INTEGER
+);
+CREATE TABLE registrations (
+    icao_hex            TEXT PRIMARY KEY,
+    registration        TEXT NOT NULL,
+    serial_number       TEXT,
+    code_aircraft       TEXT,
+    code_engine         TEXT,
+    manufactured_year   TEXT,
+    name_1              TEXT,
+    name_2              TEXT,
+    name_3              TEXT,
+    name_4              TEXT,
+    name_5              TEXT,
+    name_6              TEXT,
+    street_1            TEXT,
+    street_2            TEXT,
+    city                TEXT,
+    administrative_area TEXT,
+    postal_code         TEXT,
+    country             TEXT,
+    registrant_type     TEXT
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+def download_and_extract(url: str) -> dict[str, bytes]:
+    """Download the FAA ZIP and return a mapping of normalised filename → bytes."""
+    logger.info("Downloading FAA database from %s", url)
+    response = requests.get(url, timeout=300, headers={"User-Agent": "P5Software AROI"})
+    if response.status_code != 200:
+        raise RuntimeError(f"Download failed with HTTP {response.status_code}")
+    logger.info("Download complete (%d bytes); extracting ZIP.", len(response.content))
+    files: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        for name in zf.namelist():
+            # Normalise: lowercase; strip duplicate .txt extensions that FAA
+            # has occasionally produced (e.g. MASTER.txt.txt → master.txt)
+            lower = name.lower()
+            if lower.endswith(".txt.txt"):
+                lower = lower[:-4]
+            files[lower] = zf.read(name)
+    logger.info("Extracted %d files: %s", len(files), list(files.keys()))
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _csv_rows(data: bytes):
+    """Yield rows from a FAA CSV file (bytes, comma-delimited, UTF-8), skipping the header."""
+    reader = csv.reader(io.StringIO(data.decode("utf-8", errors="replace")))
+    next(reader, None)
+    yield from reader
+
+
+# ---------------------------------------------------------------------------
+# SQLite staging
+# ---------------------------------------------------------------------------
+
+def stage_data(files: dict[str, bytes], db_path: str) -> sqlite3.Connection:
+    """Parse acftref.txt and master.txt, stage rows into a SQLite database."""
+    logger.info("Opening staging database at %s", db_path)
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+
+    # --- engine.txt (engine reference) ---
+    # Columns: CODE, MFR, MODEL, TYPE, HORSEPOWER, THRUST
+    engine_data = files.get("engine.txt")
+    if engine_data:
+        cur = conn.cursor()
+        count = 0
+        for row in _csv_rows(engine_data):
+            if len(row) < 5:
+                continue
+            code = row[0].strip()
+            if not code:
+                continue
+            manufacturer = row[1].strip() or None
+            model = row[2].strip() or None
+            try:
+                engine_type = _decode_engine_type(str(int(row[3].strip())))
+            except (ValueError, IndexError):
+                engine_type = None
+            try:
+                horsepower = int(row[4].strip()) or None
+            except (ValueError, IndexError):
+                horsepower = None
+            try:
+                thrust = int(row[5].strip()) or None if len(row) > 5 and row[5].strip() else None
+            except (ValueError, IndexError):
+                thrust = None
+            cur.execute(
+                "INSERT OR REPLACE INTO engines (code, manufacturer, model, engine_type, horsepower, thrust) "
+                "VALUES (?,?,?,?,?,?)",
+                (code, manufacturer, model, engine_type, horsepower, thrust),
+            )
+            count += 1
+        conn.commit()
+        logger.info("Staged %d engine types.", count)
+    else:
+        logger.warning("engine.txt not found in download.")
+
+    # --- acftref.txt (aircraft reference) ---
+    # Columns: CODE, MFG, MODEL, TYPE-ACFT, TYPE-ENG, CLASS, RULES,
+    #          NO-ENG, NO-SEATS, AC-WEIGHT, SPEED
+    acft_data = files.get("acftref.txt")
+    if acft_data:
+        cur = conn.cursor()
+        count = 0
+        for row in _csv_rows(acft_data):
+            if len(row) < 8:
+                continue
+            code = row[0].strip()
+            if not code:
+                continue
+            manufacturer = row[1].strip() or None
+            model = row[2].strip() or None
+            try:
+                aircraft_type = _decode_aircraft_type(str(int(row[3].strip())))
+            except (ValueError, IndexError):
+                aircraft_type = None
+            try:
+                engine_type = _decode_engine_type(str(int(row[4].strip())))
+            except (ValueError, IndexError):
+                engine_type = None
+            try:
+                category = _decode_aircraft_class(str(int(row[5].strip())))
+            except (ValueError, IndexError):
+                category = None
+            try:
+                engine_count = int(row[7].strip()) or None
+            except (ValueError, IndexError):
+                engine_count = None
+            try:
+                seats = int(row[8].strip()) or None
+            except (ValueError, IndexError):
+                seats = None
+            cur.execute(
+                "INSERT OR REPLACE INTO aircraft "
+                "(code, aircraft_type, manufacturer, model, seats, category, engine_type, engine_count) "
+                "VALUES (?,?,?,?,?,?,?,?)",
+                (code, aircraft_type, manufacturer, model, seats, category, engine_type, engine_count),
+            )
+            count += 1
+        conn.commit()
+        logger.info("Staged %d aircraft types.", count)
+    else:
+        logger.warning("acftref.txt not found in download.")
+
+    # --- master.txt (registrations) ---
+    # Key columns (2017+ layout):
+    #  0  N-NUMBER   1  SERIAL NUMBER   2  MFR MDL CODE   3  ENG MFR MDL CODE
+    #  4  YEAR MFR   5  TYPE REGISTRANT 6  NAME           7  STREET  8  STREET2
+    #  9  CITY       10 STATE           11 ZIP CODE        14 COUNTRY
+    # 24-28 OTHER NAMES(1-5)            33 MODE S CODE HEX
+    master_data = files.get("master.txt")
+    if master_data:
+        cur = conn.cursor()
+        count = 0
+        for row in _csv_rows(master_data):
+            if len(row) < 34:
+                continue
+            icao_hex = row[33].strip().upper()
+            if not icao_hex or len(icao_hex) != 6:
+                continue
+            n_number = row[0].strip()
+            if not n_number:
+                continue
+            registration = "N" + n_number
+            serial_number = row[1].strip() or None
+            code_aircraft = row[2].strip() or None
+            code_engine = row[3].strip() or None
+            manufactured_year = row[4].strip() or None
+            registrant_type = _decode_registrant_type(row[5].strip())
+            name_fields = [row[i].strip() if i < len(row) else "" for i in (6, 24, 25, 26, 27, 28)]
+            street_1 = row[7].strip() or None if len(row) > 7 else None
+            street_2 = row[8].strip() or None if len(row) > 8 else None
+            city = row[9].strip() or None if len(row) > 9 else None
+            administrative_area = row[10].strip() or None if len(row) > 10 else None
+            postal_code = row[11].strip() or None if len(row) > 11 else None
+            country = row[14].strip() or "US" if len(row) > 14 else "US"
+            cur.execute(
+                "INSERT OR REPLACE INTO registrations "
+                "(icao_hex, registration, serial_number, code_aircraft, code_engine, manufactured_year, "
+                "name_1, name_2, name_3, name_4, name_5, name_6, "
+                "street_1, street_2, city, administrative_area, postal_code, country, registrant_type) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    icao_hex, registration, serial_number, code_aircraft, code_engine, manufactured_year,
+                    name_fields[0] or None, name_fields[1] or None, name_fields[2] or None,
+                    name_fields[3] or None, name_fields[4] or None, name_fields[5] or None,
+                    street_1, street_2, city, administrative_area, postal_code, country, registrant_type,
+                ),
+            )
+            count += 1
+        conn.commit()
+        logger.info("Staged %d registrations.", count)
+    else:
+        logger.warning("master.txt not found in download.")
+
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Build Redis record
+# ---------------------------------------------------------------------------
+
+def build_aircraft_record(
+    reg_row: sqlite3.Row,
+    acft_row: Optional[sqlite3.Row],
+    eng_row: Optional[sqlite3.Row] = None,
+) -> dict:
+    """Build the icao_hex:{hex} JSON record from staged rows."""
+    # registrant
+    names = [reg_row[f"name_{i}"] for i in range(1, 7) if reg_row[f"name_{i}"]]
+    streets = [s for s in [reg_row["street_1"], reg_row["street_2"]] if s]
+    registrant: Optional[dict] = None
+    if names or streets or reg_row["city"]:
+        registrant = {
+            "names": names,
+            "street": streets,
+            "city": reg_row["city"] or None,
+            "administrative_area": reg_row["administrative_area"] or None,
+            "postal_code": reg_row["postal_code"] or None,
+            "country": reg_row["country"] or "US",
+            "type": reg_row["registrant_type"] or None,
+        }
+
+    # aircraft
+    aircraft: Optional[dict] = None
+    if acft_row:
+        mfr_date = None
+        if reg_row["manufactured_year"]:
+            mfr_date = f"{reg_row['manufactured_year']}-01-01T00:00:00Z"
+        aircraft = {
+            "type": acft_row["aircraft_type"] or None,
+            "model": acft_row["model"] or None,
+            "seats": acft_row["seats"] or None,
+            "category": acft_row["category"] or None,
+            "manufacturer": acft_row["manufacturer"] or None,
+            "type_designator": None,          # populated by mictronics
+            "manufacturer_model": None,        # populated by mictronics
+            "serial_number": reg_row["serial_number"] or None,
+            "manufactured_date": mfr_date,
+            "wake_turbulence_category": None,  # populated by mictronics
+        }
+
+    # powerplant
+    powerplant: Optional[dict] = None
+    if acft_row or eng_row:
+        count = acft_row["engine_count"] if acft_row else None
+        eng_type = acft_row["engine_type"] if acft_row else None
+        eng_model = eng_manufacturer = power_type = power_value = None
+        if eng_row:
+            eng_model = eng_row["model"] or None
+            eng_manufacturer = eng_row["manufacturer"] or None
+            et = eng_row["engine_type"]
+            if et in _THRUST_ENGINE_TYPES:
+                power_type = "Thrust"
+                power_value = eng_row["thrust"] or None
+            elif et in _HP_ENGINE_TYPES:
+                power_type = "Horsepower"
+                power_value = eng_row["horsepower"] or None
+        if any([count, eng_type, eng_model, eng_manufacturer, power_type, power_value]):
+            powerplant = {
+                "count": count,
+                "type": eng_type,
+                "model": eng_model,
+                "manufacturer": eng_manufacturer,
+                "power_type": power_type,
+                "power_value": power_value,
+            }
+
+    return {
+        "icao_hex": reg_row["icao_hex"],
+        "registration": reg_row["registration"],
+        "registrant": registrant,
+        "aircraft": aircraft,
+        "powerplant": powerplant,
+        "military": None,
+        "source": "us-faa",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Search index
+# ---------------------------------------------------------------------------
+
+def _ensure_search_index(r: redis_lib.Redis) -> None:
+    """Create the aircraft JSON search index if it does not already exist."""
+    try:
+        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+    except Exception:
+        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+            fields=[
+                TagField("$.icao_hex", as_name="icao_hex"),
+                TagField("$.registration", as_name="registration"),
+            ],
+            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+        )
+        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+
+
+# ---------------------------------------------------------------------------
+# Write to Redis
+# ---------------------------------------------------------------------------
+
+def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> int:
+    """Write all staged registration records to Redis. Returns count of records written."""
+    eng_cur = conn.cursor()
+    eng_cur.execute("SELECT code, manufacturer, model, engine_type, horsepower, thrust FROM engines")
+    engines_by_code: dict[str, sqlite3.Row] = {row["code"]: row for row in eng_cur.fetchall()}
+
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT r.icao_hex, r.registration, r.serial_number, r.manufactured_year,
+               r.registrant_type, r.code_engine,
+               r.name_1, r.name_2, r.name_3, r.name_4, r.name_5, r.name_6,
+               r.street_1, r.street_2, r.city, r.administrative_area,
+               r.postal_code, r.country,
+               a.aircraft_type, a.manufacturer, a.model, a.seats,
+               a.category, a.engine_type, a.engine_count
+        FROM registrations r
+        LEFT JOIN aircraft a ON r.code_aircraft = a.code
+        """
+    )
+    rows = cur.fetchall()
+    logger.info("Writing %d registration records to Redis.", len(rows))
+
+    count = 0
+    pipe = r.pipeline()
+    for row in rows:
+        acft_row = row if row["manufacturer"] is not None else None
+        eng_row = engines_by_code.get(row["code_engine"]) if row["code_engine"] else None
+        record = build_aircraft_record(row, acft_row, eng_row)
+        key = icao_hex_key(record["icao_hex"])
+        pipe.json().set(key, "$", record)
+        pipe.expire(key, ttl)
+
+        count += 1
+        if count % 10000 == 0:
+            pipe.execute()
+            pipe = r.pipeline()
+            logger.info("  ... %d records written.", count)
+
+    pipe.execute()
+    logger.info("Finished writing %d records to Redis.", count)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# MQTT
+# ---------------------------------------------------------------------------
+
+def publish_completion_stats(cfg: dict, records_imported: int, status: str) -> None:
+    """Publish completion statistics to MQTT."""
+    mc = cfg.get("mqtt")
+    if not mc:
+        logger.info("No MQTT config; skipping stats publish.")
+        return
+
+    run_at = datetime.now(timezone.utc).isoformat()
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    connected = False
+
+    def _on_connect(c, userdata, flags, reason_code, properties):
+        nonlocal connected
+        connected = True
+
+    client.on_connect = _on_connect
+
+    try:
+        client.connect(mc["host"], port=mc.get("port", 1883), keepalive=60)
+        client.loop_start()
+
+        import time
+        deadline = time.monotonic() + 5
+        while not connected and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        if not connected:
+            logger.warning("MQTT connect timed out; skipping stats publish.")
+            client.loop_stop()
+            return
+
+        base = MQTT_ROOT + "/statistic"
+        client.publish(f"{base}/records_imported", str(records_imported), retain=True)
+        client.publish(f"{base}/last_run_at", run_at, retain=True)
+        client.publish(f"{base}/last_run_status", status, retain=True)
+
+        _publish_ha_autodiscovery(client)
+
+        time.sleep(0.5)
+        client.loop_stop()
+        client.disconnect()
+        logger.info("MQTT stats published (status=%s, records=%d).", status, records_imported)
+
+    except Exception as exc:
+        logger.warning("MQTT publish failed: %s", exc)
+        try:
+            client.loop_stop()
+        except Exception:
+            pass
+
+
+def _publish_ha_autodiscovery(client: mqtt.Client) -> None:
+    device = {
+        "ids": "SkyFollower_runner_us_faa",
+        "name": "SkyFollower US FAA Runner",
+        "manufacturer": "P5Software, LLC",
+    }
+    stats = [
+        ("records_imported", "US FAA Records Imported", "mdi:airplane", "total_increasing", None),
+        ("last_run_at", "US FAA Last Run At", "mdi:clock", None, None),
+        ("last_run_status", "US FAA Last Run Status", "mdi:check-circle", None, None),
+    ]
+    for name, friendly_name, icon, state_class, unit in stats:
+        payload: dict = {
+            "state_topic": f"{MQTT_ROOT}/statistic/{name}",
+            "name": friendly_name,
+            "unique_id": f"SkyFollower_runner_us_faa_{name}",
+            "object_id": f"SkyFollower_runner_us_faa_{name}",
+            "device": device,
+            "icon": icon,
+        }
+        if state_class:
+            payload["state_class"] = state_class
+        if unit:
+            payload["unit_of_measurement"] = unit
+        client.publish(
+            f"homeassistant/sensor/SkyFollower_runner_us_faa_{name}/config",
+            json.dumps(payload),
+            retain=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    path = os.environ.get("SETTINGS_PATH", "/app/settings.json")
+    with open(path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+        stream=sys.stdout,
+    )
+
+    try:
+        cfg = _load_config()
+    except FileNotFoundError as exc:
+        logger.critical("Settings file not found: %s", exc)
+        sys.exit(1)
+
+    rc = cfg["redis"]
+    r = redis_lib.Redis(
+        host=rc["host"],
+        port=rc.get("port", 6379),
+        decode_responses=True,
+    )
+
+    ttl_days = cfg.get("redis_ttl_days", 14)
+    ttl = ttl_days * 86400
+
+    db_path = "/app/data/staging.db"
+
+    status = "failure"
+    records_imported = 0
+
+    try:
+        files = download_and_extract(DOWNLOAD_URL)
+        conn = stage_data(files, db_path)
+        _ensure_search_index(r)
+        records_imported = write_to_redis(conn, r, ttl)
+        conn.close()
+        status = "success"
+        logger.info("US FAA runner completed successfully. Records imported: %d", records_imported)
+
+    except Exception as exc:
+        logger.error("US FAA runner failed: %s", exc, exc_info=True)
+
+    finally:
+        try:
+            publish_completion_stats(cfg, records_imported, status)
+        except Exception as exc:
+            logger.warning("Failed to publish MQTT stats: %s", exc)
+
+    if status != "success":
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/data-runners/us-faa/requirements.txt
+++ b/data-runners/us-faa/requirements.txt
@@ -1,0 +1,5 @@
+pydantic>=2.0
+uuid7>=0.1.0
+redis>=5.0
+paho-mqtt>=2.0
+requests>=2.31

--- a/data-runners/us-faa/tests/test_us_faa.py
+++ b/data-runners/us-faa/tests/test_us_faa.py
@@ -1,0 +1,688 @@
+"""
+Tests for the US FAA data runner.
+
+Covers:
+- Decode helpers (engine type, registrant type)
+- CSV parsing and SQLite staging
+- Redis record construction
+- Redis key construction
+- Redis write logic (mocked)
+- MQTT completion stats (mocked)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import helper
+# ---------------------------------------------------------------------------
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNNER_DIR = os.path.dirname(_HERE)          # data-runners/us-faa/
+_REPO_ROOT = os.path.abspath(os.path.join(_RUNNER_DIR, "..", ".."))
+
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _load_main():
+    spec = importlib.util.spec_from_file_location(
+        "us_faa_main",
+        os.path.join(_RUNNER_DIR, "main.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["us_faa_main"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_main()
+
+_decode_engine_type = _mod._decode_engine_type
+_decode_registrant_type = _mod._decode_registrant_type
+_decode_aircraft_type = _mod._decode_aircraft_type
+_decode_aircraft_class = _mod._decode_aircraft_class
+build_aircraft_record = _mod.build_aircraft_record
+stage_data = _mod.stage_data
+write_to_redis = _mod.write_to_redis
+publish_completion_stats = _mod.publish_completion_stats
+REDIS_TTL = _mod.REDIS_TTL
+MQTT_ROOT = _mod.MQTT_ROOT
+
+
+# ---------------------------------------------------------------------------
+# Sample CSV fixtures
+# ---------------------------------------------------------------------------
+
+# acftref.txt: CODE, MFG, MODEL, TYPE-ACFT, TYPE-ENG, CLASS, RULES, NO-ENG, NO-SEATS, AC-WEIGHT, SPEED
+_ACFTREF_CSV = (
+    "CODE,MFG,MODEL,TYPE-ACFT,TYPE-ENG,CLASS,RULES,NO-ENG,NO-SEATS,AC-WEIGHT,SPEED\n"
+    "0060V,CESSNA,172,4,1,1,0,1,4,CLASS 1,105\n"
+    "2071M,BOEING,737-800,5,5,1,0,2,189,CLASS 3,465\n"
+).encode()
+
+# engine.txt: CODE, MFR, MODEL, TYPE, HORSEPOWER, THRUST
+_ENGINE_CSV = (
+    "CODE,MFR,MODEL,TYPE,HORSEPOWER,THRUST,\n"
+    "00001,LYCOMING,O-320-D2J,1,00160,000000,\n"       # piston, 160 hp
+    "00002,PRATT & WHITNEY,JT8D-217,5,00000,015500,\n"  # turbo-fan, 15500 lbf thrust
+).encode()
+
+# master.txt: 34 columns (0-33); key columns are 0, 1, 2, 4, 5, 6, 24-28, 33
+# Row layout: N-NUMBER(0), SERIAL(1), MFR-CODE(2), ENG-CODE(3), YEAR(4), REG-TYPE(5),
+#   NAME(6), STREET(7), STREET2(8), CITY(9), STATE(10), ZIP(11), REGION(12), COUNTY(13),
+#   COUNTRY(14), LAST-ACTION(15), CERT-ISSUE(16), CERT(17), AC-TYPE(18), ENG-TYPE(19),
+#   STATUS(20), MODE-S-OCT(21), FRACT(22), AIRWTH(23), OTHER1(24), OTHER2(25),
+#   OTHER3(26), OTHER4(27), OTHER5(28), EXPIRE(29), UNIQUE-ID(30), KIT-MFR(31),
+#   KIT-MDL(32), MODE-S-HEX(33)
+
+def _master_row(*fields):
+    """Return a 34-element CSV row as bytes (header not included)."""
+    row = list(fields) + [""] * (34 - len(fields))
+    return ",".join(str(f) for f in row[:34]) + "\n"
+
+
+_MASTER_HEADER = (
+    "N-NUMBER,SERIAL NUMBER,MFR MDL CODE,ENG MFR MDL,YEAR MFR,TYPE REGISTRANT,"
+    "NAME,STREET,STREET2,CITY,STATE,ZIP CODE,REGION,COUNTY,COUNTRY,"
+    "LAST ACTION DATE,CERT ISSUE DATE,CERTIFICATION,TYPE AIRCRAFT,TYPE ENGINE,"
+    "STATUS CODE,MODE S CODE,FRACT OWNER,AIR WORTH DATE,"
+    "OTHER NAMES(1),OTHER NAMES(2),OTHER NAMES(3),OTHER NAMES(4),OTHER NAMES(5),"
+    "EXPIRATION DATE,UNIQUE ID,KIT MFR,KIT MODEL,MODE S CODE HEX\n"
+)
+
+# N659DL  — Delta 737, Corporation
+_ROW_N659DL = _master_row(
+    "659DL", "28014", "2071M", "00002", "1999", "3",
+    "DELTA AIR LINES INC", "123 MAIN ST", "", "ATLANTA", "GA", "30320",
+    "7", "", "US", "20230101", "19990101", "1TN", "5", "5",
+    "V", "52345670", "N", "19990101",
+    "", "", "", "", "",
+    "20261231", "12345678", "", "", "A8AE7F",
+)
+
+# N12345  — Individual Cessna
+_ROW_N12345 = _master_row(
+    "12345", "1234", "0060V", "00001", "2005", "1",
+    "JOHN DOE", "456 OAK AVE", "", "DALLAS", "TX", "75201",
+    "3", "", "US", "20230101", "20050101", "1N", "4", "1",
+    "V", "45678901", "N", "20050101",
+    "", "", "", "", "",
+    "20261231", "87654321", "", "", "AA0001",
+)
+
+# No matching aircraft ref
+_ROW_NO_ACFT = _master_row(
+    "99999", "9999", "NOTYPE", "", "2010", "2",
+    "SOME PARTNERSHIP", "", "", "", "", "",
+    "1", "", "US", "", "", "", "", "",
+    "V", "", "", "",
+    "", "", "", "", "",
+    "", "", "", "", "AB1234",
+)
+
+# Invalid ICAO hex (too short) — should be skipped
+_ROW_BAD_HEX = _master_row(
+    "11111", "", "", "", "", "1",
+    "SKIP ME", "", "", "", "", "",
+    "", "", "", "", "", "", "", "",
+    "", "", "", "",
+    "", "", "", "", "",
+    "", "", "", "", "BAD",
+)
+
+_MASTER_CSV = (
+    _MASTER_HEADER
+    + _ROW_N659DL
+    + _ROW_N12345
+    + _ROW_NO_ACFT
+    + _ROW_BAD_HEX
+).encode()
+
+
+def _make_files(**overrides) -> dict[str, bytes]:
+    base = {
+        "acftref.txt": _ACFTREF_CSV,
+        "engine.txt": _ENGINE_CSV,
+        "master.txt": _MASTER_CSV,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_aircraft_type
+# ---------------------------------------------------------------------------
+
+class TestDecodeAircraftType:
+    def test_fixed_wing_single(self):
+        assert _decode_aircraft_type("4") == "Airplane"
+
+    def test_fixed_wing_multi(self):
+        assert _decode_aircraft_type("5") == "Airplane"
+
+    def test_rotorcraft(self):
+        assert _decode_aircraft_type("6") == "Rotorcraft"
+
+    def test_glider(self):
+        assert _decode_aircraft_type("1") == "Glider"
+
+    def test_unknown_returns_none(self):
+        assert _decode_aircraft_type("99") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_aircraft_class
+# ---------------------------------------------------------------------------
+
+class TestDecodeAircraftClass:
+    def test_land(self):
+        assert _decode_aircraft_class("1") == "Land"
+
+    def test_sea(self):
+        assert _decode_aircraft_class("2") == "Sea"
+
+    def test_amphibian(self):
+        assert _decode_aircraft_class("3") == "Amphibian"
+
+    def test_unknown_returns_none(self):
+        assert _decode_aircraft_class("9") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_engine_type
+# ---------------------------------------------------------------------------
+
+class TestDecodeEngineType:
+    def test_piston(self):
+        assert _decode_engine_type("1") == "Piston"
+
+    def test_turbo_fan(self):
+        assert _decode_engine_type("5") == "Turbo-fan"
+
+    def test_electric(self):
+        assert _decode_engine_type("10") == "Electric"
+
+    def test_none_code(self):
+        assert _decode_engine_type("0") == "None"
+
+    def test_unknown_code_returns_none(self):
+        assert _decode_engine_type("99") is None
+
+    def test_strips_whitespace(self):
+        assert _decode_engine_type(" 1 ") == "Piston"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_registrant_type
+# ---------------------------------------------------------------------------
+
+class TestDecodeRegistrantType:
+    def test_individual(self):
+        assert _decode_registrant_type("1") == "Individual"
+
+    def test_corporation(self):
+        assert _decode_registrant_type("3") == "Corporation"
+
+    def test_government(self):
+        assert _decode_registrant_type("5") == "Government"
+
+    def test_llc(self):
+        assert _decode_registrant_type("7") == "LLC"
+
+    def test_empty_is_none(self):
+        assert _decode_registrant_type("") == "None"
+
+    def test_unknown_code(self):
+        assert _decode_registrant_type("X") == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Tests: stage_data
+# ---------------------------------------------------------------------------
+
+class TestStageData:
+    def test_aircraft_count(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM aircraft")
+            assert cur.fetchone()[0] == 2
+            conn.close()
+
+    def test_aircraft_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT aircraft_type, manufacturer, model, seats, category, engine_type, engine_count "
+                "FROM aircraft WHERE code = '2071M'"
+            )
+            row = cur.fetchone()
+            assert row[0] == "Airplane"
+            assert row[1] == "BOEING"
+            assert row[2] == "737-800"
+            assert row[3] == 189
+            assert row[4] == "Land"
+            assert row[5] == "Turbo-fan"
+            assert row[6] == 2
+            conn.close()
+
+    def test_registration_count(self):
+        # Bad hex row should be filtered out
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM registrations")
+            assert cur.fetchone()[0] == 3
+            conn.close()
+
+    def test_engine_count(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM engines")
+            assert cur.fetchone()[0] == 2
+            conn.close()
+
+    def test_engine_fields_piston(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT manufacturer, model, engine_type, horsepower, thrust FROM engines WHERE code = '00001'")
+            row = cur.fetchone()
+            assert row[0] == "LYCOMING"
+            assert row[1] == "O-320-D2J"
+            assert row[2] == "Piston"
+            assert row[3] == 160
+            assert row[4] is None
+            conn.close()
+
+    def test_engine_fields_turbofan(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT manufacturer, model, engine_type, horsepower, thrust FROM engines WHERE code = '00002'")
+            row = cur.fetchone()
+            assert row[0] == "PRATT & WHITNEY"
+            assert row[1] == "JT8D-217"
+            assert row[2] == "Turbo-fan"
+            assert row[3] is None
+            assert row[4] == 15500
+            conn.close()
+
+    def test_registration_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT icao_hex, registration, serial_number, code_engine, manufactured_year, "
+                "name_1, street_1, city, administrative_area, postal_code, country, registrant_type "
+                "FROM registrations WHERE icao_hex = 'A8AE7F'"
+            )
+            row = cur.fetchone()
+            assert row["icao_hex"] == "A8AE7F"
+            assert row["registration"] == "N659DL"
+            assert row["serial_number"] == "28014"
+            assert row["code_engine"] == "00002"
+            assert row["manufactured_year"] == "1999"
+            assert row["name_1"] == "DELTA AIR LINES INC"
+            assert row["street_1"] == "123 MAIN ST"
+            assert row["city"] == "ATLANTA"
+            assert row["administrative_area"] == "GA"
+            assert row["postal_code"] == "30320"
+            assert row["country"] == "US"
+            assert row["registrant_type"] == "Corporation"
+            conn.close()
+
+    def test_missing_engine_txt_skipped_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data({"acftref.txt": _ACFTREF_CSV, "master.txt": _MASTER_CSV},
+                              os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM engines")
+            assert cur.fetchone()[0] == 0
+            conn.close()
+
+    def test_icao_hex_uppercased(self):
+        row = _master_row(
+            "LOWER1", "", "", "", "", "1",
+            "TEST", "", "", "", "", "",
+            "", "", "", "", "", "", "", "",
+            "V", "", "", "",
+            "", "", "", "", "",
+            "", "", "", "", "a8ae7f",
+        )
+        master = (_MASTER_HEADER + row).encode()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data({"acftref.txt": _ACFTREF_CSV, "master.txt": master},
+                              os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT icao_hex FROM registrations")
+            assert cur.fetchone()[0] == "A8AE7F"
+            conn.close()
+
+    def test_n_prefix_prepended(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT registration FROM registrations WHERE icao_hex = 'AA0001'")
+            assert cur.fetchone()[0] == "N12345"
+            conn.close()
+
+    def test_missing_acftref_skipped_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data({"master.txt": _MASTER_CSV},
+                              os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM aircraft")
+            assert cur.fetchone()[0] == 0
+            conn.close()
+
+    def test_missing_master_skipped_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data({"acftref.txt": _ACFTREF_CSV},
+                              os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM registrations")
+            assert cur.fetchone()[0] == 0
+            conn.close()
+
+    def test_bad_hex_row_skipped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT icao_hex FROM registrations")
+            hexes = {r[0] for r in cur.fetchall()}
+            assert "BAD" not in hexes
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_aircraft_record
+# ---------------------------------------------------------------------------
+
+class TestBuildAircraftRecord:
+    def _fetch_rows(self, icao_hex: str):
+        """Return (reg_row, acft_row, eng_row) for the given ICAO hex."""
+        conn = stage_data(_make_files(), tempfile.mktemp(suffix=".db"))
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT r.icao_hex, r.registration, r.serial_number, r.manufactured_year,
+                   r.registrant_type, r.code_engine,
+                   r.name_1, r.name_2, r.name_3, r.name_4, r.name_5, r.name_6,
+                   r.street_1, r.street_2, r.city, r.administrative_area,
+                   r.postal_code, r.country,
+                   a.aircraft_type, a.manufacturer, a.model, a.seats,
+                   a.category, a.engine_type, a.engine_count
+            FROM registrations r
+            LEFT JOIN aircraft a ON r.code_aircraft = a.code
+            WHERE r.icao_hex = ?
+            """,
+            (icao_hex,),
+        )
+        row = cur.fetchone()
+        acft_row = row if row and row["manufacturer"] is not None else None
+
+        eng_cur = conn.cursor()
+        eng_cur.execute(
+            "SELECT code, manufacturer, model, engine_type, horsepower, thrust FROM engines WHERE code = ?",
+            (row["code_engine"],) if row and row["code_engine"] else ("",),
+        )
+        eng_row = eng_cur.fetchone()
+        conn.close()
+        return row, acft_row, eng_row
+
+    def test_top_level_fields(self):
+        row, acft_row, eng_row = self._fetch_rows("A8AE7F")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        assert record["icao_hex"] == "A8AE7F"
+        assert record["registration"] == "N659DL"
+        assert record["source"] == "us-faa"
+        assert record["military"] is None
+
+    def test_registrant_names(self):
+        row, acft_row, eng_row = self._fetch_rows("A8AE7F")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        assert record["registrant"]["names"] == ["DELTA AIR LINES INC"]
+
+    def test_registrant_address(self):
+        row, acft_row, eng_row = self._fetch_rows("A8AE7F")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        reg = record["registrant"]
+        assert reg["street"] == ["123 MAIN ST"]
+        assert reg["city"] == "ATLANTA"
+        assert reg["administrative_area"] == "GA"
+        assert reg["postal_code"] == "30320"
+        assert reg["country"] == "US"
+
+    def test_registrant_type_corporation(self):
+        row, acft_row, eng_row = self._fetch_rows("A8AE7F")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        assert record["registrant"]["type"] == "Corporation"
+
+    def test_registrant_type_individual(self):
+        row, acft_row, eng_row = self._fetch_rows("AA0001")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        assert record["registrant"]["type"] == "Individual"
+
+    def test_aircraft_fields(self):
+        row, acft_row, eng_row = self._fetch_rows("A8AE7F")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        ac = record["aircraft"]
+        assert ac["type"] == "Airplane"
+        assert ac["manufacturer"] == "BOEING"
+        assert ac["model"] == "737-800"
+        assert ac["seats"] == 189
+        assert ac["category"] == "Land"
+        assert ac["serial_number"] == "28014"
+        assert ac["manufactured_date"] == "1999-01-01T00:00:00Z"
+
+    def test_aircraft_mictronics_fields_null(self):
+        row, acft_row, eng_row = self._fetch_rows("A8AE7F")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        ac = record["aircraft"]
+        assert ac["type_designator"] is None
+        assert ac["manufacturer_model"] is None
+        assert ac["wake_turbulence_category"] is None
+
+    def test_powerplant_turbofan(self):
+        row, acft_row, eng_row = self._fetch_rows("A8AE7F")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        pp = record["powerplant"]
+        assert pp["count"] == 2
+        assert pp["type"] == "Turbo-fan"
+        assert pp["manufacturer"] == "PRATT & WHITNEY"
+        assert pp["model"] == "JT8D-217"
+        assert pp["power_type"] == "Thrust"
+        assert pp["power_value"] == 15500
+
+    def test_powerplant_piston(self):
+        row, acft_row, eng_row = self._fetch_rows("AA0001")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        pp = record["powerplant"]
+        assert pp["type"] == "Piston"
+        assert pp["manufacturer"] == "LYCOMING"
+        assert pp["model"] == "O-320-D2J"
+        assert pp["power_type"] == "Horsepower"
+        assert pp["power_value"] == 160
+
+    def test_no_aircraft_ref_gives_null_aircraft(self):
+        row, _, _ = self._fetch_rows("AB1234")
+        record = build_aircraft_record(row, None, None)
+        assert record["aircraft"] is None
+        assert record["powerplant"] is None
+
+    def test_manufactured_year_none_gives_null_date(self):
+        row, acft_row, eng_row = self._fetch_rows("AB1234")
+        record = build_aircraft_record(row, acft_row, eng_row)
+        if record["aircraft"]:
+            assert record["aircraft"]["manufactured_date"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Redis key construction
+# ---------------------------------------------------------------------------
+
+class TestRedisKeys:
+    def test_icao_hex_key_format(self):
+        from shared.redis_keys import icao_hex_key
+        assert icao_hex_key("a8ae7f") == "icao_hex:A8AE7F"
+
+    def test_aircraft_search_index_name(self):
+        from shared.redis_keys import AIRCRAFT_SEARCH_INDEX
+        assert AIRCRAFT_SEARCH_INDEX == "idx:aircraft"
+
+
+# ---------------------------------------------------------------------------
+# Tests: write_to_redis
+# ---------------------------------------------------------------------------
+
+class TestWriteToRedis:
+    def _make_db(self) -> sqlite3.Connection:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            return stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+
+    def _mock_redis(self):
+        r = MagicMock()
+        pipe = MagicMock()
+        pipe_json = MagicMock()
+        r.pipeline.return_value = pipe
+        pipe.json.return_value = pipe_json
+        pipe.execute.return_value = []
+        return r, pipe, pipe_json
+
+    def test_count_matches_staged_registrations(self):
+        conn = self._make_db()
+        r, _, _ = self._mock_redis()
+        assert write_to_redis(conn, r, REDIS_TTL) == 3
+        conn.close()
+
+    def test_icao_hex_json_set_written(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        keys = [c.args[0] for c in pipe_json.set.call_args_list]
+        assert "icao_hex:A8AE7F" in keys
+        conn.close()
+
+    def test_json_set_uses_root_path(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        for c in pipe_json.set.call_args_list:
+            assert c.args[1] == "$"
+        conn.close()
+
+    def test_expire_called_with_correct_ttl(self):
+        conn = self._make_db()
+        r, pipe, _ = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        expire_ttls = [c.args[1] for c in pipe.expire.call_args_list]
+        assert all(ttl == REDIS_TTL for ttl in expire_ttls)
+        conn.close()
+
+    def test_no_registration_key_written(self):
+        conn = self._make_db()
+        r, pipe, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        all_keys = (
+            [c.args[0] for c in pipe.set.call_args_list]
+            + [c.args[0] for c in pipe_json.set.call_args_list]
+        )
+        assert not any(k.startswith("registration:") for k in all_keys)
+        conn.close()
+
+    def test_record_written_as_dict(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
+        record = calls["icao_hex:A8AE7F"]
+        assert isinstance(record, dict)
+        assert record["source"] == "us-faa"
+        assert record["registration"] == "N659DL"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: MQTT completion stats (mocked)
+# ---------------------------------------------------------------------------
+
+class TestMqttCompletionStats:
+    def _setup_mock_client(self):
+        mock_client = MagicMock()
+
+        def fake_connect(host, port, keepalive):
+            mock_client.on_connect(mock_client, None, None, 0, None)
+
+        mock_client.connect.side_effect = fake_connect
+        return mock_client
+
+    def test_publishes_records_imported(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("us_faa_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 42, "success")
+        topics = [c.args[0] for c in mc.publish.call_args_list]
+        assert f"{MQTT_ROOT}/statistic/records_imported" in topics
+
+    def test_records_imported_value(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("us_faa_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 99, "success")
+        calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
+        assert calls[f"{MQTT_ROOT}/statistic/records_imported"] == "99"
+
+    def test_publishes_last_run_at(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("us_faa_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 0, "success")
+        topics = [c.args[0] for c in mc.publish.call_args_list]
+        assert f"{MQTT_ROOT}/statistic/last_run_at" in topics
+
+    def test_publishes_last_run_status(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("us_faa_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 0, "failure")
+        calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
+        assert calls[f"{MQTT_ROOT}/statistic/last_run_status"] == "failure"
+
+    def test_no_mqtt_config_skips(self):
+        cfg = {}
+        mc = self._setup_mock_client()
+        with patch("us_faa_main.mqtt.Client", return_value=mc):
+            publish_completion_stats(cfg, 0, "success")
+        mc.connect.assert_not_called()
+
+    def test_ha_autodiscovery_three_sensors(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("us_faa_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 100, "success")
+        ha_topics = [
+            c.args[0] for c in mc.publish.call_args_list
+            if c.args[0].startswith("homeassistant/")
+        ]
+        assert len(ha_topics) == 3
+        assert "homeassistant/sensor/SkyFollower_runner_us_faa_records_imported/config" in ha_topics
+        assert "homeassistant/sensor/SkyFollower_runner_us_faa_last_run_at/config" in ha_topics
+        assert "homeassistant/sensor/SkyFollower_runner_us_faa_last_run_status/config" in ha_topics

--- a/docker-compose.server.yaml
+++ b/docker-compose.server.yaml
@@ -17,13 +17,13 @@ services:
       RABBITMQ_DEFAULT_PASS: change_me
 
   redis:
-    image: redis:7-alpine
+    image: redis/redis-stack-server:latest
     restart: unless-stopped
     ports:
       - "6379:6379"
     volumes:
       - redis-data:/data
-    command: redis-server --appendonly yes
+    command: redis-stack-server --appendonly yes
 
   # ---------------------------------------------------------------------------
   # Scheduler

--- a/shared/models.py
+++ b/shared/models.py
@@ -87,6 +87,7 @@ class AircraftRecord(BaseModel):
     wake_turbulence_category: Optional[str] = None
     powerplant: Optional[PowerplantInfo] = None
     military: Optional[bool] = None
+    interesting: Optional[bool] = None
     operator: Optional[str] = None          # operator/owner name from registry
     airline_code: Optional[str] = None      # ICAO airline code
     serial_number: Optional[str] = None

--- a/shared/models.py
+++ b/shared/models.py
@@ -87,7 +87,6 @@ class AircraftRecord(BaseModel):
     wake_turbulence_category: Optional[str] = None
     powerplant: Optional[PowerplantInfo] = None
     military: Optional[bool] = None
-    interesting: Optional[bool] = None
     operator: Optional[str] = None          # operator/owner name from registry
     airline_code: Optional[str] = None      # ICAO airline code
     serial_number: Optional[str] = None

--- a/shared/redis_keys.py
+++ b/shared/redis_keys.py
@@ -9,15 +9,14 @@ are always explicit and typos in key names are caught by the type checker.
 _VALID_PERIODS = frozenset({"hour", "today", "lifetime"})
 _VALID_ARCHIVE_PERIODS = frozenset({"hour", "today"})
 
+# RediSearch index over all icao_hex:{hex} JSON documents.
+# Supports registration lookup without a separate reverse-index key.
+AIRCRAFT_SEARCH_INDEX = "idx:aircraft"
+
 
 def icao_hex_key(icao_hex: str) -> str:
     """Aircraft enrichment record. icao_hex:{icao_hex}"""
     return f"icao_hex:{icao_hex.upper()}"
-
-
-def registration_key(registration: str) -> str:
-    """Reverse-lookup index: registration → icao_hex. registration:{registration}"""
-    return f"registration:{registration.upper()}"
 
 
 def operator_key(designator: str) -> str:

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -1,0 +1,899 @@
+# SkyFollower Data Dictionary
+#
+# Defines the canonical completed-flight record: field types, data sources,
+# column positions, transforms, and persistence rules.
+#
+# Merge strategy: within each field's sources list, the FIRST source that
+# provides a non-null value wins, unless merge_strategy is overridden for
+# that field.
+#
+# persisted: true  (default) — field is written to the S3 archive record.
+# persisted: false — field is used during processing only; omitted on persist.
+#
+# persist_as — overrides the persisted shape for object fields that collapse
+# to a scalar on write (e.g. origin/destination objects → ICAO code string).
+
+version: "1.0"
+description: >
+  Field-level data dictionary for SkyFollower record types. Defines sources,
+  column positions, transforms, merge priority, and persistence rules for each
+  field in every record type. Add new record types under records: as the
+  project expands.
+
+merge_strategy_default: first_wins
+
+# ── Source definitions ───────────────────────────────────────────────────────
+# Sources listed here are referenced by name throughout the fields section.
+# The order within each field's sources[] list defines priority.
+
+sources:
+
+  mictronics:
+    description: "Mictronics global aircraft database — type designators and military/interesting flags"
+    url: "https://www.mictronics.de/aircraft-database/indexedDB.php"
+    format: zip+json
+    cadence: weekly_tuesday
+    files:
+      - name: aircrafts.json
+        format: "object: icao_hex → [registration, type_designator, flags_string]"
+        notes: "flags_string is a 2-char string; [0]='1' → military, [1]='1' → interesting"
+      - name: types.json
+        format: "object: type_designator → [manufacturer_model, description, wtc_code]"
+      - name: operators.json
+        format: "object: airline_designator → [name, country, callsign]"
+
+  us-faa:
+    description: "FAA Releasable Aircraft Database — US N-number registrations"
+    url: "https://registry.faa.gov/database/ReleasableAircraft.zip"
+    format: zip+csv
+    cadence: weekly_saturday
+    notes: "Requires User-Agent: 'P5Software AROI' header; 2017+ column layout"
+    files:
+      - name: master.txt
+        format: csv
+        description: "Active N-number registrations"
+        columns:
+          0:  N-NUMBER
+          1:  SERIAL NUMBER
+          2:  MFR MDL CODE
+          3:  ENG MFR MDL CODE
+          4:  YEAR MFR
+          5:  TYPE REGISTRANT
+          6:  NAME
+          7:  STREET
+          8:  STREET2
+          9:  CITY
+          10: STATE
+          11: ZIP CODE
+          12: REGION
+          13: COUNTY
+          14: COUNTRY
+          24: "OTHER NAMES(1)"
+          25: "OTHER NAMES(2)"
+          26: "OTHER NAMES(3)"
+          27: "OTHER NAMES(4)"
+          28: "OTHER NAMES(5)"
+          33: MODE S CODE HEX
+      - name: acftref.txt
+        format: csv
+        description: "Aircraft type reference; joined via master.txt MFR MDL CODE"
+        columns:
+          0: CODE
+          1: MFG
+          2: MODEL
+          3: TYPE-ACFT
+          4: TYPE-ENG
+          5: CLASS
+          7: NO-ENG
+          8: NO-SEATS
+          9: AC-WEIGHT
+      - name: engine.txt
+        format: csv
+        description: "Engine reference; joined via master.txt ENG MFR MDL CODE"
+        columns:
+          0: CODE
+          1: MFR
+          2: MODEL
+          3: TYPE
+          4: HORSEPOWER
+          5: THRUST
+
+  ca-tc:
+    description: "Transport Canada Civil Aircraft Register — Canadian C- registrations"
+    url: "https://wwwapps.tc.gc.ca/Saf-Sec-Sur/2/CCARCS-RIACC/ReleaseAccessEN.aspx"
+    format: zip+csv
+    cadence: weekly_sunday
+    notes: "Owner data is in carsownr.txt (separate file); multiple rows per mark possible — filter ACTIVE_FLAG='A'"
+    files:
+      - name: carscurr.txt
+        format: csv
+        description: "Primary aircraft registration record; one row per mark"
+        columns:
+          0:  MARK
+          3:  COMMON_NAME
+          4:  MODEL_NAME
+          5:  MANUFACTURERS_SERIAL_NUMBER
+          7:  ID_PLATE_MANUFACTURERS_NAME
+          10: AIRCRAFT_CATEGORY_E
+          13: ENGINE_MANUF_E
+          15: ENGINE_CATEGORY_E
+          17: NUMBER_OF_ENGINES
+          18: NUMBER_OF_SEATS
+          31: DATE_MANUFACTURE_ASSEMBLY
+          42: MODE_S_TRANSPONDER_BINARY
+          46: TRIMMED_MARK
+        transforms:
+          MODE_S_TRANSPONDER_BINARY: "24-char binary string — format(int(value, 2), '06X') → ICAO hex"
+          TRIMMED_MARK: "MARK without leading spaces; prepend 'C-' to form full registration"
+          DATE_MANUFACTURE_ASSEMBLY: "YYYY/MM/DD — replace '/' with '-' for ISO 8601"
+      - name: carsownr.txt
+        format: csv
+        description: "Owner/registrant records; joined to carscurr.txt by MARK_LINK = MARK; filter ACTIVE_FLAG='A'"
+        join: "carsownr.txt[0] MARK_LINK = carscurr.txt[0] MARK"
+        columns:
+          0:  MARK_LINK
+          1:  FULL_NAME
+          2:  TRADE_NAME
+          3:  STREET_NAME
+          4:  STREET_NAME2
+          5:  CITY
+          6:  PROVINCE_OR_STATE_E
+          8:  POSTAL_CODE
+          9:  COUNTRY_E
+          11: TYPE_OF_OWNER_E
+          13: ACTIVE_FLAG
+        notes: "TYPE_OF_OWNER_E stores decoded English strings ('Individual', 'Entity') not raw codes; COUNTRY_E stores full country name (e.g. 'CANADA') not ISO code"
+
+  standing-data:
+    description: "VRS Standing Data — operators, airports, and flight routes"
+    url: "https://github.com/vradarserver/standing-data"
+    format: csv
+    cadence: weekly_tuesday
+
+  flightaware:
+    description: "FlightAware origin/destination enrichment (paid; optional)"
+    format: api
+    cadence: every_3_days
+    status: optional
+
+  processor:
+    description: "Derived in real time by the message processor from ADS-B messages"
+
+
+# ── Record definitions ─────────────────────────────────────────────────────
+# Each record type defines the fields for one Redis enrichment record or the
+# completed flight S3 archive record. Sources and merge rules apply per-record.
+
+records:
+
+  flight:
+    description: >
+      Completed flight record. Written to S3 on flight completion and used as
+      the authoritative archive document. Also defines the icao_hex:{hex} Redis
+      enrichment shape written by data runners.
+    storage: S3
+    s3_path: "flights/{YYYY}/{MM}/{DD}/{icao_hex}_{ident}_{uuid}.json.gz"
+    redis_key: "icao_hex:{icao_hex}"
+    fields:
+
+      _id:
+        type: string
+        description: "UUID-v7 unique flight identifier"
+        persisted: true
+        sources:
+          - source: processor
+            transform:
+              type: generate
+              function: uuid7
+
+      first_message:
+        type: datetime
+        description: "UTC timestamp of the first ADS-B message in this flight"
+        persisted: true
+        sources:
+          - source: processor
+
+      last_message:
+        type: datetime
+        description: "UTC timestamp of the most recent ADS-B message"
+        persisted: true
+        sources:
+          - source: processor
+
+      total_messages:
+        type: integer
+        description: "Total count of ADS-B messages received for this flight"
+        persisted: true
+        sources:
+          - source: processor
+
+      icao_hex:
+        type: string
+        description: "6-character uppercase ICAO Mode S hex identifier (e.g. A8AE7F); primary key for Redis enrichment records"
+        persisted: true
+        sources:
+          - source: processor
+            description: "Present in every ADS-B message"
+          - source: mictronics
+            file: aircrafts.json
+            description: "JSON object key; already a 6-character uppercase hex string"
+          - source: us-faa
+            file: master.txt
+            field: MODE S CODE HEX
+            position: 33
+            transform:
+              type: uppercase
+              description: "Field is hex but may be mixed case — normalise to uppercase"
+          - source: ca-tc
+            file: carscurr.txt
+            field: MODE_S_TRANSPONDER_BINARY
+            position: 42
+            transform:
+              type: binary_to_hex
+              description: "24-character binary string — format(int(value, 2), '06X') → 6-character uppercase hex"
+
+      registration:
+        type: string
+        description: "Aircraft registration mark (e.g. N659DL, C-FEGI)"
+        persisted: true
+        sources:
+          - source: us-faa
+            file: master.txt
+            field: N-NUMBER
+            position: 0
+            transform:
+              type: prefix
+              value: "N"
+              description: "Prepend 'N' to the stored number to form the full mark"
+          - source: ca-tc
+            file: carscurr.txt
+            field: TRIMMED_MARK
+            position: 46
+            transform:
+              type: prefix
+              value: "C-"
+              description: "Prepend 'C-' to the stored mark to form the full registration"
+          - source: mictronics
+            file: aircrafts.json
+            field: "values[0]"
+
+      registrant:
+        type: object
+        description: "Owner/registrant information from the national civil aircraft registry"
+        persisted: true
+        properties:
+
+          names:
+            type: "array[string]"
+            description: "Registrant name(s); primary name is first; additional DBA names follow"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                fields:
+                  - { field: NAME,            position: 6  }
+                  - { field: "OTHER NAMES(1)", position: 24 }
+                  - { field: "OTHER NAMES(2)", position: 25 }
+                  - { field: "OTHER NAMES(3)", position: 26 }
+                  - { field: "OTHER NAMES(4)", position: 27 }
+                  - { field: "OTHER NAMES(5)", position: 28 }
+                transform:
+                  type: collect_non_empty
+                  description: "Collect all non-blank name fields in column order into an array"
+              - source: ca-tc
+                file: carsownr.txt
+                fields:
+                  - { field: FULL_NAME,   position: 1 }
+                  - { field: TRADE_NAME,  position: 2 }
+                transform:
+                  type: collect_non_empty
+                  description: "Collect FULL_NAME then TRADE_NAME; filter ACTIVE_FLAG='A' rows first"
+
+          street:
+            type: "array[string]"
+            description: "Street address lines; blank lines omitted"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                fields:
+                  - { field: STREET,  position: 7 }
+                  - { field: STREET2, position: 8 }
+                transform:
+                  type: collect_non_empty
+              - source: ca-tc
+                file: carsownr.txt
+                fields:
+                  - { field: STREET_NAME,  position: 3 }
+                  - { field: STREET_NAME2, position: 4 }
+                transform:
+                  type: collect_non_empty
+
+          city:
+            type: string
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                field: CITY
+                position: 9
+              - source: ca-tc
+                file: carsownr.txt
+                field: CITY
+                position: 5
+
+          administrative_area:
+            type: string
+            description: "First-level country subdivision (US state, Canadian province, etc.)"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                field: STATE
+                position: 10
+              - source: ca-tc
+                file: carsownr.txt
+                field: PROVINCE_OR_STATE_E
+                position: 6
+
+          postal_code:
+            type: string
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                field: ZIP CODE
+                position: 11
+              - source: ca-tc
+                file: carsownr.txt
+                field: POSTAL_CODE
+                position: 8
+
+          country:
+            type: string
+            description: "ISO 3166-1 alpha-2 country code"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                field: COUNTRY
+                position: 14
+                transform:
+                  type: fallback_constant
+                  value: "US"
+                  description: "Use field value if non-empty; fall back to 'US' for domestic records"
+              - source: ca-tc
+                file: carsownr.txt
+                field: COUNTRY_E
+                position: 9
+                transform:
+                  type: decode_country_name
+                  description: "Full English country name (e.g. 'CANADA') → ISO 3166-1 alpha-2 code"
+
+          type:
+            type: string
+            description: "Registrant category"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                field: TYPE REGISTRANT
+                position: 5
+                transform:
+                  type: decode_table
+                  values:
+                    "1": Individual
+                    "2": Partnership
+                    "3": Corporation
+                    "4": Co-Owned
+                    "5": Government
+                    "7": LLC
+                    "8": "Non-Citizen Corporation"
+                    "9": "Non-Citizen Co-Owned"
+              - source: ca-tc
+                file: carsownr.txt
+                field: TYPE_OF_OWNER_E
+                position: 11
+                transform:
+                  type: decode_table
+                  values:
+                    "Individual": Individual
+                    "Entity": Corporation
+                    "Manufacturer": Corporation
+
+      aircraft:
+        type: object
+        description: "Aircraft type and physical specification data"
+        persisted: true
+        properties:
+
+          type:
+            type: string
+            description: "Aircraft category (Airplane, Rotorcraft, Glider, etc.)"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: acftref.txt
+                field: TYPE-ACFT
+                position: 3
+                transform:
+                  type: decode_table
+                  values:
+                    "1": Glider
+                    "2": Balloon
+                    "3": "Blimp/Dirigible"
+                    "4": Airplane
+                    "5": Airplane
+                    "6": Rotorcraft
+                    "7": Weight-Shift-Control
+                    "8": Powered Parachute
+                    "9": Gyroplane
+              - source: ca-tc
+                file: carscurr.txt
+                field: AIRCRAFT_CATEGORY_E
+                position: 10
+                transform:
+                  type: decode_table
+                  values:
+                    "Aeroplane": Airplane
+                    "Helicopter": Helicopter
+                    "Glider": Glider
+                    "Balloon": Balloon
+                    "Gyroplane": Gyroplane
+
+          model:
+            type: string
+            description: "Model designation from the national registry (e.g. 757-232)"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: acftref.txt
+                field: MODEL
+                position: 2
+              - source: ca-tc
+                file: carscurr.txt
+                field: MODEL_NAME
+                position: 4
+
+          seats:
+            type: integer
+            description: "Number of seats certified"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: acftref.txt
+                field: NO-SEATS
+                position: 8
+              - source: ca-tc
+                file: carscurr.txt
+                field: NUMBER_OF_SEATS
+                position: 18
+
+          category:
+            type: string
+            description: "Aircraft build category (Land, Sea, Amphibian)"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: acftref.txt
+                field: CLASS
+                position: 5
+                transform:
+                  type: decode_table
+                  values:
+                    "1": Land
+                    "2": Sea
+                    "3": Amphibian
+
+          manufacturer:
+            type: string
+            description: "Aircraft manufacturer name"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: acftref.txt
+                field: MFG
+                position: 1
+              - source: ca-tc
+                file: carscurr.txt
+                field: ID_PLATE_MANUFACTURERS_NAME
+                position: 7
+              - source: mictronics
+                file: types.json
+                field: "values[0]"
+                transform:
+                  type: split_first
+                  delimiter: " "
+                  description: "Split 'Boeing 737-800' on first space; keep left part"
+
+          type_designator:
+            type: string
+            description: "ICAO 4-character aircraft type designator (e.g. B752)"
+            persisted: true
+            sources:
+              - source: mictronics
+                file: aircrafts.json
+                field: "values[1]"
+
+          manufacturer_model:
+            type: string
+            description: "Combined manufacturer + model string from Mictronics types (e.g. BOEING 757-200)"
+            persisted: true
+            sources:
+              - source: mictronics
+                file: types.json
+                field: "values[0]"
+
+          serial_number:
+            type: string
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                field: SERIAL NUMBER
+                position: 1
+              - source: ca-tc
+                file: carscurr.txt
+                field: MANUFACTURERS_SERIAL_NUMBER
+                position: 5
+
+          manufactured_date:
+            type: datetime
+            description: "Date of manufacture as ISO 8601 UTC datetime; FAA is year-only precision (January 1 assumed); TC is nominally full date but 99.8% of records are also January 1"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: master.txt
+                field: YEAR MFR
+                position: 4
+                precision: year
+                transform:
+                  type: format_string
+                  pattern: "{value}-01-01T00:00:00Z"
+                  description: "FAA provides 4-digit year only — January 1 at midnight UTC assumed"
+                  skip_if_empty: true
+              - source: ca-tc
+                file: carscurr.txt
+                field: DATE_MANUFACTURE_ASSEMBLY
+                position: 31
+                precision: date
+                transform:
+                  type: format_string
+                  pattern: "{value.replace('/', '-')}T00:00:00Z"
+                  description: "TC provides YYYY/MM/DD — reformat separators and append UTC time"
+                  skip_if_empty: true
+
+          wake_turbulence_category:
+            type: string
+            description: "ICAO wake turbulence category (Light, Medium, Heavy, Super)"
+            persisted: true
+            sources:
+              - source: mictronics
+                file: types.json
+                field: "values[2]"
+                transform:
+                  type: decode_table
+                  values:
+                    "J": Super
+                    "H": Heavy
+                    "M": Medium
+                    "L": Light
+                    "M/L": "Medium/Light"
+                    "-": "Unknown/None"
+
+      powerplant:
+        type: object
+        description: "Engine and powerplant specification data"
+        persisted: true
+        properties:
+
+          count:
+            type: integer
+            description: "Number of engines installed"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: acftref.txt
+                field: NO-ENG
+                position: 7
+              - source: ca-tc
+                file: carscurr.txt
+                field: NUMBER_OF_ENGINES
+                position: 17
+
+          type:
+            type: string
+            description: "Engine type (Reciprocating, Turbo-fan, etc.)"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: acftref.txt
+                field: TYPE-ENG
+                position: 4
+                transform:
+                  type: decode_table
+                  values:
+                    "0": None
+                    "1": Piston
+                    "2": Turbo-prop
+                    "3": Turbo-shaft
+                    "4": Turbo-jet
+                    "5": Turbo-fan
+                    "6": Ramjet
+                    "7": 2 Cycle
+                    "8": 4 Cycle
+                    "9": Unknown
+                    "10": Electric
+                    "11": Rotary
+              - source: ca-tc
+                file: carscurr.txt
+                field: ENGINE_CATEGORY_E
+                position: 15
+                transform:
+                  type: decode_table
+                  values:
+                    "Piston": Piston
+                    "Turbo Fan": Turbo-fan
+                    "Turbo Prop": Turbo-prop
+                    "Turbo Shaft": Turbo-shaft
+                    "Turbo Jet": Turbo-jet
+                    "Electric": Electric
+                    "Other": Unknown
+
+          model:
+            type: string
+            description: "Engine model designation (e.g. LEAP-1B28)"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: engine.txt
+                field: MODEL
+                position: 2
+                join: "master.txt[3] → engine.txt[0]"
+
+          manufacturer:
+            type: string
+            description: "Engine manufacturer name"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: engine.txt
+                field: MFR
+                position: 1
+                join: "master.txt[3] → engine.txt[0]"
+              - source: ca-tc
+                file: carscurr.txt
+                field: ENGINE_MANUF_E
+                position: 13
+
+          power_type:
+            type: string
+            description: "Power rating unit — Horsepower (piston/turbo-prop) or Thrust (jet)"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: engine.txt
+                description: "Derived from engine TYPE; piston/prop → Horsepower; jet → Thrust"
+
+          power_value:
+            type: integer
+            description: "Rated power output in horsepower or pounds of thrust"
+            persisted: true
+            sources:
+              - source: us-faa
+                file: engine.txt
+                description: "HORSEPOWER or THRUST column depending on engine type"
+
+      military:
+        type: boolean
+        description: "True if the aircraft is known to be military"
+        persisted: true
+        sources:
+          - source: mictronics
+            file: aircrafts.json
+            field: "values[2]"
+            transform:
+              type: string_index_equals
+              index: 0
+              equals: "1"
+              description: "flags_string[0] == '1'"
+
+      ident:
+        type: string
+        description: "Callsign/flight number broadcast by the aircraft (e.g. DAL2)"
+        persisted: true
+        sources:
+          - source: processor
+            description: "DF 17 TC 1-4 ident message"
+
+      operator:
+        type: object
+        description: "Airline operator enrichment from standing data; keyed by airline_designator"
+        persisted: true
+        properties:
+          airline_designator:
+            type: string
+            description: "3-character ICAO airline code (e.g. DAL)"
+            sources:
+              - source: standing-data
+          name:
+            type: string
+            description: "Full airline name (e.g. Delta Air Lines)"
+            sources:
+              - source: standing-data
+          callsign:
+            type: string
+            description: "RTF callsign (e.g. DELTA)"
+            sources:
+              - source: standing-data
+          country:
+            type: string
+            sources:
+              - source: standing-data
+
+      squawk:
+        type: string
+        description: "4-digit Mode A transponder squawk code (e.g. 7314)"
+        persisted: true
+        sources:
+          - source: processor
+            description: "DF 5/21 squawk message"
+
+      origin:
+        type: object
+        description: "Departure airport enrichment; full object during processing; ICAO code string on persist"
+        persisted: true
+        persist_as:
+          type: string
+          from_field: icao_code
+          description: "Only the ICAO code string (e.g. 'KMLB') is written to the S3 record"
+        properties:
+          icao_code:
+            type: string
+            description: "ICAO 4-character airport code"
+            sources:
+              - source: flightaware
+              - source: standing-data
+                file: routes
+          iata_code:
+            type: string
+            description: "IATA 3-character airport code"
+            sources:
+              - source: standing-data
+                file: airports
+          name:
+            type: string
+            sources:
+              - source: standing-data
+                file: airports
+          city:
+            type: string
+            sources:
+              - source: standing-data
+                file: airports
+          administrative_area:
+            type: string
+            description: "ISO 3166-2 subdivision code (e.g. US-FL)"
+            sources:
+              - source: standing-data
+                file: airports
+          country:
+            type: string
+            description: "ISO 3166-1 alpha-2 country code"
+            sources:
+              - source: standing-data
+                file: airports
+          phonic:
+            type: string
+            description: "Spoken/phonetic airport name for TTS notifications"
+            sources:
+              - source: standing-data
+                file: airports
+
+      destination:
+        type: object
+        description: "Arrival airport enrichment; full object during processing; ICAO code string on persist"
+        persisted: true
+        persist_as:
+          type: string
+          from_field: icao_code
+          description: "Only the ICAO code string (e.g. 'KATL') is written to the S3 record"
+        properties:
+          icao_code:
+            type: string
+            description: "ICAO 4-character airport code"
+            sources:
+              - source: flightaware
+              - source: standing-data
+                file: routes
+          iata_code:
+            type: string
+            description: "IATA 3-character airport code"
+            sources:
+              - source: standing-data
+                file: airports
+          name:
+            type: string
+            sources:
+              - source: standing-data
+                file: airports
+          city:
+            type: string
+            sources:
+              - source: standing-data
+                file: airports
+          administrative_area:
+            type: string
+            description: "ISO 3166-2 subdivision code (e.g. US-GA)"
+            sources:
+              - source: standing-data
+                file: airports
+          country:
+            type: string
+            description: "ISO 3166-1 alpha-2 country code"
+            sources:
+              - source: standing-data
+                file: airports
+          phonic:
+            type: string
+            description: "Spoken/phonetic airport name for TTS notifications"
+            sources:
+              - source: standing-data
+                file: airports
+
+      matched_rules:
+        type: "array[string]"
+        description: "Rule name identifiers that fired for this flight"
+        persisted: true
+        sources:
+          - source: processor
+
+      positions:
+        type: "array[object]"
+        description: "Time-ordered position reports"
+        persisted: true
+        properties:
+          timestamp:
+            type: datetime
+            description: "UTC timestamp of the position report"
+            sources:
+              - source: processor
+          latitude:
+            type: float
+            sources:
+              - source: processor
+          longitude:
+            type: float
+            sources:
+              - source: processor
+          altitude:
+            type: integer
+            description: "Altitude in feet MSL; null if not present in the ADS-B message"
+            sources:
+              - source: processor
+
+      velocities:
+        type: "array[object]"
+        description: "Time-ordered velocity reports"
+        persisted: true
+        properties:
+          timestamp:
+            type: datetime
+            description: "UTC timestamp of the velocity report"
+            sources:
+              - source: processor
+          velocity:
+            type: float
+            description: "Ground speed in knots"
+            sources:
+              - source: processor
+          heading:
+            type: float
+            description: "True heading in degrees (0–359)"
+            sources:
+              - source: processor
+          vertical_speed:
+            type: integer
+            description: "Vertical speed in feet per minute; negative = descending"
+            sources:
+              - source: processor


### PR DESCRIPTION
Closes #11
Closes #36

## Summary

- **US FAA runner** — new `data-runners/us-faa/` container parses `master.txt`, `acftref.txt`, and `engine.txt` from the FAA Releasable Aircraft Database; writes enrichment records in the nested `registrant`/`aircraft`/`powerplant` shape defined by the data dictionary; 59 tests
- **RedisJSON migration** — all runners now use `JSON.SET` + `EXPIRE` instead of `SET key json_string`; Redis image upgraded to `redis/redis-stack-server:latest`; RediSearch index `idx:aircraft` on `$.icao_hex` and `$.registration` replaces separate `registration:{reg}` reverse-index keys
- **Mictronics updates** — fix military flag parsing bug (real data is a 2-char string, not a list); add `interesting` flag support; update tests to 43 passing
- **Data dictionary** — `specs/data-dictionary.yaml` documents field sources, column positions, transforms, merge priority, and persistence rules across mictronics, us-faa, and ca-tc (when built)

## Test plan

- [ ] Run `pytest data-runners/us-faa/tests/` — 59 tests pass
- [ ] Run `pytest data-runners/mictronics/tests/` — 43 tests pass
- [ ] Start `redis/redis-stack-server` locally and run mictronics container end-to-end; verify records are written with `JSON.GET`
- [ ] Run us-faa container end-to-end; verify nested `registrant`/`aircraft`/`powerplant` structure in Redis
- [ ] Verify `FT.SEARCH idx:aircraft @registration:{N659DL}` returns the correct record

🤖 Generated with [Claude Code](https://claude.com/claude-code)