### PR TITLE
OurAirports: store as JSON, add iata_code + lat/lon, add search index

### DIFF
--- a/data-runners/ourairports/main.py
+++ b/data-runners/ourairports/main.py
@@ -27,7 +27,10 @@ import requests
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from shared.redis_keys import airport_key
+from redis.commands.search.field import TagField
+from redis.commands.search.index_definition import IndexDefinition, IndexType
+
+from shared.redis_keys import AIRPORT_SEARCH_INDEX, airport_key
 
 logger = logging.getLogger("ourairports")
 
@@ -40,12 +43,15 @@ MQTT_ROOT = "SkyFollower/runner/ourairports"
 # ---------------------------------------------------------------------------
 _SCHEMA = """
 CREATE TABLE airports (
-    icao_code TEXT PRIMARY KEY,
-    name      TEXT,
-    city      TEXT,
-    region    TEXT,
-    country   TEXT,
-    phonic    TEXT
+    icao_code  TEXT PRIMARY KEY,
+    iata_code  TEXT,
+    name       TEXT,
+    city       TEXT,
+    region     TEXT,
+    country    TEXT,
+    latitude   REAL,
+    longitude  REAL,
+    phonic     TEXT
 );
 """
 
@@ -184,17 +190,27 @@ def stage_data(csv_text: str, db_path: str) -> sqlite3.Connection:
             continue
 
         icao = ident.upper()
+        iata_code = row.get("iata_code", "").strip() or None
         name = row.get("name", "").strip() or None
         city = row.get("municipality", "").strip() or None
         region = row.get("iso_region", "").strip() or None
         country = row.get("iso_country", "").strip() or None
         phonic = compute_phonic(icao, name or "", city or "") or None
 
+        try:
+            latitude = float(row.get("latitude_deg", "")) or None
+        except (ValueError, TypeError):
+            latitude = None
+        try:
+            longitude = float(row.get("longitude_deg", "")) or None
+        except (ValueError, TypeError):
+            longitude = None
+
         cur.execute(
             "INSERT OR REPLACE INTO airports "
-            "(icao_code, name, city, region, country, phonic) "
-            "VALUES (?,?,?,?,?,?)",
-            (icao, name, city, region, country, phonic),
+            "(icao_code, iata_code, name, city, region, country, latitude, longitude, phonic) "
+            "VALUES (?,?,?,?,?,?,?,?,?)",
+            (icao, iata_code, name, city, region, country, latitude, longitude, phonic),
         )
         count += 1
 
@@ -211,25 +227,45 @@ def stage_data(csv_text: str, db_path: str) -> sqlite3.Connection:
 
 def build_airport_record(row: sqlite3.Row) -> dict:
     """Build the airport:{icao_code} JSON record from a staged row."""
-    return {
-        "icao_code": row["icao_code"],
-        "name": row["name"],
-        "city": row["city"],
-        "region": row["region"],
-        "country": row["country"],
-        "phonic": row["phonic"],
-    }
+    record: dict = {"icao_code": row["icao_code"]}
+    if row["iata_code"]:
+        record["iata_code"] = row["iata_code"]
+    record["name"] = row["name"]
+    record["city"] = row["city"]
+    record["region"] = row["region"]
+    record["country"] = row["country"]
+    if row["latitude"] is not None:
+        record["latitude"] = row["latitude"]
+    if row["longitude"] is not None:
+        record["longitude"] = row["longitude"]
+    record["phonic"] = row["phonic"]
+    return record
 
 
 # ---------------------------------------------------------------------------
 # Write to Redis
 # ---------------------------------------------------------------------------
 
+def _ensure_search_index(r: redis_lib.Redis) -> None:
+    """Create the airport JSON search index if it does not already exist."""
+    try:
+        r.ft(AIRPORT_SEARCH_INDEX).info()
+    except Exception:
+        r.ft(AIRPORT_SEARCH_INDEX).create_index(
+            fields=[
+                TagField("$.icao_code", as_name="icao_code"),
+                TagField("$.iata_code", as_name="iata_code"),
+            ],
+            definition=IndexDefinition(prefix=["airport:"], index_type=IndexType.JSON),
+        )
+        logger.info("Created search index %r.", AIRPORT_SEARCH_INDEX)
+
+
 def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> int:
     """Write all staged airport records to Redis. Returns count of records written."""
     cur = conn.cursor()
     cur.execute(
-        "SELECT icao_code, name, city, region, country, phonic FROM airports"
+        "SELECT icao_code, iata_code, name, city, region, country, latitude, longitude, phonic FROM airports"
     )
     rows = cur.fetchall()
     logger.info("Writing %d airport records to Redis.", len(rows))
@@ -239,7 +275,8 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     for row in rows:
         record = build_airport_record(row)
         key = airport_key(record["icao_code"])
-        pipe.set(key, json.dumps(record), ex=ttl)
+        pipe.json().set(key, "$", record)
+        pipe.expire(key, ttl)
         count += 1
         if count % 10000 == 0:
             pipe.execute()
@@ -398,6 +435,7 @@ def main() -> None:
         conn = stage_data(csv_text, db_path)
 
         # 3. Write to Redis
+        _ensure_search_index(r)
         records_imported = write_to_redis(conn, r, ttl)
         conn.close()
 

