### PR TITLE
shared: add aircraft:simple/detail key helpers; deprecate icao_hex key

### DIFF
--- a/shared/redis_keys.py
+++ b/shared/redis_keys.py
@@ -9,18 +9,40 @@ are always explicit and typos in key names are caught by the type checker.
 _VALID_PERIODS = frozenset({"hour", "today", "lifetime"})
 _VALID_ARCHIVE_PERIODS = frozenset({"hour", "today"})
 
-# RediSearch index over all icao_hex:{hex} JSON documents.
-# Supports registration lookup without a separate reverse-index key.
-AIRCRAFT_SEARCH_INDEX = "idx:aircraft"
+# RediSearch index over all aircraft:simple:{hex} JSON documents (Mictronics).
+# Indexed fields: $.icao_hex, $.registration
+AIRCRAFT_SIMPLE_SEARCH_INDEX = "idx:aircraft:simple"
+
+# RediSearch index over all aircraft:detail:{hex} JSON documents (country runners).
+# Indexed fields: $.icao_hex, $.registration
+AIRCRAFT_DETAIL_SEARCH_INDEX = "idx:aircraft:detail"
 
 # RediSearch index over all airport:{icao_code} JSON documents.
 # Supports lookup by ICAO code or IATA code.
 AIRPORT_SEARCH_INDEX = "idx:airport"
 
+# ---------------------------------------------------------------------------
+# Deprecated — retained until all runners are migrated to the simple/detail
+# key schema. Remove once icao_hex_key() has no remaining callers.
+# ---------------------------------------------------------------------------
+
+# RediSearch index over all icao_hex:{hex} JSON documents.
+AIRCRAFT_SEARCH_INDEX = "idx:aircraft"
+
 
 def icao_hex_key(icao_hex: str) -> str:
-    """Aircraft enrichment record. icao_hex:{icao_hex}"""
+    """Deprecated. Use aircraft_simple_key() or aircraft_detail_key(). icao_hex:{icao_hex}"""
     return f"icao_hex:{icao_hex.upper()}"
+
+
+def aircraft_simple_key(icao_hex: str) -> str:
+    """Mictronics aircraft enrichment record. aircraft:simple:{icao_hex}"""
+    return f"aircraft:simple:{icao_hex.upper()}"
+
+
+def aircraft_detail_key(icao_hex: str) -> str:
+    """Country-runner aircraft enrichment record. aircraft:detail:{icao_hex}"""
+    return f"aircraft:detail:{icao_hex.upper()}"
 
 
 def operator_key(designator: str) -> str:

--- a/shared/tests/test_redis_keys.py
+++ b/shared/tests/test_redis_keys.py
@@ -1,7 +1,11 @@
 import pytest
 
 from shared.redis_keys import (
+    AIRCRAFT_DETAIL_SEARCH_INDEX,
+    AIRCRAFT_SIMPLE_SEARCH_INDEX,
     airport_key,
+    aircraft_detail_key,
+    aircraft_simple_key,
     config_areas_key,
     config_areas_version_key,
     config_rules_key,
@@ -13,18 +17,27 @@ from shared.redis_keys import (
     metrics_registration_misses_key,
     operator_key,
     processor_heartbeat_key,
-    registration_key,
 )
 
 
 class TestEnrichmentKeys:
-    def test_icao_hex_key(self):
+    def test_aircraft_simple_key(self):
+        assert aircraft_simple_key("a8ae7f") == "aircraft:simple:A8AE7F"
+        assert aircraft_simple_key("A8AE7F") == "aircraft:simple:A8AE7F"
+
+    def test_aircraft_detail_key(self):
+        assert aircraft_detail_key("a8ae7f") == "aircraft:detail:A8AE7F"
+        assert aircraft_detail_key("A8AE7F") == "aircraft:detail:A8AE7F"
+
+    def test_aircraft_simple_search_index_name(self):
+        assert AIRCRAFT_SIMPLE_SEARCH_INDEX == "idx:aircraft:simple"
+
+    def test_aircraft_detail_search_index_name(self):
+        assert AIRCRAFT_DETAIL_SEARCH_INDEX == "idx:aircraft:detail"
+
+    def test_icao_hex_key_deprecated_still_works(self):
         assert icao_hex_key("a8ae7f") == "icao_hex:A8AE7F"
         assert icao_hex_key("A8AE7F") == "icao_hex:A8AE7F"
-
-    def test_registration_key(self):
-        assert registration_key("n659dl") == "registration:N659DL"
-        assert registration_key("N659DL") == "registration:N659DL"
 
     def test_operator_key(self):
         assert operator_key("dal") == "operator:DAL"


### PR DESCRIPTION
Closes #94

## Summary
- Adds `AIRCRAFT_SIMPLE_SEARCH_INDEX` (`idx:aircraft:simple`) and `AIRCRAFT_DETAIL_SEARCH_INDEX` (`idx:aircraft:detail`) constants
- Adds `aircraft_simple_key()` and `aircraft_detail_key()` key builder functions
- Retains `icao_hex_key()` and `AIRCRAFT_SEARCH_INDEX` marked deprecated until all runners are migrated (follow-on cleanup PR)
- Removes the never-implemented `registration_key()` from tests — the `registration:{reg}` plain-string reverse-index is dead code that nothing reads; eliminated as part of #93

## Test plan
- [ ] `python3 -m pytest shared/tests/test_redis_keys.py` — 20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)