### PR TITLE
traffic-recorder: 978 UAT support, connection UX, and format fixes

### DIFF
--- a/tools/traffic-recorder/main.py
+++ b/tools/traffic-recorder/main.py
@@ -57,41 +57,63 @@ def parse_1090_stream(data: bytes, buf: bytearray) -> list[str]:
 # 978 line parser  (-hex;rs=N;rssi=N;t=N.NNN;  — dump978-fa format)
 # ---------------------------------------------------------------------------
 
-def parse_978_line(line: str) -> tuple[str, str, float] | None:
+def parse_978_line(line: str) -> tuple[str, str, float, float | None, int | None] | None:
     """
     Parse a dump978-fa output line.
 
-    Returns (raw_hex, icao_hex, received_at) or None if the line should be
-    skipped (!-preambles, blank lines, unrecognised format).
+    Returns (raw_hex, icao_hex, received_at, rssi, rs) or None if the line
+    should be skipped (!-preambles, blank lines, unrecognised format).
 
-    ICAO address is at bytes 1-3 of the UAT payload (hex chars [2:8]).
+    raw_hex preserves the leading - (downlink) or + (uplink) symbol so
+    downstream processors can distinguish frame direction.
+
+    ICAO address is at bytes 1-3 of the UAT payload. In raw_hex that is
+    chars [3:9] — one char for the symbol, two chars for byte 0, then the
+    three ICAO bytes.
+
+    rssi: received signal strength (dBFS float).
+    rs:   Reed-Solomon errors corrected (int; absent on clean frames).
     Timestamp is taken from the t= field in the metadata.
     """
     line = line.strip()
     if not line or line.startswith("!"):
         return None
-    if not line.startswith("-"):
+    if line[0] not in ("-", "+"):
         return None
 
+    symbol = line[0]
     parts = line[1:].split(";")
-    raw_hex = parts[0].upper()
-    if len(raw_hex) < 8:
+    hex_payload = parts[0].upper()
+    if len(hex_payload) < 8:
         return None
-    if not all(c in "0123456789ABCDEF" for c in raw_hex):
+    if not all(c in "0123456789ABCDEF" for c in hex_payload):
         return None
 
-    icao_hex = raw_hex[2:8]
+    raw_hex = symbol + hex_payload
+    icao_hex = hex_payload[2:8]
 
     received_at: float = time.time()
+    rssi: float | None = None
+    rs: int | None = None
+
     for field in parts[1:]:
         if field.startswith("t="):
             try:
                 received_at = float(field[2:])
             except ValueError:
                 pass
-            break
+        elif field.startswith("rssi="):
+            try:
+                rssi = float(field[5:])
+            except ValueError:
+                pass
+        elif field.startswith("rs="):
+            try:
+                rs = int(field[3:])
+            except ValueError:
+                pass
 
-    return raw_hex, icao_hex, received_at
+    return raw_hex, icao_hex, received_at, rssi, rs
 
 
 # ---------------------------------------------------------------------------
@@ -176,16 +198,27 @@ class SourceCapture(threading.Thread):
                 raw_line, line_buf = line_buf.split(b"\n", 1)
                 result = parse_978_line(raw_line.decode("ascii", errors="ignore"))
                 if result:
-                    raw_hex, icao_hex, received_at = result
-                    self._write(raw_hex, icao_hex, received_at)
+                    raw_hex, icao_hex, received_at, rssi, rs = result
+                    self._write(raw_hex, icao_hex, received_at, rssi=rssi, rs=rs)
 
-    def _write(self, raw_hex: str, icao_hex: str, received_at: float) -> None:
+    def _write(
+        self,
+        raw_hex: str,
+        icao_hex: str,
+        received_at: float,
+        rssi: float | None = None,
+        rs: int | None = None,
+    ) -> None:
         record = {
             "raw": raw_hex,
             "icao_hex": icao_hex,
             "received_at": received_at,
             "source": self.source_tag,
         }
+        if rssi is not None:
+            record["rssi"] = rssi
+        if rs is not None:
+            record["rs"] = rs
         line = json.dumps(record, separators=(",", ":"))
         with self._output_lock:
             self._output_file.write(line + "\n")

