### PR TITLE
Rename source tag mlat → MLAT

### DIFF
--- a/receiver/README.md
+++ b/receiver/README.md
@@ -28,7 +28,7 @@ reconnect. One receiver container handles all configured sources concurrently
 |-------|------|-------------|
 | `host` | string | Hostname or IP of the readsb instance. |
 | `port` | integer | TCP port of the readsb raw output (e.g. `30002` for 1090 MHz, `30978` for 978 MHz UAT). |
-| `source` | string | Tag applied to every message from this stream. One of `"1090"`, `"978"`, or `"mlat"`. |
+| `source` | string | Tag applied to every message from this stream. One of `"1090"`, `"978"`, or `"MLAT"`. |
 
 Example with two sources:
 

--- a/shared/models.py
+++ b/shared/models.py
@@ -17,7 +17,7 @@ class InboundMessage(BaseModel):
     raw: str
     icao_hex: str
     received_at: float  # Unix timestamp (seconds)
-    source: Literal["1090", "978", "mlat"]
+    source: Literal["1090", "978", "MLAT"]
 
     @field_validator("icao_hex")
     @classmethod
@@ -158,7 +158,7 @@ class CompletedFlight(BaseModel):
     first_message: datetime
     last_message: datetime
     total_messages: int
-    source: Literal["1090", "978", "mlat"]  # additive; not in legacy format
+    source: Literal["1090", "978", "MLAT"]  # additive; not in legacy format
     aircraft: dict                           # AircraftRecord fields; must include icao_hex
     ident: Optional[str] = None
     operator: Optional[dict] = None          # OperatorRecord fields; source key stripped

--- a/shared/tests/test_models.py
+++ b/shared/tests/test_models.py
@@ -41,8 +41,8 @@ class TestInboundMessage:
             InboundMessage(raw="x", icao_hex="ABCDEF", received_at=0.0, source="978MHz")
 
     def test_mlat_source(self):
-        msg = InboundMessage(raw="x", icao_hex="ABCDEF", received_at=0.0, source="mlat")
-        assert msg.source == "mlat"
+        msg = InboundMessage(raw="x", icao_hex="ABCDEF", received_at=0.0, source="MLAT")
+        assert msg.source == "MLAT"
 
 
 class TestPosition:

--- a/specs/asyncapi.yaml
+++ b/specs/asyncapi.yaml
@@ -527,8 +527,8 @@ components:
           description: Arrival airport; omitted when unknown
         source:
           type: string
-          enum: ["1090", "978"]
-          description: Receive source. mlat support is tracked in issue #32
+          enum: ["1090", "978", "MLAT"]
+          description: Receive source. MLAT support is tracked in issue #32
         first_message:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- Updates `source` field literals in `InboundMessage` and `CompletedFlight` models from `"mlat"` to `"MLAT"` for consistency with `"1090"` and `"978"`
- Updates `specs/asyncapi.yaml` enum and description
- Updates `receiver/README.md` source tag documentation
- Updates test values in `shared/tests/test_models.py`

Closes #73

## Test plan
- [ ] `shared/tests/test_models.py` passes (26 tests)
- [ ] `test_mlat_source` passes with `"MLAT"` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)