### PR TITLE
Fix ofelia missing runners profile in docker-compose.server.yaml

### DIFF
--- a/docker-compose.server.yaml
+++ b/docker-compose.server.yaml
@@ -32,6 +32,7 @@ services:
   ofelia:
     image: mcuadros/ofelia:latest
     restart: unless-stopped
+    profiles: ["runners"]
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/ofelia/config.ini:/etc/ofelia/config.ini:ro


### PR DESCRIPTION
## Summary

- Adds `profiles: ["runners"]` to the `ofelia` service so it matches the profile of the runner services it depends on
- Without this, `docker compose ... up rabbitmq redis` fails with "depends on undefined service" because Compose validates the whole file

Fixes #76

## Test plan

- [ ] `docker compose -f docker-compose.server.yaml up rabbitmq redis -d` starts without error
- [ ] `docker compose -f docker-compose.server.yaml --profile runners up -d` still brings up ofelia and all runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)