--- a/tools/traffic-recorder/main.py
+++ b/tools/traffic-recorder/main.py
@@ -2,8 +2,9 @@
 """
 SkyFollower Traffic Recorder
 
-Connects to one or more readsb TCP sources, captures raw ADS-B messages, and
-writes them to an NDJSON file for later replay by the traffic-replayer tool.
+Connects to one or more readsb/dump978-fa TCP sources, captures raw ADS-B and
+UAT messages, and writes them to an NDJSON file for later replay by the
+traffic-replayer tool.
 
 Usage:
     python main.py --output capture.ndjson --duration 7200 \
@@ -24,7 +25,7 @@ import time
 import pyModeS as pms
 
 # ---------------------------------------------------------------------------
-# TCP stream parser (same protocol as receiver)
+# 1090 TCP stream parser  (*hex;\n  — readsb raw format)
 # ---------------------------------------------------------------------------
 
 _STAR = 0x2A
@@ -36,7 +37,7 @@ _HEX_BYTES = frozenset(
 )
 
 
-def parse_tcp_stream(data: bytes, buf: bytearray) -> list[str]:
+def parse_1090_stream(data: bytes, buf: bytearray) -> list[str]:
     messages: list[str] = []
     for byte in data:
         if byte == _STAR:
@@ -50,6 +51,47 @@ def parse_tcp_stream(data: bytes, buf: bytearray) -> list[str]:
         else:
             buf.clear()
     return messages
+
+
+# ---------------------------------------------------------------------------
+# 978 line parser  (-hex;rs=N;rssi=N;t=N.NNN;  — dump978-fa format)
+# ---------------------------------------------------------------------------
+
+def parse_978_line(line: str) -> tuple[str, str, float] | None:
+    """
+    Parse a dump978-fa output line.
+
+    Returns (raw_hex, icao_hex, received_at) or None if the line should be
+    skipped (!-preambles, blank lines, unrecognised format).
+
+    ICAO address is at bytes 1-3 of the UAT payload (hex chars [2:8]).
+    Timestamp is taken from the t= field in the metadata.
+    """
+    line = line.strip()
+    if not line or line.startswith("!"):
+        return None
+    if not line.startswith("-"):
+        return None
+
+    parts = line[1:].split(";")
+    raw_hex = parts[0].upper()
+    if len(raw_hex) < 8:
+        return None
+    if not all(c in "0123456789ABCDEF" for c in raw_hex):
+        return None
+
+    icao_hex = raw_hex[2:8]
+
+    received_at: float = time.time()
+    for field in parts[1:]:
+        if field.startswith("t="):
+            try:
+                received_at = float(field[2:])
+            except ValueError:
+                pass
+            break
+
+    return raw_hex, icao_hex, received_at
 
 
 # ---------------------------------------------------------------------------
@@ -96,33 +138,59 @@ class SourceCapture(threading.Thread):
             print(f"Connected to {self.host}:{self.port} (source={self.source_tag})", flush=True)
             self.connected_event.set()
             sock.settimeout(1.0)
-            buf = bytearray()
-            while not self._stop.is_set():
+            if self.source_tag == "978":
+                self._capture_978(sock)
+            else:
+                self._capture_1090(sock)
+
+    def _capture_1090(self, sock: socket.socket) -> None:
+        buf = bytearray()
+        while not self._stop.is_set():
+            try:
+                data = sock.recv(4096)
+            except socket.timeout:
+                continue
+            if not data:
+                break
+            for raw_hex in parse_1090_stream(data, buf):
                 try:
-                    data = sock.recv(4096)
-                except socket.timeout:
+                    decoded = pms.decode(raw_hex)
+                    icao_hex = decoded.get("icao") if decoded else None
+                except Exception:
                     continue
-                if not data:
-                    break
-                for raw_hex in parse_tcp_stream(data, buf):
-                    try:
-                        decoded = pms.decode(raw_hex)
-                        icao_hex = decoded.get("icao") if decoded else None
-                    except Exception:
-                        continue
-                    if not icao_hex or len(icao_hex) != 6:
-                        continue
-                    record = {
-                        "raw": raw_hex,
-                        "icao_hex": icao_hex.upper(),
-                        "received_at": time.time(),
-                        "source": self.source_tag,
-                    }
-                    line = json.dumps(record, separators=(",", ":"))
-                    with self._output_lock:
-                        self._output_file.write(line + "\n")
-                        self._output_file.flush()
-                    self.count += 1
+                if not icao_hex or len(icao_hex) != 6:
+                    continue
+                self._write(raw_hex, icao_hex.upper(), time.time())
+
+    def _capture_978(self, sock: socket.socket) -> None:
+        line_buf = b""
+        while not self._stop.is_set():
+            try:
+                data = sock.recv(4096)
+            except socket.timeout:
+                continue
+            if not data:
+                break
+            line_buf += data
+            while b"\n" in line_buf:
+                raw_line, line_buf = line_buf.split(b"\n", 1)
+                result = parse_978_line(raw_line.decode("ascii", errors="ignore"))
+                if result:
+                    raw_hex, icao_hex, received_at = result
+                    self._write(raw_hex, icao_hex, received_at)
+
+    def _write(self, raw_hex: str, icao_hex: str, received_at: float) -> None:
+        record = {
+            "raw": raw_hex,
+            "icao_hex": icao_hex,
+            "received_at": received_at,
+            "source": self.source_tag,
+        }
+        line = json.dumps(record, separators=(",", ":"))
+        with self._output_lock:
+            self._output_file.write(line + "\n")
+            self._output_file.flush()
+        self.count += 1
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +225,7 @@ def main() -> None:
         nargs="+",
         required=True,
         metavar="HOST:PORT:SOURCE_TAG",
-        help='One or more readsb sources, e.g. "localhost:30002:1090"',
+        help='One or more sources, e.g. "localhost:30002:1090" "localhost:30978:978"',
     )
     args = parser.parse_args()
 
@@ -212,14 +280,9 @@ def main() -> None:
                     stop_event.set()
                     break
 
-                counts = ", ".join(
-                    f"{t.source_tag}={t.count}" for t in threads
-                )
+                counts = ", ".join(f"{t.source_tag}={t.count}" for t in threads)
                 total = sum(t.count for t in threads)
-                print(
-                    f"[{int(elapsed):5d}s] {total} messages captured  ({counts})",
-                    flush=True,
-                )
+                print(f"[{int(elapsed):5d}s] {total} messages captured  ({counts})", flush=True)
         except KeyboardInterrupt:
             stop_event.set()
 

--- a/tools/traffic-recorder/main.py
+++ b/tools/traffic-recorder/main.py
@@ -162,7 +162,7 @@ class SourceCapture(threading.Thread):
             sock.settimeout(1.0)
             if self.source_tag == "978":
                 self._capture_978(sock)
-            else:
+            elif self.source_tag == "1090":
                 self._capture_1090(sock)
 
     def _capture_1090(self, sock: socket.socket) -> None:
@@ -230,6 +230,9 @@ class SourceCapture(threading.Thread):
 # Entry point
 # ---------------------------------------------------------------------------
 
+_VALID_SOURCE_TAGS = {"1090", "978"}
+
+
 def _parse_source(s: str) -> tuple[str, int, str]:
     parts = s.split(":")
     if len(parts) != 3:
@@ -241,6 +244,10 @@ def _parse_source(s: str) -> tuple[str, int, str]:
         port = int(port_str)
     except ValueError:
         raise argparse.ArgumentTypeError(f"Invalid port in source {s!r}: {port_str!r}")
+    if tag not in _VALID_SOURCE_TAGS:
+        raise argparse.ArgumentTypeError(
+            f"Invalid source_tag {tag!r} in {s!r} — must be one of: {', '.join(sorted(_VALID_SOURCE_TAGS))}"
+        )
     return host, port, tag
 
 

--- a/tools/traffic-recorder/main.py
+++ b/tools/traffic-recorder/main.py
@@ -57,12 +57,12 @@ def parse_1090_stream(data: bytes, buf: bytearray) -> list[str]:
 # 978 line parser  (-hex;rs=N;rssi=N;t=N.NNN;  — dump978-fa format)
 # ---------------------------------------------------------------------------
 
-def parse_978_line(line: str) -> tuple[str, str, float, float | None, int | None] | None:
+def parse_978_line(line: str) -> tuple[str, str, float] | None:
     """
     Parse a dump978-fa output line.
 
