### PR TITLE
Fix runner record shapes: remove source field, omit unowned nulls, restructure mictronics

### DIFF
--- a/data-runners/ca-transport-canada/main.py
+++ b/data-runners/ca-transport-canada/main.py
@@ -388,13 +388,9 @@ def build_aircraft_record(acft_row: sqlite3.Row, owner_rows: list[sqlite3.Row]) 
             "type": acft_row["aircraft_type"] or None,
             "model": acft_row["model"] or None,
             "seats": acft_row["seat_count"],
-            "category": None,
             "manufacturer": acft_row["manufacturer_name"] or None,
-            "type_designator": None,
-            "manufacturer_model": None,
             "serial_number": acft_row["serial_number"] or None,
             "manufactured_date": acft_row["manufactured_date"] or None,
-            "wake_turbulence_category": None,
         }
 
     # powerplant
@@ -403,10 +399,7 @@ def build_aircraft_record(acft_row: sqlite3.Row, owner_rows: list[sqlite3.Row]) 
         powerplant = {
             "count": acft_row["engine_count"],
             "type": acft_row["engine_category"] or None,
-            "model": None,
             "manufacturer": acft_row["engine_manufacturer"] or None,
-            "power_type": None,
-            "power_value": None,
         }
 
     return {
@@ -415,8 +408,6 @@ def build_aircraft_record(acft_row: sqlite3.Row, owner_rows: list[sqlite3.Row]) 
         "registrant": registrant,
         "aircraft": aircraft,
         "powerplant": powerplant,
-        "military": None,
-        "source": "ca-transport-canada",
     }
 
 

--- a/data-runners/ca-transport-canada/tests/test_ca_tc.py
+++ b/data-runners/ca-transport-canada/tests/test_ca_tc.py
@@ -565,8 +565,8 @@ class TestBuildAircraftRecord:
         record = build_aircraft_record(acft, owners)
         assert record["icao_hex"] == "C00001"
         assert record["registration"] == "C-GABC"
-        assert record["source"] == "ca-transport-canada"
-        assert record["military"] is None
+        assert "source" not in record
+        assert "military" not in record
         conn.close()
 
     def test_registrant_with_active_owner(self):
@@ -602,13 +602,13 @@ class TestBuildAircraftRecord:
         assert record["aircraft"]["type"] == "Airplane"
         conn.close()
 
-    def test_aircraft_category_is_null(self):
-        # aircraft.category (Land/Sea/Amphibian) is FAA-only — must be null for TC
+    def test_aircraft_category_absent(self):
+        """aircraft.category (Land/Sea/Amphibian) is FAA-only — must be omitted from TC record."""
         conn = self._make_conn()
         acft = self._fetch_acft_row("C00001", conn)
         owners = self._fetch_owner_rows("C-GABC", conn)
         record = build_aircraft_record(acft, owners)
-        assert record["aircraft"]["category"] is None
+        assert "category" not in record["aircraft"]
         conn.close()
 
     def test_aircraft_manufacturer_from_col7(self):
@@ -620,15 +620,16 @@ class TestBuildAircraftRecord:
         assert record["aircraft"]["manufacturer"] == "CESSNA AIRCRAFT CO"
         conn.close()
 
-    def test_aircraft_mictronics_fields_null(self):
+    def test_aircraft_mictronics_fields_absent(self):
+        """Fields owned by mictronics must be omitted entirely from the TC record."""
         conn = self._make_conn()
         acft = self._fetch_acft_row("C00001", conn)
         owners = self._fetch_owner_rows("C-GABC", conn)
         record = build_aircraft_record(acft, owners)
         ac = record["aircraft"]
-        assert ac["type_designator"] is None
-        assert ac["manufacturer_model"] is None
-        assert ac["wake_turbulence_category"] is None
+        assert "type_designator" not in ac
+        assert "manufacturer_model" not in ac
+        assert "wake_turbulence_category" not in ac
         conn.close()
 
     def test_powerplant_piston(self):
@@ -640,9 +641,9 @@ class TestBuildAircraftRecord:
         assert pp["count"] == 1
         assert pp["type"] == "Piston"
         assert pp["manufacturer"] == "LYCOMING"
-        assert pp["model"] is None
-        assert pp["power_type"] is None
-        assert pp["power_value"] is None
+        assert "model" not in pp
+        assert "power_type" not in pp
+        assert "power_value" not in pp
         conn.close()
 
     def test_powerplant_turbofan(self):
@@ -740,14 +741,14 @@ class TestWriteToRedis:
         assert not any(k.startswith("registration:") for k in all_keys)
         conn.close()
 
