### PR TITLE
mictronics: update download URL to GitHub raw source

### DIFF
--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -7,7 +7,7 @@ operators, and types JSON files, stages records in local SQLite, writes
 enrichment data to Redis with a 14-day TTL, publishes MQTT completion stats,
 then exits.
 
-Data source: https://www.mictronics.de/aircraft-database/indexedDB.php
+Data source: https://github.com/Mictronics/aircraft-database/raw/refs/heads/main/indexedDB.zip
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ from shared.redis_keys import AIRCRAFT_SIMPLE_SEARCH_INDEX, aircraft_simple_key,
 
 logger = logging.getLogger("mictronics")
 
-DOWNLOAD_URL = "https://www.mictronics.de/aircraft-database/indexedDB.php"
+DOWNLOAD_URL = "https://github.com/Mictronics/aircraft-database/raw/refs/heads/main/indexedDB.zip"
 REDIS_TTL = 14 * 86400  # 14 days in seconds
 MQTT_ROOT = "SkyFollower/runner/mictronics"
 

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -30,7 +30,7 @@ sources:
 
   mictronics:
     description: "Mictronics global aircraft database — type designators, military/interesting flags, and operators"
-    url: "https://www.mictronics.de/aircraft-database/indexedDB.php"
+    url: "https://github.com/Mictronics/aircraft-database/raw/refs/heads/main/indexedDB.zip"
     format: zip+json
     cadence: weekly_tuesday
     files:


### PR DESCRIPTION
## Summary

- Updates `DOWNLOAD_URL` in `data-runners/mictronics/main.py` from the dead PHP endpoint to the GitHub raw file URL
- Updates module docstring to match
- Updates `specs/data-dictionary.yaml` source URL for mictronics

Closes #120

## Test plan
- [ ] Build Docker image: `docker build -t skyfollower-mictronics:local data-runners/mictronics/`
- [ ] Run with local settings and verify download succeeds (no HTTP 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)