### PR TITLE
Mictronics: write operator:{code} keys to Redis

### DIFF
--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key, operator_key
 
 logger = logging.getLogger("mictronics")
 
@@ -262,6 +262,18 @@ def build_aircraft_record(row: sqlite3.Row, types_row: Optional[sqlite3.Row]) ->
     return record
 
 
+def build_operator_record(row: sqlite3.Row) -> dict:
+    """Build the operator:{designator} JSON record from a staged row."""
+    record: dict = {"airline_designator": row["airline_designator"]}
+    if row["name"]:
+        record["name"] = row["name"]
+    if row["country"]:
+        record["country"] = row["country"]
+    if row["callsign"]:
+        record["callsign"] = row["callsign"]
+    return record
+
+
 # ---------------------------------------------------------------------------
 # Search index
 # ---------------------------------------------------------------------------
@@ -329,6 +341,34 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     return count
 
 
+def write_operators_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> int:
+    """Write all staged operator records to Redis. Returns count of records written."""
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT airline_designator, name, country, callsign FROM operators "
+        "WHERE airline_designator IS NOT NULL AND airline_designator != ''"
+    )
+    rows = cur.fetchall()
+    logger.info("Writing %d operator records to Redis.", len(rows))
+
+    count = 0
+    pipe = r.pipeline()
+    for row in rows:
+        record = build_operator_record(row)
+        key = operator_key(record["airline_designator"])
+        pipe.json().set(key, "$", record)
+        pipe.expire(key, ttl)
+        count += 1
+        if count % 10000 == 0:
+            pipe.execute()
+            pipe = r.pipeline()
+            logger.info("  ... %d operator records written.", count)
+
+    pipe.execute()
+    logger.info("Finished writing %d operator records to Redis.", count)
+    return count
+
+
 # ---------------------------------------------------------------------------
 # MQTT
 # ---------------------------------------------------------------------------
@@ -336,6 +376,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
 def publish_completion_stats(
     cfg: dict,
     records_imported: int,
+    operators_imported: int,
     status: str,
 ) -> None:
     """Publish completion statistics to MQTT and HA autodiscovery."""