-    Returns (raw_hex, icao_hex, received_at, rssi, rs) or None if the line
-    should be skipped (!-preambles, blank lines, unrecognised format).
+    Returns (raw_hex, icao_hex, received_at) or None if the line should be
+    skipped (!-preambles, blank lines, unrecognised format).
 
     raw_hex preserves the leading - (downlink) or + (uplink) symbol so
     downstream processors can distinguish frame direction.
@@ -71,8 +71,6 @@ def parse_978_line(line: str) -> tuple[str, str, float, float | None, int | None
     chars [3:9] — one char for the symbol, two chars for byte 0, then the
     three ICAO bytes.
 
-    rssi: received signal strength (dBFS float).
-    rs:   Reed-Solomon errors corrected (int; absent on clean frames).
     Timestamp is taken from the t= field in the metadata.
     """
     line = line.strip()
@@ -93,27 +91,15 @@ def parse_978_line(line: str) -> tuple[str, str, float, float | None, int | None
     icao_hex = hex_payload[2:8]
 
     received_at: float = time.time()
-    rssi: float | None = None
-    rs: int | None = None
-
     for field in parts[1:]:
         if field.startswith("t="):
             try:
                 received_at = float(field[2:])
             except ValueError:
                 pass
-        elif field.startswith("rssi="):
-            try:
-                rssi = float(field[5:])
-            except ValueError:
-                pass
-        elif field.startswith("rs="):
-            try:
-                rs = int(field[3:])
-            except ValueError:
-                pass
+            break
 
-    return raw_hex, icao_hex, received_at, rssi, rs
+    return raw_hex, icao_hex, received_at
 
 
 # ---------------------------------------------------------------------------
@@ -198,27 +184,16 @@ class SourceCapture(threading.Thread):
                 raw_line, line_buf = line_buf.split(b"\n", 1)
                 result = parse_978_line(raw_line.decode("ascii", errors="ignore"))
                 if result:
-                    raw_hex, icao_hex, received_at, rssi, rs = result
-                    self._write(raw_hex, icao_hex, received_at, rssi=rssi, rs=rs)
+                    raw_hex, icao_hex, received_at = result
+                    self._write(raw_hex, icao_hex, received_at)
 
-    def _write(
-        self,
-        raw_hex: str,
-        icao_hex: str,
-        received_at: float,
-        rssi: float | None = None,
-        rs: int | None = None,
-    ) -> None:
+    def _write(self, raw_hex: str, icao_hex: str, received_at: float) -> None:
         record = {
             "raw": raw_hex,
             "icao_hex": icao_hex,
             "received_at": received_at,
             "source": self.source_tag,
         }
-        if rssi is not None:
-            record["rssi"] = rssi
-        if rs is not None:
-            record["rs"] = rs
         line = json.dumps(record, separators=(",", ":"))
         with self._output_lock:
             self._output_file.write(line + "\n")


### PR DESCRIPTION
## Summary

- Fixes ICAO extraction to use `pms.decode().get("icao")` — `pms.icao()` was silently dropping all messages
- Adds 978 UAT parser for dump978-fa line format (`-hex;rs=N;rssi=N;t=N;`): skips `!` preambles, preserves `-`/`+` direction symbol in `raw`, uses `t=` timestamp from the message
- Dispatches to `_capture_1090()` or `_capture_978()` based on source tag
- Waits for all sources to connect before entering progress loop; prints `Receiving data...` once all connected
- First progress stats appear at 30s (not 0s)
- Any connection failure stops the entire capture and exits with code 1
- Source tags validated — only `1090` or `978` accepted; clear error message otherwise
- Both sources produce identical record shape: `raw`, `icao_hex`, `received_at`, `source`

## Test plan

- [ ] Run with `--sources host:30002:1090` — confirm messages captured and ICAO populated
- [ ] Run with `--sources host:30002:1090 host:30978:978` — confirm both sources captured, 978 records include `-`/`+` prefix in `raw`
- [ ] Run with a bad port on one source — confirm error printed and exit code 1
- [ ] Run with an invalid source tag — confirm error message names valid options
- [ ] Confirm `[0s]` progress line no longer appears before `Connected` messages

Closes #69

Generated with Claude Code