--- a/shared/redis_keys.py
+++ b/shared/redis_keys.py
@@ -13,6 +13,10 @@ _VALID_ARCHIVE_PERIODS = frozenset({"hour", "today"})
 # Supports registration lookup without a separate reverse-index key.
 AIRCRAFT_SEARCH_INDEX = "idx:aircraft"
 
+# RediSearch index over all airport:{icao_code} JSON documents.
+# Supports lookup by ICAO code or IATA code.
+AIRPORT_SEARCH_INDEX = "idx:airport"
+
 
 def icao_hex_key(icao_hex: str) -> str:
     """Aircraft enrichment record. icao_hex:{icao_hex}"""

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -276,6 +276,25 @@ sources:
           "AIRCRAFT TYPE - MAKE/MODEL":   combined make and model free-text (stored as aircraft.model)
           "SERIAL #":                     manufacturer serial number
 
+  ourairports:
+    description: "OurAirports global airport database — airport:{icao_code} Redis keys"
+    url: "https://davidmegginson.github.io/ourairports-data/airports.csv"
+    format: csv
+    cadence: weekly_monday
+    notes: "Filtered to 4-character ICAO codes only (3-char and other-length idents dropped); stored as Redis JSON via JSON.SET in airport:{icao_code} keys; RediSearch index idx:airport on icao_code and iata_code TagFields; phonic name computed algorithmically from name + municipality fields with optional host-provided phonic_overrides.json override file; iata_code omitted if blank; latitude/longitude stored as floats"
+    files:
+      - name: airports.csv
+        format: csv
+        columns:
+          ident:          4-character ICAO airport code (primary key; non-4-char rows dropped)
+          iata_code:      IATA 3-character airport code (omitted from record if blank)
+          name:           official airport name
+          municipality:   city/municipality name (stored as city)
+          iso_region:     ISO 3166-2 subdivision code (e.g. US-FL; stored as region)
+          iso_country:    ISO 3166-1 alpha-2 country code
+          latitude_deg:   decimal latitude (stored as latitude float)
+          longitude_deg:  decimal longitude (stored as longitude float)
+
   standing-data:
     description: "VRS Standing Data — operators, airports, and flight routes"
     url: "https://github.com/vradarserver/standing-data"
@@ -1264,36 +1283,42 @@ records:
             type: string
             description: "IATA 3-character airport code"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: iata_code
           name:
             type: string
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: name
           city:
             type: string
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: municipality
           administrative_area:
             type: string
             description: "ISO 3166-2 subdivision code (e.g. US-FL)"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: iso_region
           country:
             type: string
             description: "ISO 3166-1 alpha-2 country code"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: iso_country
           phonic:
             type: string
             description: "Spoken/phonetic airport name for TTS notifications"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                description: "Computed algorithmically from name + municipality; overridable via phonic_overrides.json"
 
       destination:
         type: object
@@ -1315,36 +1340,42 @@ records:
             type: string
             description: "IATA 3-character airport code"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: iata_code
           name:
             type: string
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: name
           city:
             type: string
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: municipality
           administrative_area:
             type: string
             description: "ISO 3166-2 subdivision code (e.g. US-GA)"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: iso_region
           country:
             type: string
             description: "ISO 3166-1 alpha-2 country code"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                field: iso_country
           phonic:
             type: string
             description: "Spoken/phonetic airport name for TTS notifications"
             sources:
-              - source: standing-data
-                file: airports
+              - source: ourairports
+                file: airports.csv
+                description: "Computed algorithmically from name + municipality; overridable via phonic_overrides.json"
 
       matched_rules:
         type: "array[string]"


### PR DESCRIPTION
Closes #61

## Summary
- Switch `airport:{icao_code}` storage from `SET key json_string` to `JSON.SET` so airport records are queryable via RediSearch, consistent with aircraft records
- Add `iata_code` field (from CSV `iata_code`; omitted if blank)
- Add `latitude` and `longitude` fields (from CSV `latitude_deg` / `longitude_deg`; stored as floats)
- Add `_ensure_search_index()` that creates `idx:airport` over all `airport:*` JSON keys with `icao_code` and `iata_code` as TagFields
- Add `AIRPORT_SEARCH_INDEX = "idx:airport"` to `shared/redis_keys.py`
- Update SQLite staging schema to include new columns
- Update `specs/data-dictionary.yaml`: add `ourairports` source entry; correct all `origin`/`destination` airport field sources from `standing-data file: airports` to `ourairports file: airports.csv`

## Test plan
- [ ] Build and run: `docker compose -f docker-compose.server.yaml build runner-ourairports && docker compose -f docker-compose.server.yaml run --rm runner-ourairports`
- [ ] Verify `airport:KJFK` is stored as JSON with `icao_code`, `iata_code`, `latitude`, `longitude`, `name`, `city`, `region`, `country`, `phonic`
- [ ] Verify `FT.SEARCH idx:airport @iata_code:{JFK}` returns the KJFK record
- [ ] Verify `FT.SEARCH idx:airport @icao_code:{KJFK}` returns the KJFK record
- [ ] Verify airports with no IATA code omit the `iata_code` field rather than storing null

🤖 Generated with [Claude Code](https://claude.com/claude-code)