@@ -372,6 +413,7 @@ def publish_completion_stats(
 
         base = MQTT_ROOT + "/statistic"
         client.publish(f"{base}/records_imported", str(records_imported), retain=True)
+        client.publish(f"{base}/operators_imported", str(operators_imported), retain=True)
         client.publish(f"{base}/last_run_at", run_at, retain=True)
         client.publish(f"{base}/last_run_status", status, retain=True)
 
@@ -381,7 +423,10 @@ def publish_completion_stats(
         time.sleep(0.5)
         client.loop_stop()
         client.disconnect()
-        logger.info("MQTT stats published (status=%s, records=%d).", status, records_imported)
+        logger.info(
+            "MQTT stats published (status=%s, records=%d, operators=%d).",
+            status, records_imported, operators_imported,
+        )
 
     except Exception as exc:
         logger.warning("MQTT publish failed: %s", exc)
@@ -399,6 +444,7 @@ def _publish_ha_autodiscovery(client: mqtt.Client) -> None:
     }
     stats = [
         ("records_imported", "Mictronics Records Imported", "mdi:airplane", "total_increasing", None),
+        ("operators_imported", "Mictronics Operators Imported", "mdi:account-group", "total_increasing", None),
         ("last_run_at", "Mictronics Last Run At", "mdi:clock", None, None),
         ("last_run_status", "Mictronics Last Run Status", "mdi:check-circle", None, None),
     ]
@@ -463,6 +509,7 @@ def main() -> None:
 
     status = "failure"
     records_imported = 0
+    operators_imported = 0
 
     try:
         # 1. Download and extract
@@ -474,10 +521,14 @@ def main() -> None:
         # 3. Ensure search index exists, then write to Redis
         _ensure_search_index(r)
         records_imported = write_to_redis(conn, r, ttl)
+        operators_imported = write_operators_to_redis(conn, r, ttl)
         conn.close()
 
         status = "success"
-        logger.info("Mictronics runner completed successfully. Records imported: %d", records_imported)
+        logger.info(
+            "Mictronics runner completed successfully. Records imported: %d, Operators imported: %d",
+            records_imported, operators_imported,
+        )
 
     except Exception as exc:
         logger.error("Mictronics runner failed: %s", exc, exc_info=True)
@@ -486,7 +537,7 @@ def main() -> None:
     finally:
         # 4. Publish MQTT stats regardless of success/failure
         try:
-            publish_completion_stats(cfg, records_imported, status)
+            publish_completion_stats(cfg, records_imported, operators_imported, status)
         except Exception as exc:
             logger.warning("Failed to publish MQTT stats: %s", exc)
 

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -53,8 +53,10 @@ _mod = _load_main()
 _decode_wtc = _mod._decode_wtc
 _split_manufacturer_model = _mod._split_manufacturer_model
 build_aircraft_record = _mod.build_aircraft_record
+build_operator_record = _mod.build_operator_record
 stage_data = _mod.stage_data
 write_to_redis = _mod.write_to_redis
+write_operators_to_redis = _mod.write_operators_to_redis
 publish_completion_stats = _mod.publish_completion_stats
 REDIS_TTL = _mod.REDIS_TTL
 MQTT_ROOT = _mod.MQTT_ROOT
@@ -370,6 +372,121 @@ class TestBuildAircraftRecord:
 
 
 # ---------------------------------------------------------------------------
+# Tests: build_operator_record
+# ---------------------------------------------------------------------------
+
+class TestBuildOperatorRecord:
+    def _row(self, designator, name=None, country=None, callsign=None):
+        return {
+            "airline_designator": designator,
+            "name": name,
+            "country": country,
+            "callsign": callsign,
+        }
+
+    def test_full_record(self):
+        row = self._row("DAL", "Delta Air Lines", "United States", "DELTA")
+        record = build_operator_record(row)
+        assert record == {
+            "airline_designator": "DAL",
+            "name": "Delta Air Lines",
+            "country": "United States",
+            "callsign": "DELTA",
+        }
+
+    def test_null_fields_omitted(self):
+        row = self._row("XYZ", name=None, country=None, callsign=None)
+        record = build_operator_record(row)
+        assert record == {"airline_designator": "XYZ"}
+        assert "name" not in record
+        assert "country" not in record
+        assert "callsign" not in record
+
+    def test_partial_fields(self):
+        row = self._row("AAL", "American Airlines", country=None, callsign="AMERICAN")
+        record = build_operator_record(row)
+        assert record["name"] == "American Airlines"
+        assert record["callsign"] == "AMERICAN"
+        assert "country" not in record
+
+
+# ---------------------------------------------------------------------------
+# Tests: write_operators_to_redis
+# ---------------------------------------------------------------------------
+
+class TestWriteOperatorsToRedis:
+    def _make_db(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(_mod._SCHEMA)
+        conn.execute(
+            "INSERT INTO operators (airline_designator, name, country, callsign) "
+            "VALUES ('DAL', 'Delta Air Lines', 'United States', 'DELTA')"
+        )
+        conn.execute(
+            "INSERT INTO operators (airline_designator, name, country, callsign) "
+            "VALUES ('AAL', 'American Airlines', 'United States', 'AMERICAN')"
+        )
+        conn.commit()
+        return conn
+
+    def _mock_redis(self):
+        r = MagicMock()
+        pipe = MagicMock()
+        pipe_json = MagicMock()
+        r.pipeline.return_value = pipe
+        pipe.json.return_value = pipe_json
+        pipe.execute.return_value = []
+        return r, pipe, pipe_json
+
+    def test_count_matches_operators(self):
+        conn = self._make_db()
+        r, _, _ = self._mock_redis()
+        assert write_operators_to_redis(conn, r, REDIS_TTL) == 2
+        conn.close()
+
+    def test_operator_key_written(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_operators_to_redis(conn, r, REDIS_TTL)
+        keys = [c.args[0] for c in pipe_json.set.call_args_list]
+        assert "operator:DAL" in keys
+        assert "operator:AAL" in keys
+        conn.close()
+
+    def test_json_set_uses_root_path(self):
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_operators_to_redis(conn, r, REDIS_TTL)
+        for c in pipe_json.set.call_args_list:
+            assert c.args[1] == "$"
+        conn.close()
+
+    def test_expire_called_with_correct_ttl(self):
+        conn = self._make_db()
+        r, pipe, _ = self._mock_redis()
+        write_operators_to_redis(conn, r, REDIS_TTL)
+        expire_ttls = [c.args[1] for c in pipe.expire.call_args_list]
+        assert all(ttl == REDIS_TTL for ttl in expire_ttls)
+        conn.close()
+
+    def test_empty_designator_skipped(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(_mod._SCHEMA)
+        conn.execute(
+            "INSERT INTO operators (airline_designator, name, country, callsign) "
+            "VALUES ('', 'No Designator', 'US', 'NONE')"
+        )
+        conn.commit()
+        r, _, pipe_json = self._mock_redis()
+        count = write_operators_to_redis(conn, r, REDIS_TTL)
+        assert count == 0
+        pipe_json.set.assert_not_called()
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # Tests: Redis key construction
 # ---------------------------------------------------------------------------
 
@@ -512,7 +629,7 @@ class TestMqttCompletionStats:
         mc = self._setup_mock_client()
         with patch("mictronics_main.mqtt.Client", return_value=mc):
             with patch("time.sleep"):
-                publish_completion_stats(cfg, 42, "success")
+                publish_completion_stats(cfg, 42, 10, "success")
         topics = [c.args[0] for c in mc.publish.call_args_list]
         assert f"{MQTT_ROOT}/statistic/records_imported" in topics
 
@@ -521,16 +638,25 @@ class TestMqttCompletionStats:
         mc = self._setup_mock_client()
         with patch("mictronics_main.mqtt.Client", return_value=mc):
             with patch("time.sleep"):
-                publish_completion_stats(cfg, 99, "success")
+                publish_completion_stats(cfg, 99, 5, "success")
         calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
         assert calls[f"{MQTT_ROOT}/statistic/records_imported"] == "99"
+
+    def test_publishes_operators_imported(self):
+        cfg = {"mqtt": {"host": "localhost", "port": 1883}}
+        mc = self._setup_mock_client()
+        with patch("mictronics_main.mqtt.Client", return_value=mc):
+            with patch("time.sleep"):
+                publish_completion_stats(cfg, 0, 77, "success")
+        calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
+        assert calls[f"{MQTT_ROOT}/statistic/operators_imported"] == "77"
 
     def test_publishes_last_run_at(self):
         cfg = {"mqtt": {"host": "localhost", "port": 1883}}
         mc = self._setup_mock_client()
         with patch("mictronics_main.mqtt.Client", return_value=mc):
             with patch("time.sleep"):
-                publish_completion_stats(cfg, 0, "success")
+                publish_completion_stats(cfg, 0, 0, "success")
         topics = [c.args[0] for c in mc.publish.call_args_list]
         assert f"{MQTT_ROOT}/statistic/last_run_at" in topics
 
@@ -539,7 +665,7 @@ class TestMqttCompletionStats:
         mc = self._setup_mock_client()
         with patch("mictronics_main.mqtt.Client", return_value=mc):
             with patch("time.sleep"):
-                publish_completion_stats(cfg, 0, "failure")
+                publish_completion_stats(cfg, 0, 0, "failure")
         calls = {c.args[0]: c.args[1] for c in mc.publish.call_args_list}
         assert calls[f"{MQTT_ROOT}/statistic/last_run_status"] == "failure"
 
@@ -547,20 +673,21 @@ class TestMqttCompletionStats:
         cfg = {}
         mc = self._setup_mock_client()
         with patch("mictronics_main.mqtt.Client", return_value=mc):
-            publish_completion_stats(cfg, 0, "success")
+            publish_completion_stats(cfg, 0, 0, "success")
         mc.connect.assert_not_called()
 
-    def test_ha_autodiscovery_three_sensors(self):
+    def test_ha_autodiscovery_four_sensors(self):
         cfg = {"mqtt": {"host": "localhost", "port": 1883}}
         mc = self._setup_mock_client()
         with patch("mictronics_main.mqtt.Client", return_value=mc):
             with patch("time.sleep"):
-                publish_completion_stats(cfg, 100, "success")
+                publish_completion_stats(cfg, 100, 10, "success")
         ha_topics = [
             c.args[0] for c in mc.publish.call_args_list
             if c.args[0].startswith("homeassistant/")
         ]
-        assert len(ha_topics) == 3
+        assert len(ha_topics) == 4
         assert "homeassistant/sensor/SkyFollower_runner_mictronics_records_imported/config" in ha_topics
+        assert "homeassistant/sensor/SkyFollower_runner_mictronics_operators_imported/config" in ha_topics
         assert "homeassistant/sensor/SkyFollower_runner_mictronics_last_run_at/config" in ha_topics
         assert "homeassistant/sensor/SkyFollower_runner_mictronics_last_run_status/config" in ha_topics

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -29,7 +29,7 @@ merge_strategy_default: first_wins
 sources:
 
   mictronics:
-    description: "Mictronics global aircraft database — type designators and military/interesting flags"
+    description: "Mictronics global aircraft database — type designators, military/interesting flags, and operators"
     url: "https://www.mictronics.de/aircraft-database/indexedDB.php"
     format: zip+json
     cadence: weekly_tuesday
@@ -1232,28 +1232,36 @@ records:
 
       operator:
         type: object
-        description: "Airline operator enrichment from standing data; keyed by airline_designator"
+        description: "Airline operator enrichment from Mictronics; keyed by airline_designator"
         persisted: true
         properties:
           airline_designator:
             type: string
             description: "3-character ICAO airline code (e.g. DAL)"
             sources:
-              - source: standing-data
+              - source: mictronics
+                file: operators.json
+                field: "key (airline_designator)"
           name:
             type: string
             description: "Full airline name (e.g. Delta Air Lines)"
             sources:
-              - source: standing-data
+              - source: mictronics
+                file: operators.json
+                field: "values[0]"
+          country:
+            type: string
+            sources:
+              - source: mictronics
+                file: operators.json
+                field: "values[1]"
           callsign:
             type: string
             description: "RTF callsign (e.g. DELTA)"
             sources:
-              - source: standing-data
-          country:
-            type: string
-            sources:
-              - source: standing-data
+              - source: mictronics
+                file: operators.json
+                field: "values[2]"
 
       squawk:
         type: string


### PR DESCRIPTION
## Summary

- Adds `build_operator_record()` and `write_operators_to_redis()` to populate `operator:{designator}` keys in Redis with 14-day TTL after each run
- Null/empty fields are omitted from the JSON record
- Records with an empty `airline_designator` are skipped
- Adds `operators_imported` statistic to MQTT completion stats and Home Assistant autodiscovery (4 sensors total, up from 3)
- Updates `specs/data-dictionary.yaml` to reflect Mictronics as the source for `operator:{code}` keys, with field-level source mapping from `operators.json`
- 54 tests, all passing

## Test plan

- [ ] Build local image from repo root: `docker build -t skyfollower-runner-mictronics:local -f data-runners/mictronics/Dockerfile .`
- [ ] Run against local Redis: `docker run --rm -v /path/to/settings.local.json:/app/settings.json:ro skyfollower-runner-mictronics:local`
- [ ] Verify operator key written: `redis-cli json.get operator:DAL`

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)