### PR TITLE
Add Transport Canada (CCARCS) data runner

### DIFF
--- a/data-runners/ca-transport-canada/Dockerfile
+++ b/data-runners/ca-transport-canada/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY shared/requirements.txt shared_requirements.txt
+COPY data-runners/ca-transport-canada/requirements.txt .
+RUN pip install --no-cache-dir -r shared_requirements.txt -r requirements.txt
+
+COPY shared/ ./shared/
+COPY data-runners/ca-transport-canada/ ./ca-transport-canada/
+
+ENV PYTHONPATH=/app
+ENV SETTINGS_PATH=/app/settings.json
+
+CMD ["python", "ca-transport-canada/main.py"]

--- a/data-runners/ca-transport-canada/main.py
+++ b/data-runners/ca-transport-canada/main.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""
+SkyFollower Transport Canada Data Runner
+
+Downloads the CCARCS database ZIP, parses aircraft (carscurr.txt) and owner
+(carsownr.txt) CSV files, stages records in local SQLite, writes enrichment
+data to Redis with a 14-day TTL, publishes MQTT completion stats, then exits.
+
+Data source: https://wwwapps.tc.gc.ca/Saf-Sec-Sur/2/CCARCS-RIACC/download/ccarcsdb.zip
+
+Column references follow the data dictionary (specs/data-dictionary.yaml).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import os
+import sqlite3
+import sys
+import zipfile
+from datetime import datetime, timezone
+from typing import Optional
+
+import paho.mqtt.client as mqtt
+import redis as redis_lib
+import requests
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from redis.commands.search.field import TagField
+from redis.commands.search.index_definition import IndexDefinition, IndexType
+
+from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+
+logger = logging.getLogger("ca-transport-canada")
+
+DOWNLOAD_URL = "https://wwwapps.tc.gc.ca/Saf-Sec-Sur/2/CCARCS-RIACC/download/ccarcsdb.zip"
+REDIS_TTL = 14 * 86400
+MQTT_ROOT = "SkyFollower/runner/ca-transport-canada"
+
+# ---------------------------------------------------------------------------
+# Decode tables (data-dictionary.yaml)
+# ---------------------------------------------------------------------------
+
+# carscurr.txt col 10 AIRCRAFT_CATEGORY_E → aircraft.type
+_AIRCRAFT_CATEGORIES: dict[str, str] = {
+    "Aeroplane": "Airplane",
+    "Helicopter": "Helicopter",
+    "Glider": "Glider",
+    "Balloon": "Balloon",
+    "Gyroplane": "Gyroplane",
+}
+
+# carscurr.txt col 15 ENGINE_CATEGORY_E → powerplant.type
+_ENGINE_CATEGORIES: dict[str, str] = {
+    "Piston": "Piston",
+    "Turbo Fan": "Turbo-fan",
+    "Turbo Prop": "Turbo-prop",
+    "Turbo Shaft": "Turbo-shaft",
+    "Turbo Jet": "Turbo-jet",
+    "Electric": "Electric",
+    "Other": "Unknown",
+}
+
+# carsownr.txt col 9 COUNTRY_E (full English name) → ISO 3166-1 alpha-2
+_COUNTRY_NAMES: dict[str, str] = {
+    "CANADA": "CA",
+    "UNITED STATES": "US",
+    "UNITED KINGDOM": "GB",
+    "AUSTRALIA": "AU",
+    "NEW ZEALAND": "NZ",
+    "FRANCE": "FR",
+    "GERMANY": "DE",
+    "ITALY": "IT",
+    "SPAIN": "ES",
+    "NETHERLANDS": "NL",
+    "SWITZERLAND": "CH",
+    "AUSTRIA": "AT",
+    "BELGIUM": "BE",
+    "DENMARK": "DK",
+    "SWEDEN": "SE",
+    "NORWAY": "NO",
+    "FINLAND": "FI",
+    "JAPAN": "JP",
+    "CHINA": "CN",
+    "BRAZIL": "BR",
+    "MEXICO": "MX",
+    "IRELAND": "IE",
+}
+
+
+# ---------------------------------------------------------------------------
+# Decode helpers
+# ---------------------------------------------------------------------------
+
+def _parse_registration(raw_mark: str) -> Optional[str]:
+    """Prepend 'C-' to the trimmed TC mark. Returns None for blank input."""
+    value = raw_mark.strip()
+    return ("C-" + value) if value else None
+
+
+def _parse_icao_hex(binary_str: str) -> Optional[str]:
+    """Convert TC 24-bit binary string to 6-char uppercase hex (data-dict col 42)."""
+    value = binary_str.strip()
+    if not value or len(value) != 24:
+        return None
+    try:
+        return format(int(value, 2), "06X")
+    except ValueError:
+        return None
+
+
+def _parse_date_yyyymmdd(value: str) -> Optional[str]:
+    """Convert TC YYYY/MM/DD date to ISO 8601 UTC datetime string, or None."""
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y/%m/%d").strftime("%Y-%m-%dT00:00:00Z")
+    except ValueError:
+        return None
+
+
+def _parse_int(value: str) -> Optional[int]:
+    """Parse integer, returning None on empty or zero."""
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        result = int(value)
+        return result if result != 0 else None
+    except ValueError:
+        return None
+
+
+def _parse_float(value: str) -> Optional[float]:
+    """Parse float, returning None on empty or zero."""
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        result = float(value)
+        return result if result != 0.0 else None
+    except ValueError:
+        return None
+
+
+def _decode_aircraft_type(raw: str) -> Optional[str]:
+    """Map AIRCRAFT_CATEGORY_E to canonical aircraft.type string."""
+    return _AIRCRAFT_CATEGORIES.get(raw.strip())
+
+
+def _decode_engine_category(raw: str) -> Optional[str]:
+    """Map ENGINE_CATEGORY_E to canonical powerplant.type string."""
+    return _ENGINE_CATEGORIES.get(raw.strip())
+
+
+def _decode_country(raw: str) -> str:
+    """Map full English country name to ISO 3166-1 alpha-2 code, defaulting to 'CA'."""
+    return _COUNTRY_NAMES.get(raw.strip().upper(), "CA")
+
+
+# ---------------------------------------------------------------------------
+# SQLite schema for local staging
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE aircraft (
+    icao_hex                TEXT PRIMARY KEY,
+    registration            TEXT NOT NULL,
+    aircraft_type           TEXT,
+    manufacturer_name       TEXT,
+    model                   TEXT,
+    serial_number           TEXT,
+    engine_manufacturer     TEXT,
+    engine_category         TEXT,
+    engine_count            INTEGER,
+    seat_count              INTEGER,
+    manufactured_date       TEXT,
+    ineffective_date        TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE owners (
+    registration    TEXT NOT NULL,
+    name            TEXT,
+    trade_name      TEXT,
+    street_1        TEXT,
+    street_2        TEXT,
+    city            TEXT,
+    province        TEXT,
+    postal_code     TEXT,
+    country         TEXT,
+    owner_type      TEXT,
+    status          TEXT
+);
+CREATE INDEX idx_owners_registration ON owners(registration);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+def download_and_extract(url: str) -> dict[str, bytes]:
+    """Download the TC ZIP and return a mapping of lowercased filename → bytes."""
+    logger.info("Downloading Transport Canada database from %s", url)
+    response = requests.get(url, timeout=300, headers={"User-Agent": "P5Software SkyFollower"})
+    if response.status_code != 200:
+        raise RuntimeError(f"Download failed with HTTP {response.status_code}")
+    logger.info("Download complete (%d bytes); extracting ZIP.", len(response.content))
+    files: dict[str, bytes] = {}
+    with zipfile.ZipFile(io.BytesIO(response.content)) as zf:
+        for name in zf.namelist():
+            files[name.lower()] = zf.read(name)
+    logger.info("Extracted %d files: %s", len(files), list(files.keys()))
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _csv_rows(data: bytes):
+    """Yield rows from a TC CSV file (ISO-8859-1, comma-delimited), skipping header.
+
+    TC appends a blank row then a record count at the end — stop on first empty row.
+    """
+    reader = csv.reader(io.StringIO(data.decode("iso-8859-1", errors="replace")))
+    next(reader, None)
+    for row in reader:
+        if not row:
+            break
+        yield row
+
+
+# ---------------------------------------------------------------------------
+# SQLite staging
+# ---------------------------------------------------------------------------
+
+def stage_data(files: dict[str, bytes], db_path: str) -> sqlite3.Connection:
+    """Parse carscurr.txt and carsownr.txt, stage rows into SQLite."""
+    logger.info("Opening staging database at %s", db_path)
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_SCHEMA)
+
+    # --- carscurr.txt (aircraft records) ---
+    # Key column indices (data-dictionary.yaml, ca-tc / carscurr.txt):
+    #  0  MARK (raw letters; strip + prepend 'C-')
+    #  4  MODEL_NAME
+    #  5  MANUFACTURERS_SERIAL_NUMBER
+    #  7  ID_PLATE_MANUFACTURERS_NAME
+    # 10  AIRCRAFT_CATEGORY_E → decode via _AIRCRAFT_CATEGORIES
+    # 13  ENGINE_MANUF_E
+    # 15  ENGINE_CATEGORY_E   → decode via _ENGINE_CATEGORIES
+    # 17  NUMBER_OF_ENGINES
+    # 18  NUMBER_OF_SEATS
+    # 23  ineffective date (TC-internal; empty = currently registered)
+    # 31  DATE_MANUFACTURE_ASSEMBLY (YYYY/MM/DD)
+    # 42  MODE_S_TRANSPONDER_BINARY
+    # 46  TRIMMED_MARK (preferred; same as strip(col 0) when present)
+    aircraft_data = files.get("carscurr.txt")
+    if aircraft_data:
+        cur = conn.cursor()
+        count = 0
+        for row in _csv_rows(aircraft_data):
+            if len(row) < 43:
+                continue
+            icao_hex = _parse_icao_hex(row[42])
+            if not icao_hex:
+                continue
+            # Use TRIMMED_MARK (col 46) when present; fall back to col 0 strip
+            raw_mark = row[46].strip() if len(row) > 46 and row[46].strip() else row[0].strip()
+            registration = _parse_registration(raw_mark)
+            if not registration:
+                continue
+            ineffective_date = row[23].strip() if len(row) > 23 else ""
+            cur.execute(
+                "INSERT OR REPLACE INTO aircraft "
+                "(icao_hex, registration, aircraft_type, manufacturer_name, model, serial_number, "
+                "engine_manufacturer, engine_category, engine_count, seat_count, "
+                "manufactured_date, ineffective_date) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    icao_hex,
+                    registration,
+                    _decode_aircraft_type(row[10]) if len(row) > 10 else None,
+                    row[7].strip() or None,
+                    row[4].strip() or None,
+                    row[5].strip() or None,
+                    row[13].strip() or None,
+                    _decode_engine_category(row[15]) if len(row) > 15 else None,
+                    _parse_int(row[17]) if len(row) > 17 else None,
+                    _parse_int(row[18]) if len(row) > 18 else None,
+                    _parse_date_yyyymmdd(row[31]) if len(row) > 31 else None,
+                    ineffective_date,
+                ),
+            )
+            count += 1
+        conn.commit()
+        logger.info("Staged %d aircraft records.", count)
+    else:
+        logger.warning("carscurr.txt not found in download.")
+
+    # --- carsownr.txt (owner records) ---
+    # Key column indices (data-dictionary.yaml, ca-tc / carsownr.txt):
+    #  0  MARK_LINK (same format as carscurr.txt MARK)
+    #  1  FULL_NAME
+    #  2  TRADE_NAME
+    #  3  STREET_NAME
+    #  4  STREET_NAME2
+    #  5  CITY
+    #  6  PROVINCE_OR_STATE_E
+    #  8  POSTAL_CODE
+    #  9  COUNTRY_E (full English name → ISO code)
+    # 11  TYPE_OF_OWNER_E
+    # 13  ACTIVE_FLAG (A = active)
+    owner_data = files.get("carsownr.txt")
+    if owner_data:
+        cur = conn.cursor()
+        count = 0
+        for row in _csv_rows(owner_data):
+            if len(row) < 12:
+                continue
+            registration = _parse_registration(row[0])
+            if not registration:
+                continue
+            status_code = row[13].strip() if len(row) > 13 else ""
+            status = "Active" if status_code.upper() == "A" else "Inactive"
+            country_raw = row[9].strip() if len(row) > 9 else ""
+            cur.execute(
+                "INSERT INTO owners "
+                "(registration, name, trade_name, street_1, street_2, city, province, "
+                "postal_code, country, owner_type, status) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    registration,
+                    row[1].strip() or None,
+                    row[2].strip() or None,
+                    row[3].strip() or None,
+                    row[4].strip() or None,
+                    row[5].strip() or None,
+                    row[6].strip() or None,
+                    row[8].strip() or None if len(row) > 8 else None,
+                    _decode_country(country_raw) if country_raw else "CA",
+                    row[11].strip() or None if len(row) > 11 else None,
+                    status,
+                ),
+            )
+            count += 1
+        conn.commit()
+        logger.info("Staged %d owner records.", count)
+    else:
+        logger.warning("carsownr.txt not found in download.")
+
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Build Redis record
+# ---------------------------------------------------------------------------
+
+def build_aircraft_record(acft_row: sqlite3.Row, owner_rows: list[sqlite3.Row]) -> dict:
+    """Build the icao_hex:{hex} JSON record from staged rows."""
+    # registrant — use first active owner record
+    registrant: Optional[dict] = None
+    if owner_rows:
+        o = owner_rows[0]
+        names = [n for n in [o["name"], o["trade_name"]] if n]
+        streets = [s for s in [o["street_1"], o["street_2"]] if s]
+        registrant = {
+            "names": names,
+            "street": streets,
+            "city": o["city"] or None,
+            "administrative_area": o["province"] or None,
+            "postal_code": o["postal_code"] or None,
+            "country": o["country"] or "CA",
+            "type": o["owner_type"] or None,
+        }
+
+    # aircraft — type from decoded AIRCRAFT_CATEGORY_E; category null (FAA-only field)
+    aircraft: Optional[dict] = None
+    if acft_row["manufacturer_name"] or acft_row["model"] or acft_row["seat_count"] or acft_row["serial_number"]:
+        aircraft = {
+            "type": acft_row["aircraft_type"] or None,
+            "model": acft_row["model"] or None,
+            "seats": acft_row["seat_count"],
+            "category": None,
+            "manufacturer": acft_row["manufacturer_name"] or None,
+            "type_designator": None,
+            "manufacturer_model": None,
+            "serial_number": acft_row["serial_number"] or None,
+            "manufactured_date": acft_row["manufactured_date"] or None,
+            "wake_turbulence_category": None,
+        }
+
+    # powerplant
+    powerplant: Optional[dict] = None
+    if acft_row["engine_count"] or acft_row["engine_category"] or acft_row["engine_manufacturer"]:
+        powerplant = {
+            "count": acft_row["engine_count"],
+            "type": acft_row["engine_category"] or None,
+            "model": None,
+            "manufacturer": acft_row["engine_manufacturer"] or None,
+            "power_type": None,
+            "power_value": None,
+        }
+
+    return {
+        "icao_hex": acft_row["icao_hex"],
+        "registration": acft_row["registration"],
+        "registrant": registrant,
+        "aircraft": aircraft,
+        "powerplant": powerplant,
+        "military": None,
+        "source": "ca-transport-canada",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Search index
+# ---------------------------------------------------------------------------
+
+def _ensure_search_index(r: redis_lib.Redis) -> None:
+    """Create the aircraft JSON search index if it does not already exist."""
+    try:
+        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+    except Exception:
+        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+            fields=[
+                TagField("$.icao_hex", as_name="icao_hex"),
+                TagField("$.registration", as_name="registration"),
+            ],
+            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+        )
+        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+
+
+# ---------------------------------------------------------------------------
+# Write to Redis
+# ---------------------------------------------------------------------------
+
+def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> int:
+    """Write active aircraft records to Redis. Returns count of records written."""
+    acft_cur = conn.cursor()
+    acft_cur.execute(
+        "SELECT icao_hex, registration, aircraft_type, manufacturer_name, model, serial_number, "
+        "engine_manufacturer, engine_category, engine_count, seat_count, manufactured_date "
+        "FROM aircraft WHERE ineffective_date = ''"
+    )
+    acft_rows = acft_cur.fetchall()
+    logger.info("Writing %d active registration records to Redis.", len(acft_rows))
+
+    owner_cur = conn.cursor()
+
+    count = 0
+    pipe = r.pipeline()
+    for acft_row in acft_rows:
+        owner_cur.execute(
+            "SELECT name, trade_name, street_1, street_2, city, province, "
+            "postal_code, country, owner_type FROM owners "
+            "WHERE registration = ? AND status = 'Active' LIMIT 1",
+            (acft_row["registration"],),
+        )
+        owner_rows = owner_cur.fetchall()
+        record = build_aircraft_record(acft_row, owner_rows)
+        key = icao_hex_key(record["icao_hex"])
+        pipe.json().set(key, "$", record)
+        pipe.expire(key, ttl)
+
+        count += 1
+        if count % 10000 == 0:
+            pipe.execute()
+            pipe = r.pipeline()
+            logger.info("  ... %d records written.", count)
+
+    pipe.execute()
+    logger.info("Finished writing %d records to Redis.", count)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# MQTT
+# ---------------------------------------------------------------------------
+
+def publish_completion_stats(cfg: dict, records_imported: int, status: str) -> None:
+    """Publish completion statistics to MQTT."""
+    mc = cfg.get("mqtt")
+    if not mc:
+        logger.info("No MQTT config; skipping stats publish.")
+        return
+
+    run_at = datetime.now(timezone.utc).isoformat()
+
+    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+    connected = False
+
+    def _on_connect(c, userdata, flags, reason_code, properties):
+        nonlocal connected
+        connected = True
+
+    client.on_connect = _on_connect
+
+    try:
+        client.connect(mc["host"], port=mc.get("port", 1883), keepalive=60)
+        client.loop_start()
+
+        import time
+        deadline = time.monotonic() + 5
+        while not connected and time.monotonic() < deadline:
+            time.sleep(0.05)
+
+        if not connected:
+            logger.warning("MQTT connect timed out; skipping stats publish.")
+            client.loop_stop()
+            return
+
+        base = MQTT_ROOT + "/statistic"
+        client.publish(f"{base}/records_imported", str(records_imported), retain=True)
+        client.publish(f"{base}/last_run_at", run_at, retain=True)
+        client.publish(f"{base}/last_run_status", status, retain=True)
+
+        _publish_ha_autodiscovery(client)
+
+        time.sleep(0.5)
+        client.loop_stop()
+        client.disconnect()
+        logger.info("MQTT stats published (status=%s, records=%d).", status, records_imported)
+
+    except Exception as exc:
+        logger.warning("MQTT publish failed: %s", exc)
+        try:
+            client.loop_stop()
+        except Exception:
+            pass
+
+
+def _publish_ha_autodiscovery(client: mqtt.Client) -> None:
+    device = {
+        "ids": "SkyFollower_runner_ca_transport_canada",
+        "name": "SkyFollower Transport Canada Runner",
+        "manufacturer": "P5Software, LLC",
+    }
+    stats = [
+        ("records_imported", "Transport Canada Records Imported", "mdi:airplane", "total_increasing", None),
+        ("last_run_at", "Transport Canada Last Run At", "mdi:clock", None, None),
+        ("last_run_status", "Transport Canada Last Run Status", "mdi:check-circle", None, None),
+    ]
+    for name, friendly_name, icon, state_class, unit in stats:
+        payload: dict = {
+            "state_topic": f"{MQTT_ROOT}/statistic/{name}",
+            "name": friendly_name,
+            "unique_id": f"SkyFollower_runner_ca_transport_canada_{name}",
+            "object_id": f"SkyFollower_runner_ca_transport_canada_{name}",
+            "device": device,
+            "icon": icon,
+        }
+        if state_class:
+            payload["state_class"] = state_class
+        if unit:
+            payload["unit_of_measurement"] = unit
+        client.publish(
+            f"homeassistant/sensor/SkyFollower_runner_ca_transport_canada_{name}/config",
+            json.dumps(payload),
+            retain=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    path = os.environ.get("SETTINGS_PATH", "/app/settings.json")
+    with open(path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+        stream=sys.stdout,
+    )
+
+    try:
+        cfg = _load_config()
+    except FileNotFoundError as exc:
+        logger.critical("Settings file not found: %s", exc)
+        sys.exit(1)
+
+    rc = cfg["redis"]
+    r = redis_lib.Redis(
+        host=rc["host"],
+        port=rc.get("port", 6379),
+        decode_responses=True,
+    )
+
+    ttl_days = cfg.get("redis_ttl_days", 14)
+    ttl = ttl_days * 86400
+
+    db_path = "/app/data/staging.db"
+
+    status = "failure"
+    records_imported = 0
+
+    try:
+        files = download_and_extract(DOWNLOAD_URL)
+        conn = stage_data(files, db_path)
+        _ensure_search_index(r)
+        records_imported = write_to_redis(conn, r, ttl)
+        conn.close()
+        status = "success"
+        logger.info("Transport Canada runner completed successfully. Records imported: %d", records_imported)
+
+    except Exception as exc:
+        logger.error("Transport Canada runner failed: %s", exc, exc_info=True)
+
+    finally:
+        try:
+            publish_completion_stats(cfg, records_imported, status)
+        except Exception as exc:
+            logger.warning("Failed to publish MQTT stats: %s", exc)
+
+    if status != "success":
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/data-runners/ca-transport-canada/requirements.txt
+++ b/data-runners/ca-transport-canada/requirements.txt
@@ -1,0 +1,5 @@
+pydantic>=2.0
+uuid7>=0.1.0
+redis>=5.0
+paho-mqtt>=2.0
+requests>=2.31

--- a/data-runners/ca-transport-canada/tests/test_ca_tc.py
+++ b/data-runners/ca-transport-canada/tests/test_ca_tc.py
@@ -1,0 +1,825 @@
+"""
+Tests for the Transport Canada data runner.
+
+Covers:
+- Parse/decode helpers (registration, ICAO hex, date, aircraft/engine category, country)
+- CSV parsing and SQLite staging
+- Redis record construction
+- Active-record filtering (ineffective_date)
+- Redis write logic (mocked)
+- MQTT completion stats (mocked)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import helper
+# ---------------------------------------------------------------------------
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNNER_DIR = os.path.dirname(_HERE)        # data-runners/ca-transport-canada/
+_REPO_ROOT = os.path.abspath(os.path.join(_RUNNER_DIR, "..", ".."))
+
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _load_main():
+    spec = importlib.util.spec_from_file_location(
+        "ca_tc_main",
+        os.path.join(_RUNNER_DIR, "main.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ca_tc_main"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_main()
+
+_parse_registration = _mod._parse_registration
+_parse_icao_hex = _mod._parse_icao_hex
+_parse_date_yyyymmdd = _mod._parse_date_yyyymmdd
+_parse_int = _mod._parse_int
+_parse_float = _mod._parse_float
+_decode_aircraft_type = _mod._decode_aircraft_type
+_decode_engine_category = _mod._decode_engine_category
+_decode_country = _mod._decode_country
+build_aircraft_record = _mod.build_aircraft_record
+stage_data = _mod.stage_data
+write_to_redis = _mod.write_to_redis
+publish_completion_stats = _mod.publish_completion_stats
+REDIS_TTL = _mod.REDIS_TTL
+MQTT_ROOT = _mod.MQTT_ROOT
+
+
+# ---------------------------------------------------------------------------
+# ICAO hex binary strings for test records
+# format(int(binary, 2), '06X') must produce a 6-char hex
+# ---------------------------------------------------------------------------
+
+_BIN_C00001 = "110000000000000000000001"   # → C00001
+_BIN_C00002 = "110000000000000000000010"   # → C00002
+_BIN_C00003 = "110000000000000000000011"   # → C00003 (inactive)
+
+
+# ---------------------------------------------------------------------------
+# Sample CSV fixtures
+# ---------------------------------------------------------------------------
+
+def _acft_row(**fields) -> str:
+    """Build a 47-column carscurr.txt data row from keyword {index: value} overrides."""
+    row = [""] * 47
+    for idx, val in fields.items():
+        row[int(idx)] = str(val)
+    return ",".join(row)
+
+
+_ACFT_HEADER = (
+    "COL0,COL1,COL2,COL3,COL4,COL5,COL6,COL7,COL8,COL9,"   # 0-9
+    "COL10,COL11,COL12,COL13,COL14,COL15,COL16,COL17,COL18,COL19,"  # 10-19
+    "COL20,COL21,COL22,COL23,COL24,COL25,COL26,COL27,COL28,COL29,"  # 20-29
+    "COL30,COL31,COL32,COL33,COL34,COL35,COL36,COL37,COL38,COL39,"  # 30-39
+    "COL40,COL41,COL42,COL43,COL44,COL45,COL46\n"  # 40-46
+)
+
+# Active — C-GABC: full data including col 46 TRIMMED_MARK
+_ROW_C_GABC = _acft_row(**{
+    "0":  "GABC",
+    "4":  "172P",
+    "5":  "SN001",
+    "7":  "CESSNA AIRCRAFT CO",
+    "10": "Aeroplane",
+    "13": "LYCOMING",
+    "15": "Piston",
+    "17": "1",
+    "18": "4",
+    "19": "1100.0",
+    "23": "",                        # active — no ineffective date
+    "31": "2000/01/15",
+    "42": _BIN_C00001,
+    "46": "GABC",                    # TRIMMED_MARK (col 46)
+})
+
+# Active — CF-XYZ style (old 3-char mark); data dict says 'C-' prefix always
+_ROW_C_XYZ = _acft_row(**{
+    "0":  "XYZ",
+    "4":  "737-200",
+    "5":  "SN002",
+    "7":  "THE BOEING COMPANY",
+    "10": "Aeroplane",
+    "13": "CFM INTERNATIONAL",
+    "15": "Turbo Fan",               # raw TC string — decoded to "Turbo-fan"
+    "17": "2",
+    "18": "150",
+    "31": "1995/06/01",
+    "42": _BIN_C00002,
+    "46": "XYZ",                     # TRIMMED_MARK
+})
+
+# Inactive — C-GINV (ineffective_date set → filtered from Redis)
+_ROW_C_GINV = _acft_row(**{
+    "0":  "GINV",
+    "7":  "PIPER",
+    "4":  "PA-28",
+    "5":  "SN003",
+    "23": "2020/03/01",
+    "42": _BIN_C00003,
+    "46": "GINV",
+})
+
+# Row with invalid binary ICAO — must be skipped
+_ROW_BAD_ICAO = _acft_row(**{
+    "0":  "BADC",
+    "7":  "TEST",
+    "42": "NOTBINARY",
+    "46": "BADC",
+})
+
+_ACFT_CSV = (
+    _ACFT_HEADER
+    + _ROW_C_GABC + "\n"
+    + _ROW_C_XYZ + "\n"
+    + _ROW_C_GINV + "\n"
+    + _ROW_BAD_ICAO + "\n"
+).encode("iso-8859-1")
+
+
+def _owner_row(**fields) -> str:
+    """Build a 20-column carsownr.txt data row."""
+    row = [""] * 20
+    for idx, val in fields.items():
+        row[int(idx)] = str(val)
+    return ",".join(row)
+
+
+_OWNER_HEADER = (
+    "COL0,COL1,COL2,COL3,COL4,COL5,COL6,COL7,COL8,COL9,"
+    "COL10,COL11,COL12,COL13,COL14,COL15,COL16,COL17,COL18,COL19\n"
+)
+
+# Active owner for C-GABC
+_OWNER_C_GABC = _owner_row(**{
+    "0":  "GABC",
+    "1":  "JOHN DOE",
+    "2":  "DOE AVIATION",
+    "3":  "123 MAPLE ST",
+    "5":  "VANCOUVER",
+    "6":  "BC",
+    "8":  "V6Z 1A1",
+    "9":  "CANADA",
+    "11": "Individual",
+    "13": "A",
+})
+
+# Inactive owner for C-XYZ — should not appear as registrant
+_OWNER_C_XYZ = _owner_row(**{
+    "0":  "XYZ",
+    "1":  "OLD CORP",
+    "5":  "TORONTO",
+    "9":  "CANADA",
+    "11": "Entity",
+    "13": "I",
+})
+
+_OWNER_CSV = (
+    _OWNER_HEADER
+    + _OWNER_C_GABC + "\n"
+    + _OWNER_C_XYZ + "\n"
+).encode("iso-8859-1")
+
+
+def _make_files(**overrides) -> dict[str, bytes]:
+    base = {
+        "carscurr.txt": _ACFT_CSV,
+        "carsownr.txt": _OWNER_CSV,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_registration
+# ---------------------------------------------------------------------------
+
+class TestParseRegistration:
+    def test_four_char_gives_c_prefix(self):
+        assert _parse_registration("GABC") == "C-GABC"
+
+    def test_three_char_gives_c_prefix(self):
+        # Data dictionary: always 'C-' regardless of mark length
+        assert _parse_registration("XYZ") == "C-XYZ"
+
+    def test_strips_whitespace(self):
+        assert _parse_registration("  GABC  ") == "C-GABC"
+
+    def test_empty_returns_none(self):
+        assert _parse_registration("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert _parse_registration("   ") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_icao_hex
+# ---------------------------------------------------------------------------
+
+class TestParseIcaoHex:
+    def test_binary_converts_correctly(self):
+        assert _parse_icao_hex(_BIN_C00001) == "C00001"
+
+    def test_result_is_uppercase(self):
+        result = _parse_icao_hex(_BIN_C00001)
+        assert result == result.upper()
+
+    def test_empty_returns_none(self):
+        assert _parse_icao_hex("") is None
+
+    def test_non_binary_returns_none(self):
+        assert _parse_icao_hex("NOTBINARY") is None
+
+    def test_wrong_length_returns_none(self):
+        # 23-bit number produces a 5-char hex, not 6
+        assert _parse_icao_hex("11000000000000000000001") is None
+
+    def test_strips_whitespace(self):
+        assert _parse_icao_hex("  " + _BIN_C00001 + "  ") == "C00001"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_date_yyyymmdd
+# ---------------------------------------------------------------------------
+
+class TestParseDateYyyymmdd:
+    def test_valid_date(self):
+        assert _parse_date_yyyymmdd("2000/01/15") == "2000-01-15T00:00:00Z"
+
+    def test_empty_returns_none(self):
+        assert _parse_date_yyyymmdd("") is None
+
+    def test_strips_whitespace(self):
+        assert _parse_date_yyyymmdd("  2000/01/15  ") == "2000-01-15T00:00:00Z"
+
+    def test_invalid_format_returns_none(self):
+        assert _parse_date_yyyymmdd("2000-01-15") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_aircraft_type
+# ---------------------------------------------------------------------------
+
+class TestDecodeAircraftType:
+    def test_aeroplane_maps_to_airplane(self):
+        assert _decode_aircraft_type("Aeroplane") == "Airplane"
+
+    def test_helicopter(self):
+        assert _decode_aircraft_type("Helicopter") == "Helicopter"
+
+    def test_glider(self):
+        assert _decode_aircraft_type("Glider") == "Glider"
+
+    def test_balloon(self):
+        assert _decode_aircraft_type("Balloon") == "Balloon"
+
+    def test_gyroplane(self):
+        assert _decode_aircraft_type("Gyroplane") == "Gyroplane"
+
+    def test_unknown_returns_none(self):
+        assert _decode_aircraft_type("Unknown") is None
+
+    def test_strips_whitespace(self):
+        assert _decode_aircraft_type("  Aeroplane  ") == "Airplane"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_engine_category
+# ---------------------------------------------------------------------------
+
+class TestDecodeEngineCategory:
+    def test_piston(self):
+        assert _decode_engine_category("Piston") == "Piston"
+
+    def test_turbo_fan_with_space(self):
+        assert _decode_engine_category("Turbo Fan") == "Turbo-fan"
+
+    def test_turbo_prop(self):
+        assert _decode_engine_category("Turbo Prop") == "Turbo-prop"
+
+    def test_turbo_shaft(self):
+        assert _decode_engine_category("Turbo Shaft") == "Turbo-shaft"
+
+    def test_turbo_jet(self):
+        assert _decode_engine_category("Turbo Jet") == "Turbo-jet"
+
+    def test_electric(self):
+        assert _decode_engine_category("Electric") == "Electric"
+
+    def test_other_maps_to_unknown(self):
+        assert _decode_engine_category("Other") == "Unknown"
+
+    def test_unrecognised_returns_none(self):
+        assert _decode_engine_category("Rocket") is None
+
+    def test_strips_whitespace(self):
+        assert _decode_engine_category("  Piston  ") == "Piston"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_country
+# ---------------------------------------------------------------------------
+
+class TestDecodeCountry:
+    def test_canada(self):
+        assert _decode_country("CANADA") == "CA"
+
+    def test_case_insensitive(self):
+        assert _decode_country("canada") == "CA"
+
+    def test_united_states(self):
+        assert _decode_country("UNITED STATES") == "US"
+
+    def test_unknown_defaults_to_ca(self):
+        assert _decode_country("RURITANIA") == "CA"
+
+    def test_strips_whitespace(self):
+        assert _decode_country("  CANADA  ") == "CA"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_int and _parse_float
+# ---------------------------------------------------------------------------
+
+class TestParseHelpers:
+    def test_parse_int_valid(self):
+        assert _parse_int("4") == 4
+
+    def test_parse_int_zero_returns_none(self):
+        assert _parse_int("0") is None
+
+    def test_parse_int_empty_returns_none(self):
+        assert _parse_int("") is None
+
+    def test_parse_float_valid(self):
+        assert _parse_float("1100.0") == 1100.0
+
+    def test_parse_float_zero_returns_none(self):
+        assert _parse_float("0.0") is None
+
+    def test_parse_float_empty_returns_none(self):
+        assert _parse_float("") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: stage_data
+# ---------------------------------------------------------------------------
+
+class TestStageData:
+    def test_aircraft_count_includes_inactive(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM aircraft")
+            # GABC + XYZ + GINV staged; bad ICAO skipped
+            assert cur.fetchone()[0] == 3
+            conn.close()
+
+    def test_active_aircraft_count(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM aircraft WHERE ineffective_date = ''")
+            assert cur.fetchone()[0] == 2
+            conn.close()
+
+    def test_aircraft_fields_c_gabc(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT registration, aircraft_type, manufacturer_name, model, serial_number, "
+                "engine_manufacturer, engine_category, engine_count, seat_count, manufactured_date "
+                "FROM aircraft WHERE icao_hex = 'C00001'"
+            )
+            row = cur.fetchone()
+            assert row["registration"] == "C-GABC"
+            assert row["aircraft_type"] == "Airplane"
+            assert row["manufacturer_name"] == "CESSNA AIRCRAFT CO"
+            assert row["model"] == "172P"
+            assert row["serial_number"] == "SN001"
+            assert row["engine_manufacturer"] == "LYCOMING"
+            assert row["engine_category"] == "Piston"
+            assert row["engine_count"] == 1
+            assert row["seat_count"] == 4
+            assert row["manufactured_date"] == "2000-01-15T00:00:00Z"
+            conn.close()
+
+    def test_aircraft_trimmed_mark_used_for_registration(self):
+        # col 46 (TRIMMED_MARK) preferred over col 0 when present
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT registration FROM aircraft WHERE icao_hex = 'C00002'")
+            # TRIMMED_MARK = "XYZ", always prepend 'C-'
+            assert cur.fetchone()["registration"] == "C-XYZ"
+            conn.close()
+
+    def test_three_char_mark_gets_c_prefix(self):
+        # Data dictionary: always 'C-' regardless of mark length
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT registration FROM aircraft WHERE icao_hex = 'C00002'")
+            assert cur.fetchone()["registration"] == "C-XYZ"
+            conn.close()
+
+    def test_engine_category_decoded(self):
+        # "Turbo Fan" (raw TC) → "Turbo-fan" (canonical)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT engine_category FROM aircraft WHERE icao_hex = 'C00002'")
+            assert cur.fetchone()["engine_category"] == "Turbo-fan"
+            conn.close()
+
+    def test_inactive_aircraft_has_ineffective_date(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT ineffective_date FROM aircraft WHERE icao_hex = 'C00003'")
+            assert cur.fetchone()["ineffective_date"] != ""
+            conn.close()
+
+    def test_bad_icao_skipped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT icao_hex FROM aircraft")
+            hexes = {r[0] for r in cur.fetchall()}
+            assert "NOTBINARY" not in hexes
+            conn.close()
+
+    def test_owner_count(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM owners")
+            assert cur.fetchone()[0] == 2
+            conn.close()
+
+    def test_active_owner_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT name, trade_name, street_1, city, province, postal_code, country, owner_type, status "
+                "FROM owners WHERE registration = 'C-GABC'"
+            )
+            row = cur.fetchone()
+            assert row["name"] == "JOHN DOE"
+            assert row["trade_name"] == "DOE AVIATION"
+            assert row["street_1"] == "123 MAPLE ST"
+            assert row["city"] == "VANCOUVER"
+            assert row["province"] == "BC"
+            assert row["postal_code"] == "V6Z 1A1"
+            assert row["country"] == "CA"           # decoded from "CANADA"
+            assert row["owner_type"] == "Individual"
+            assert row["status"] == "Active"
+            conn.close()
+
+    def test_country_decoded_from_english_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT country FROM owners WHERE registration = 'C-GABC'")
+            assert cur.fetchone()["country"] == "CA"
+            conn.close()
+
+    def test_inactive_owner_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT status FROM owners WHERE registration = 'C-XYZ'")
+            assert cur.fetchone()["status"] == "Inactive"
+            conn.close()
+
+    def test_missing_aircraft_file_skips_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data({"carsownr.txt": _OWNER_CSV}, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM aircraft")
+            assert cur.fetchone()[0] == 0
+            conn.close()
+
+    def test_missing_owner_file_skips_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            conn = stage_data({"carscurr.txt": _ACFT_CSV}, os.path.join(tmpdir, "staging.db"))
+            cur = conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM owners")
+            assert cur.fetchone()[0] == 0
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_aircraft_record
+# ---------------------------------------------------------------------------
+
+class TestBuildAircraftRecord:
+    def _make_conn(self) -> sqlite3.Connection:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            return stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+
+    def _fetch_acft_row(self, icao_hex: str, conn: sqlite3.Connection) -> sqlite3.Row:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT icao_hex, registration, aircraft_type, manufacturer_name, model, serial_number, "
+            "engine_manufacturer, engine_category, engine_count, seat_count, manufactured_date "
+            "FROM aircraft WHERE icao_hex = ?",
+            (icao_hex,),
+        )
+        return cur.fetchone()
+
+    def _fetch_owner_rows(self, registration: str, conn: sqlite3.Connection) -> list[sqlite3.Row]:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT name, trade_name, street_1, street_2, city, province, "
+            "postal_code, country, owner_type FROM owners "
+            "WHERE registration = ? AND status = 'Active' LIMIT 1",
+            (registration,),
+        )
+        return cur.fetchall()
+
+    def test_top_level_fields(self):
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00001", conn)
+        owners = self._fetch_owner_rows("C-GABC", conn)
+        record = build_aircraft_record(acft, owners)
+        assert record["icao_hex"] == "C00001"
+        assert record["registration"] == "C-GABC"
+        assert record["source"] == "ca-transport-canada"
+        assert record["military"] is None
+        conn.close()
+
+    def test_registrant_with_active_owner(self):
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00001", conn)
+        owners = self._fetch_owner_rows("C-GABC", conn)
+        record = build_aircraft_record(acft, owners)
+        reg = record["registrant"]
+        assert "JOHN DOE" in reg["names"]
+        assert "DOE AVIATION" in reg["names"]
+        assert "123 MAPLE ST" in reg["street"]
+        assert reg["city"] == "VANCOUVER"
+        assert reg["administrative_area"] == "BC"
+        assert reg["postal_code"] == "V6Z 1A1"
+        assert reg["country"] == "CA"
+        assert reg["type"] == "Individual"
+        conn.close()
+
+    def test_registrant_none_when_no_active_owners(self):
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00002", conn)
+        owners = self._fetch_owner_rows("C-XYZ", conn)
+        record = build_aircraft_record(acft, owners)
+        assert record["registrant"] is None
+        conn.close()
+
+    def test_aircraft_type_decoded(self):
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00001", conn)
+        owners = self._fetch_owner_rows("C-GABC", conn)
+        record = build_aircraft_record(acft, owners)
+        # AIRCRAFT_CATEGORY_E "Aeroplane" → aircraft.type "Airplane"
+        assert record["aircraft"]["type"] == "Airplane"
+        conn.close()
+
+    def test_aircraft_category_is_null(self):
+        # aircraft.category (Land/Sea/Amphibian) is FAA-only — must be null for TC
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00001", conn)
+        owners = self._fetch_owner_rows("C-GABC", conn)
+        record = build_aircraft_record(acft, owners)
+        assert record["aircraft"]["category"] is None
+        conn.close()
+
+    def test_aircraft_manufacturer_from_col7(self):
+        # ID_PLATE_MANUFACTURERS_NAME (col 7) — not COMMON_NAME (col 3)
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00001", conn)
+        owners = self._fetch_owner_rows("C-GABC", conn)
+        record = build_aircraft_record(acft, owners)
+        assert record["aircraft"]["manufacturer"] == "CESSNA AIRCRAFT CO"
+        conn.close()
+
+    def test_aircraft_mictronics_fields_null(self):
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00001", conn)
+        owners = self._fetch_owner_rows("C-GABC", conn)
+        record = build_aircraft_record(acft, owners)
+        ac = record["aircraft"]
+        assert ac["type_designator"] is None
+        assert ac["manufacturer_model"] is None
+        assert ac["wake_turbulence_category"] is None
+        conn.close()
+
+    def test_powerplant_piston(self):
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00001", conn)
+        owners = self._fetch_owner_rows("C-GABC", conn)
+        record = build_aircraft_record(acft, owners)
+        pp = record["powerplant"]
+        assert pp["count"] == 1
+        assert pp["type"] == "Piston"
+        assert pp["manufacturer"] == "LYCOMING"
+        assert pp["model"] is None
+        assert pp["power_type"] is None
+        assert pp["power_value"] is None
+        conn.close()
+
+    def test_powerplant_turbofan(self):
+        conn = self._make_conn()
+        acft = self._fetch_acft_row("C00002", conn)
+        owners = self._fetch_owner_rows("C-XYZ", conn)
+        record = build_aircraft_record(acft, owners)
+        pp = record["powerplant"]
+        assert pp["count"] == 2
+        assert pp["type"] == "Turbo-fan"
+        assert pp["manufacturer"] == "CFM INTERNATIONAL"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Redis key construction
+# ---------------------------------------------------------------------------
+
+class TestRedisKeys:
+    def test_icao_hex_key_format(self):
+        from shared.redis_keys import icao_hex_key
+        assert icao_hex_key("c00001") == "icao_hex:C00001"
+
+    def test_aircraft_search_index_name(self):
+        from shared.redis_keys import AIRCRAFT_SEARCH_INDEX
+        assert AIRCRAFT_SEARCH_INDEX == "idx:aircraft"
+
+
+# ---------------------------------------------------------------------------
+# Tests: write_to_redis
+# ---------------------------------------------------------------------------
+
+class TestWriteToRedis:
+    def _make_db(self) -> sqlite3.Connection:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            return stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
+
+    def _mock_redis(self):
+        r = MagicMock()
+        pipe = MagicMock()
+        pipe_json = MagicMock()
+        r.pipeline.return_value = pipe
+        pipe.json.return_value = pipe_json
+        pipe.execute.return_value = []
+        return r, pipe, pipe_json
+
+    def test_only_active_records_written(self):
+        conn = self._make_db()
+        r, _, _ = self._mock_redis()
+        count = write_to_redis(conn, r, REDIS_TTL)
+        assert count == 2
+        conn.close()
+
+    def test_active_icao_hex_written(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        keys = [c.args[0] for c in pipe_json.set.call_args_list]
+        assert "icao_hex:C00001" in keys
+        assert "icao_hex:C00002" in keys
+        conn.close()
+
+    def test_inactive_icao_hex_not_written(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        keys = [c.args[0] for c in pipe_json.set.call_args_list]
+        assert "icao_hex:C00003" not in keys
+        conn.close()
+
+    def test_json_set_uses_root_path(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        for c in pipe_json.set.call_args_list:
+            assert c.args[1] == "$"
+        conn.close()
+
+    def test_expire_called_with_correct_ttl(self):
+        conn = self._make_db()
+        r, pipe, _ = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        expire_ttls = [c.args[1] for c in pipe.expire.call_args_list]
+        assert all(ttl == REDIS_TTL for ttl in expire_ttls)
+        conn.close()
+
+    def test_no_registration_key_written(self):
+        conn = self._make_db()
+        r, pipe, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        all_keys = (
+            [c.args[0] for c in pipe.set.call_args_list]
+            + [c.args[0] for c in pipe_json.set.call_args_list]
+        )
+        assert not any(k.startswith("registration:") for k in all_keys)
+        conn.close()
+
+    def test_record_source_is_ca_transport_canada(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
+        record = calls["icao_hex:C00001"]
+        assert isinstance(record, dict)
+        assert record["source"] == "ca-transport-canada"
+        assert record["registration"] == "C-GABC"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: MQTT completion stats (mocked)
+# ---------------------------------------------------------------------------
+
+class TestMqttCompletionStats:
+    def _setup_mock_client(self):
+        mock_client = MagicMock()
+
+        def fake_connect(host, port, keepalive):
+            mock_client.on_connect(mock_client, None, None, 0, None)
+
+        mock_client.connect.side_effect = fake_connect
+        return mock_client
+
+    def test_publishes_records_imported(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("ca_tc_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 42, "success")
+        topics = [c.args[0] for c in mc.publish.call_args_list]
+        assert f"{MQTT_ROOT}/statistic/records_imported" in topics
+
+    def test_records_imported_value(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("ca_tc_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 99, "success")
+        calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
+        assert calls[f"{MQTT_ROOT}/statistic/records_imported"] == "99"
+
+    def test_publishes_last_run_at(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("ca_tc_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 0, "success")
+        topics = [c.args[0] for c in mc.publish.call_args_list]
+        assert f"{MQTT_ROOT}/statistic/last_run_at" in topics
+
+    def test_publishes_last_run_status(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("ca_tc_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 0, "failure")
+        calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
+        assert calls[f"{MQTT_ROOT}/statistic/last_run_status"] == "failure"
+
+    def test_no_mqtt_config_skips(self):
+        cfg = {}
+        mc = self._setup_mock_client()
+        with patch("ca_tc_main.mqtt.Client", return_value=mc):
+            publish_completion_stats(cfg, 0, "success")
+        mc.connect.assert_not_called()
+
+    def test_ha_autodiscovery_three_sensors(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("ca_tc_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 100, "success")
+        ha_topics = [
+            c.args[0] for c in mc.publish.call_args_list
+            if c.args[0].startswith("homeassistant/")
+        ]
+        assert len(ha_topics) == 3
+        assert "homeassistant/sensor/SkyFollower_runner_ca_transport_canada_records_imported/config" in ha_topics
+        assert "homeassistant/sensor/SkyFollower_runner_ca_transport_canada_last_run_at/config" in ha_topics
+        assert "homeassistant/sensor/SkyFollower_runner_ca_transport_canada_last_run_status/config" in ha_topics


### PR DESCRIPTION
## Summary

- Downloads the TC CCARCS ZIP from wwwapps.tc.gc.ca, parses `carscurr.txt` (aircraft) and `carsownr.txt` (owners) via local SQLite staging, writes active `icao_hex:{hex}` JSON records to Redis with 14-day TTL, then publishes MQTT completion stats with Home Assistant autodiscovery
- Implements the `ca-tc` source per `specs/data-dictionary.yaml`: 24-bit binary → 6-char hex ICAO conversion, `'C-'` prefix for all marks (col 46 TRIMMED_MARK preferred, col 0 fallback), `AIRCRAFT_CATEGORY_E` decode table (Aeroplane→Airplane etc.), `ENGINE_CATEGORY_E` decode table (Turbo Fan→Turbo-fan etc.), `COUNTRY_E` full English name → ISO 3166-1 alpha-2 decode, and `ID_PLATE_MANUFACTURERS_NAME` (col 7) as the manufacturer source
- Only records with empty `ineffective_date` are written to Redis; `aircraft.category` (Land/Sea/Amphibian) is null as TC does not provide this — consistent with the data dictionary (FAA-only field)

## Test plan

- [ ] 80 unit tests covering parse/decode helpers, SQLite staging, Redis record construction, active-record filtering, mocked Redis writes, and mocked MQTT stats — all pass
- [ ] Dockerfile builds for linux/arm64 and linux/amd64 (validated at release via CI)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)