-    def test_record_source_is_ca_transport_canada(self):
+    def test_record_written_as_dict(self):
         conn = self._make_db()
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
         record = calls["icao_hex:C00001"]
         assert isinstance(record, dict)
-        assert record["source"] == "ca-transport-canada"
+        assert "source" not in record
         assert record["registration"] == "C-GABC"
         conn.close()
 

--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -220,32 +220,31 @@ def build_aircraft_record(row: sqlite3.Row, types_row: Optional[sqlite3.Row]) ->
     registration = row["registration"] or None
     type_designator = row["type_designator"] or None
     military = bool(row["military"])
-    interesting = bool(row["interesting"])
 
     manufacturer: Optional[str] = None
-    model: Optional[str] = None
+    manufacturer_model: Optional[str] = None
     wake_turbulence_category: Optional[str] = None
     if types_row and types_row["manufacturer_model"]:
-        manufacturer, model = _split_manufacturer_model(types_row["manufacturer_model"])
+        manufacturer, _ = _split_manufacturer_model(types_row["manufacturer_model"])
+        manufacturer_model = types_row["manufacturer_model"]
     if types_row:
         wake_turbulence_category = types_row["wake_turbulence_category"] or None
 
-    return {
-        "icao_hex": icao_hex,
-        "registration": registration,
+    aircraft_fields = {k: v for k, v in {
         "type_designator": type_designator,
         "manufacturer": manufacturer,
-        "model": model,
+        "manufacturer_model": manufacturer_model,
         "wake_turbulence_category": wake_turbulence_category,
+    }.items() if v is not None}
+
+    record: dict = {
+        "icao_hex": icao_hex,
+        "registration": registration,
         "military": military,
-        "interesting": interesting,
-        "is_private_operator": None,
-        "operator": None,
-        "airline_code": None,
-        "serial_number": None,
-        "year_built": None,
-        "source": "mictronics",
     }
+    if aircraft_fields:
+        record["aircraft"] = aircraft_fields
+    return record
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -319,10 +319,24 @@ class TestBuildAircraftRecord:
 
         assert record["icao_hex"] == "A8AE7F"
         assert record["registration"] == "N659DL"
-        assert record["type_designator"] == "B763"
-        assert record["manufacturer"] == "Boeing"
-        assert record["model"] == "767-332ER"
-        assert record["source"] == "mictronics"
+        assert record["military"] is False
+        assert "source" not in record
+        ac = record["aircraft"]
+        assert ac["type_designator"] == "B763"
+        assert ac["manufacturer"] == "Boeing"
+        assert ac["manufacturer_model"] == "Boeing 767-332ER"
+
+    def test_no_source_field(self):
+        row = self._row("A8AE7F", "N659DL", "B763", False)
+        record = build_aircraft_record(row, None)
+        assert "source" not in record
+
+    def test_no_unowned_fields(self):
+        """Non-data-dictionary fields must be absent from the record."""
+        row = self._row("A8AE7F", "N659DL", "B763", False, manufacturer_model="Boeing 767-332ER")
+        record = build_aircraft_record(row, row)
+        for field in ("interesting", "is_private_operator", "operator", "airline_code", "serial_number", "year_built"):
+            assert field not in record, f"Unexpected field: {field!r}"
 
     def test_military_true(self):
         row = self._row("AA0002", "MILCRAFT", "F16", True)
@@ -334,25 +348,19 @@ class TestBuildAircraftRecord:
         record = build_aircraft_record(row, None)
         assert record["military"] is False
 
-    def test_interesting_true(self):
-        row = self._row("AA0004", "N99999", "B763", False, interesting=True)
-        record = build_aircraft_record(row, None)
-        assert record["interesting"] is True
-
-    def test_null_fields_present(self):
-        """Fields unavailable from Mictronics must be null, not omitted."""
-        row = self._row("A8AE7F", "N659DL", "B763", False, manufacturer_model="Boeing 767-332ER")
-        record = build_aircraft_record(row, row)
-
-        for field in ("is_private_operator", "operator", "airline_code", "serial_number", "year_built"):
-            assert field in record, f"Missing field: {field!r}"
-            assert record[field] is None, f"Field {field!r} should be None"
-
-    def test_no_types_row(self):
+    def test_no_types_row_type_designator_in_aircraft(self):
+        """When types_row is None, aircraft still contains type_designator if set."""
         row = self._row("A8AE7F", "N659DL", "B763", 0)
         record = build_aircraft_record(row, None)
-        assert record["manufacturer"] is None
-        assert record["model"] is None
+        assert record["aircraft"]["type_designator"] == "B763"
+        assert "manufacturer" not in record["aircraft"]
+        assert "manufacturer_model" not in record["aircraft"]
+
+    def test_no_types_row_no_type_designator_omits_aircraft(self):
+        """When both types_row is None and type_designator is None, aircraft key is omitted."""
+        row = self._row("AA0003", "", None, 0)
+        record = build_aircraft_record(row, None)
+        assert "aircraft" not in record
 
     def test_empty_registration_becomes_none(self):
         row = self._row("AA0003", "", None, 0)

--- a/data-runners/us-faa/main.py
+++ b/data-runners/us-faa/main.py
@@ -383,11 +383,8 @@ def build_aircraft_record(
             "seats": acft_row["seats"] or None,
             "category": acft_row["category"] or None,
             "manufacturer": acft_row["manufacturer"] or None,
-            "type_designator": None,          # populated by mictronics
-            "manufacturer_model": None,        # populated by mictronics
             "serial_number": reg_row["serial_number"] or None,
             "manufactured_date": mfr_date,
-            "wake_turbulence_category": None,  # populated by mictronics
         }
 
     # powerplant
@@ -422,8 +419,6 @@ def build_aircraft_record(
         "registrant": registrant,
         "aircraft": aircraft,
         "powerplant": powerplant,
-        "military": None,
-        "source": "us-faa",
     }
 
 

--- a/data-runners/us-faa/tests/test_us_faa.py
+++ b/data-runners/us-faa/tests/test_us_faa.py
@@ -448,8 +448,8 @@ class TestBuildAircraftRecord:
         record = build_aircraft_record(row, acft_row, eng_row)
         assert record["icao_hex"] == "A8AE7F"
         assert record["registration"] == "N659DL"
-        assert record["source"] == "us-faa"
-        assert record["military"] is None
+        assert "source" not in record
+        assert "military" not in record
 
     def test_registrant_names(self):
         row, acft_row, eng_row = self._fetch_rows("A8AE7F")
@@ -488,13 +488,14 @@ class TestBuildAircraftRecord:
         assert ac["serial_number"] == "28014"
         assert ac["manufactured_date"] == "1999-01-01T00:00:00Z"
 
-    def test_aircraft_mictronics_fields_null(self):
+    def test_aircraft_mictronics_fields_absent(self):
+        """Fields owned by mictronics must be omitted entirely from the FAA record."""
         row, acft_row, eng_row = self._fetch_rows("A8AE7F")
         record = build_aircraft_record(row, acft_row, eng_row)
         ac = record["aircraft"]
-        assert ac["type_designator"] is None
-        assert ac["manufacturer_model"] is None
-        assert ac["wake_turbulence_category"] is None
+        assert "type_designator" not in ac
+        assert "manufacturer_model" not in ac
+        assert "wake_turbulence_category" not in ac
 
     def test_powerplant_turbofan(self):
         row, acft_row, eng_row = self._fetch_rows("A8AE7F")
@@ -610,7 +611,7 @@ class TestWriteToRedis:
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
         record = calls["icao_hex:A8AE7F"]
         assert isinstance(record, dict)
-        assert record["source"] == "us-faa"
+        assert "source" not in record
         assert record["registration"] == "N659DL"
         conn.close()
 


### PR DESCRIPTION
## Summary

- **#48** — Remove `source` field from all runner Redis records (mictronics, us-faa, ca-transport-canada)
- **#49** — Omit null fields not owned by each runner: `military` from ca-transport-canada and us-faa; `aircraft.category`, `aircraft.type_designator`, `aircraft.manufacturer_model`, `aircraft.wake_turbulence_category` from ca-transport-canada and us-faa; `powerplant.model`, `powerplant.power_type`, `powerplant.power_value` from ca-transport-canada
- **#50** — Fix mictronics record structure: move `type_designator`, `manufacturer`, `manufacturer_model` (full string, not split-right), and `wake_turbulence_category` into a nested `aircraft` object; remove `interesting`, `is_private_operator`, `operator`, `airline_code`, `serial_number`, `year_built`

This branch also includes the ca-transport-canada runner from #47 (closing that PR as superseded).

Closes #48, #49, #50

## Test plan

- [ ] `python3 -m pytest data-runners/mictronics/tests/` — 44 tests pass
- [ ] `python3 -m pytest data-runners/us-faa/tests/` — 59 tests pass
- [ ] `python3 -m pytest data-runners/ca-transport-canada/tests/` — 80 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)