### PR TITLE
shared: add Lua merge script for aircraft:simple + aircraft:detail

### DIFF
--- a/shared/lua/merge_aircraft.lua
+++ b/shared/lua/merge_aircraft.lua
@@ -1,0 +1,38 @@
+-- merge_aircraft.lua
+--
+-- Merges aircraft:simple:{icao_hex} and aircraft:detail:{icao_hex} into a
+-- single JSON document and returns it as a string.
+--
+-- ARGV[1] : icao_hex (e.g. "A8AE7F")
+--
+-- Returns nil if no simple record exists for the given icao_hex.
+-- Detail fields win over simple fields on any overlap (same semantics as the
+-- old deep-merge-on-write pattern, but performed server-side at read time).
+--
+-- Called by the processor via EVALSHA so the merge is a single round-trip.
+
+local icao_hex = ARGV[1]
+
+local function deep_merge(base, update)
+    for k, v in pairs(update) do
+        if type(v) == 'table' and type(base[k]) == 'table' then
+            deep_merge(base[k], v)
+        else
+            base[k] = v
+        end
+    end
+end
+
+local simple_raw = redis.call('JSON.GET', 'aircraft:simple:' .. icao_hex)
+if not simple_raw then
+    return nil
+end
+
+local result = cjson.decode(simple_raw)
+
+local detail_raw = redis.call('JSON.GET', 'aircraft:detail:' .. icao_hex)
+if detail_raw then
+    deep_merge(result, cjson.decode(detail_raw))
+end
+
+return cjson.encode(result)


### PR DESCRIPTION
Closes #96

## Summary
- Creates `shared/lua/merge_aircraft.lua`
- Accepts `ARGV[1]` = icao_hex; returns merged JSON string or nil if no simple record exists
- Deep-merges `aircraft:detail:{hex}` on top of `aircraft:simple:{hex}` using `cjson` — detail fields win on overlap
- Processor wiring (`r.script_load()` / `r.evalsha()`) is tracked separately in issue #101

## Test plan
- [ ] Script is syntactically valid Lua (no unit test framework for Lua in this repo — validated by inspection and will be confirmed when the processor wires it up in #101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)