### PR TITLE
mictronics: write to aircraft:simple:{hex}; update search index prefix

### DIFF
--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key, operator_key
+from shared.redis_keys import AIRCRAFT_SIMPLE_SEARCH_INDEX, aircraft_simple_key, operator_key
 
 logger = logging.getLogger("mictronics")
 
@@ -279,18 +279,18 @@ def build_operator_record(row: sqlite3.Row) -> dict:
 # ---------------------------------------------------------------------------
 
 def _ensure_search_index(r: redis_lib.Redis) -> None:
-    """Create the aircraft JSON search index if it does not already exist."""
+    """Create the aircraft simple JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:simple:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_SIMPLE_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +327,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     for row in rows:
         types_row = row if row["manufacturer_model"] is not None else None
         record = build_aircraft_record(row, types_row)
-        key = icao_hex_key(record["icao_hex"])
+        key = aircraft_simple_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -491,17 +491,17 @@ class TestWriteOperatorsToRedis:
 # ---------------------------------------------------------------------------
 
 class TestRedisKeys:
-    def test_icao_hex_key_format(self):
-        from shared.redis_keys import icao_hex_key
-        assert icao_hex_key("a8ae7f") == "icao_hex:A8AE7F"
+    def test_aircraft_simple_key_format(self):
+        from shared.redis_keys import aircraft_simple_key
+        assert aircraft_simple_key("a8ae7f") == "aircraft:simple:A8AE7F"
 
-    def test_icao_hex_key_already_upper(self):
-        from shared.redis_keys import icao_hex_key
-        assert icao_hex_key("A8AE7F") == "icao_hex:A8AE7F"
+    def test_aircraft_simple_key_already_upper(self):
+        from shared.redis_keys import aircraft_simple_key
+        assert aircraft_simple_key("A8AE7F") == "aircraft:simple:A8AE7F"
 
-    def test_aircraft_search_index_name(self):
-        from shared.redis_keys import AIRCRAFT_SEARCH_INDEX
-        assert AIRCRAFT_SEARCH_INDEX == "idx:aircraft"
+    def test_aircraft_simple_search_index_name(self):
+        from shared.redis_keys import AIRCRAFT_SIMPLE_SEARCH_INDEX
+        assert AIRCRAFT_SIMPLE_SEARCH_INDEX == "idx:aircraft:simple"
 
 
 # ---------------------------------------------------------------------------
@@ -533,7 +533,7 @@ class TestWriteToRedis:
         r_json = MagicMock()
         r.json.return_value = r_json
         r_json.mget.side_effect = lambda keys, path: [
-            [existing] if existing and k == f"icao_hex:{existing['icao_hex']}" else None
+            [existing] if existing and k == f"aircraft:simple:{existing['icao_hex']}" else None
             for k in keys
         ]
 
@@ -555,7 +555,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "icao_hex:A8AE7F" in keys
+        assert "aircraft:simple:A8AE7F" in keys
         conn.close()
 
     def test_json_set_uses_root_path(self):
@@ -597,7 +597,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis(existing=existing)
         write_to_redis(conn, r, REDIS_TTL)
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["icao_hex:A8AE7F"]
+        record = calls["aircraft:simple:A8AE7F"]
         # mictronics owns military — its value (False) overwrites the existing True
         assert record["military"] is False
         # registrant is not owned by mictronics — must be preserved


### PR DESCRIPTION
Closes #97

## Summary
- Replaces `icao_hex_key()` / `AIRCRAFT_SEARCH_INDEX` with `aircraft_simple_key()` / `AIRCRAFT_SIMPLE_SEARCH_INDEX` throughout
- RediSearch index prefix changes from `icao_hex:` to `aircraft:simple:` — this is the index that lookup-based country runners (au-casa, fr-dgac, at-austrocontrol, ky-caa, bs-caa) will query to resolve registration → icao_hex
- Deep-merge retained: Mictronics may run multiple times and needs to update its own simple records in place
- No `source` field added to simple records

## Test plan
- [ ] `python3 -m pytest data-runners/mictronics/tests/test_mictronics.py` — 54 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)