### PR TITLE
ca-transport-canada: write to aircraft:detail, remove deep-merge

### DIFF
--- a/data-runners/ca-transport-canada/main.py
+++ b/data-runners/ca-transport-canada/main.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, aircraft_detail_key
 
 logger = logging.getLogger("ca-transport-canada")
 
@@ -360,21 +360,6 @@ def stage_data(files: dict[str, bytes], db_path: str) -> sqlite3.Connection:
 
 
 # ---------------------------------------------------------------------------
-# Record merge
-# ---------------------------------------------------------------------------
-
-def _deep_merge(base: dict, update: dict) -> dict:
-    """Merge update into base. update values win; nested dicts are merged recursively."""
-    result = dict(base)
-    for k, v in update.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-            result[k] = _deep_merge(result[k], v)
-        else:
-            result[k] = v
-    return result
-
-
-# ---------------------------------------------------------------------------
 # Build Redis record
 # ---------------------------------------------------------------------------
 
@@ -431,18 +416,18 @@ def build_aircraft_record(acft_row: sqlite3.Row, owner_rows: list[sqlite3.Row]) 
 # ---------------------------------------------------------------------------
 
 def _ensure_search_index(r: redis_lib.Redis) -> None:
-    """Create the aircraft JSON search index if it does not already exist."""
+    """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -466,12 +451,9 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     batch: list[tuple[str, dict]] = []
 
     def _flush():
-        keys = [k for k, _ in batch]
-        existing_list = r.json().mget(keys, "$")
         pipe = r.pipeline()
-        for (key, new_record), existing_raw in zip(batch, existing_list):
-            merged = _deep_merge(existing_raw[0], new_record) if existing_raw else new_record
-            pipe.json().set(key, "$", merged)
+        for key, record in batch:
+            pipe.json().set(key, "$", record)
             pipe.expire(key, ttl)
         pipe.execute()
 
@@ -484,7 +466,8 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
         )
         owner_rows = owner_cur.fetchall()
         record = build_aircraft_record(acft_row, owner_rows)
-        key = icao_hex_key(record["icao_hex"])
+        record["source"] = "ca-transport-canada"
+        key = aircraft_detail_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/ca-transport-canada/tests/test_ca_tc.py
+++ b/data-runners/ca-transport-canada/tests/test_ca_tc.py
@@ -664,13 +664,13 @@ class TestBuildAircraftRecord:
 # ---------------------------------------------------------------------------
 
 class TestRedisKeys:
-    def test_icao_hex_key_format(self):
-        from shared.redis_keys import icao_hex_key
-        assert icao_hex_key("c00001") == "icao_hex:C00001"
+    def test_aircraft_detail_key_format(self):
+        from shared.redis_keys import aircraft_detail_key
+        assert aircraft_detail_key("c00001") == "aircraft:detail:C00001"
 
-    def test_aircraft_search_index_name(self):
-        from shared.redis_keys import AIRCRAFT_SEARCH_INDEX
-        assert AIRCRAFT_SEARCH_INDEX == "idx:aircraft"
+    def test_aircraft_detail_search_index_name(self):
+        from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX
+        assert AIRCRAFT_DETAIL_SEARCH_INDEX == "idx:aircraft:detail"
 
 
 # ---------------------------------------------------------------------------
@@ -682,15 +682,8 @@ class TestWriteToRedis:
         with tempfile.TemporaryDirectory() as tmpdir:
             return stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
 
-    def _mock_redis(self, existing: Optional[dict] = None):
+    def _mock_redis(self):
         r = MagicMock()
-        r_json = MagicMock()
-        r.json.return_value = r_json
-        r_json.mget.side_effect = lambda keys, path: [
-            [existing] if existing and k == f"icao_hex:{existing['icao_hex']}" else None
-            for k in keys
-        ]
-
         pipe = MagicMock()
         pipe_json = MagicMock()
         r.pipeline.return_value = pipe
@@ -710,8 +703,8 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "icao_hex:C00001" in keys
-        assert "icao_hex:C00002" in keys
+        assert "aircraft:detail:C00001" in keys
+        assert "aircraft:detail:C00002" in keys
         conn.close()
 
     def test_inactive_icao_hex_not_written(self):
@@ -719,7 +712,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "icao_hex:C00003" not in keys
+        assert "aircraft:detail:C00003" not in keys
         conn.close()
 
     def test_json_set_uses_root_path(self):
@@ -754,31 +747,20 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["icao_hex:C00001"]
+        record = calls["aircraft:detail:C00001"]
         assert isinstance(record, dict)
-        assert "source" not in record
+        assert record["source"] == "ca-transport-canada"
         assert record["registration"] == "C-GABC"
         conn.close()
 
-    def test_merges_with_existing_record(self):
-        """TC fields overwrite existing; unowned fields from other runners are preserved."""
+    def test_source_set_on_all_records(self):
+        """Every record written to Redis carries source='ca-transport-canada'."""
         conn = self._make_db()
-        existing = {
-            "icao_hex": "C00001",
-            "military": False,
-            "aircraft": {"type_designator": "C172", "wake_turbulence_category": "Light"},
-        }
-        r, _, pipe_json = self._mock_redis(existing=existing)
+        r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
-        calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["icao_hex:C00001"]
-        # military is mictronics-owned — preserved from existing since TC omits it
-        assert record["military"] is False
-        # mictronics aircraft fields are preserved alongside TC aircraft fields
-        assert record["aircraft"]["type_designator"] == "C172"
-        assert record["aircraft"]["wake_turbulence_category"] == "Light"
-        # TC aircraft fields are present
-        assert record["aircraft"]["type"] == "Airplane"
+        for call in pipe_json.set.call_args_list:
+            record = call.args[2]
+            assert record["source"] == "ca-transport-canada"
         conn.close()
 
 


### PR DESCRIPTION
## Summary

- Switch write key from `icao_hex:{hex}` to `aircraft:detail:{hex}` (`aircraft_detail_key()`)
- Remove the read-before-write deep-merge pattern; each run now fire-and-forgets the full fresh record
- Add `"source": "ca-transport-canada"` to every record before writing
- Update `_ensure_search_index` to use `AIRCRAFT_DETAIL_SEARCH_INDEX` with prefix `aircraft:detail:`
- Update imports: add `aircraft_detail_key, AIRCRAFT_DETAIL_SEARCH_INDEX`; remove `icao_hex_key, AIRCRAFT_SEARCH_INDEX`
- Update tests accordingly (81 passing)

Closes #98

## Test plan

- [x] `cd data-runners/ca-transport-canada && python3 -m pytest tests/ -v` — 81 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)