### PR TITLE
au-casa: write to aircraft:detail, add type sanity check

### DIFF
--- a/data-runners/au-casa/main.py
+++ b/data-runners/au-casa/main.py
@@ -3,9 +3,10 @@
 SkyFollower Australia CASA Data Runner
 
 Downloads the Civil Aviation Safety Authority (CASA) aircraft register CSV,
-looks up each VH- registration in the Redis search index to find the ICAO hex
-(provided by Mictronics), deep-merges CASA enrichment data into existing Redis
-records, publishes MQTT completion stats, then exits.
+looks up each VH- registration in the Mictronics simple index to find the ICAO
+hex, performs a type sanity check to reject false cross-registry joins, writes
+full CASA enrichment records to aircraft:detail:{icao_hex} keys in Redis,
+publishes MQTT completion stats, then exits.
 
 Important: the CASA register does not publish ICAO hex (Mode S) addresses.
 This runner can only enrich records that already exist in Redis from Mictronics.
@@ -21,6 +22,7 @@ import io
 import json
 import logging
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from typing import Optional
@@ -35,7 +37,12 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
-from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+from shared.redis_keys import (
+    AIRCRAFT_DETAIL_SEARCH_INDEX,
+    AIRCRAFT_SIMPLE_SEARCH_INDEX,
+    aircraft_detail_key,
+    aircraft_simple_key,
+)
 
 logger = logging.getLogger("au-casa")
 
@@ -159,6 +166,38 @@ def _parse_int(value: str) -> Optional[int]:
 
 
 # ---------------------------------------------------------------------------
+# Type sanity check (detect false joins between registries)
+# ---------------------------------------------------------------------------
+
+_TYPE_TOKEN_RE = re.compile(r'[A-Z]{1,4}\d{2,4}')
+
+
+def _type_tokens(model_str: str) -> set:
+    """Extract alphanumeric type tokens from a model/type designator string."""
+    return {t.split('-')[0] for t in _TYPE_TOKEN_RE.findall(model_str.upper())}
+
+
+def _type_check_passes(simple_record: dict, detail_model_str: str) -> bool:
+    """Return True if the CASA model string is consistent with the Mictronics simple record.
+
+    Returns True (pass) when either side has no extractable tokens — we only
+    reject when both sides have tokens and they share none in common.
+    """
+    if not detail_model_str:
+        return True
+    simple_tokens = _type_tokens(
+        (simple_record.get("type_designator") or "") + " " +
+        (simple_record.get("manufacturer_model") or "")
+    )
+    if not simple_tokens:
+        return True
+    detail_tokens = _type_tokens(detail_model_str)
+    if not detail_tokens:
+        return True
+    return bool(simple_tokens & detail_tokens)
+
+
+# ---------------------------------------------------------------------------
 # RediSearch tag escaping
 # ---------------------------------------------------------------------------
 
@@ -226,37 +265,22 @@ def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Record merge
-# ---------------------------------------------------------------------------
-
-def _deep_merge(base: dict, update: dict) -> dict:
-    """Merge update into base. update values win; nested dicts are merged recursively."""
-    result = dict(base)
-    for k, v in update.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-            result[k] = _deep_merge(result[k], v)
-        else:
-            result[k] = v
-    return result
-
-
-# ---------------------------------------------------------------------------
 # Search index
 # ---------------------------------------------------------------------------
 
 def _ensure_search_index(r: redis_lib.Redis) -> None:
-    """Create the aircraft JSON search index if it does not already exist."""
+    """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -278,13 +302,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("icao_hex:", "")
+                icao_hex = doc.id.replace("aircraft:simple:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -320,7 +344,7 @@ def download_registry(url: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
-    """Enrich existing Redis records with CASA data. Returns count of records written."""
+    """Write CASA data to aircraft:detail Redis keys. Returns count of records written."""
     # Filter suspended records
     active_rows = [row for row in rows if row.get("suspendstatus", "").strip().lower() != "suspended"]
     suspended_count = len(rows) - len(active_rows)
@@ -346,31 +370,47 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     )
 
     count = 0
-    batch: list[tuple[str, dict]] = []
+    skipped = 0
+    pipe = r.pipeline()
+    pipe_size = 0
 
-    def _flush() -> None:
-        keys = [k for k, _ in batch]
-        existing_list = r.json().mget(keys, "$")
-        pipe = r.pipeline()
-        for (key, new_record), existing_raw in zip(batch, existing_list):
-            merged = _deep_merge(existing_raw[0], new_record) if existing_raw else new_record
-            pipe.json().set(key, "$", merged)
-            pipe.expire(key, ttl)
+    def _flush_pipe() -> None:
+        nonlocal pipe_size
         pipe.execute()
+        pipe_size = 0
 
     for registration, icao_hex in reg_icao_map.items():
         row = reg_row_map[registration]
+
+        # Type sanity check: reject false joins where registries share a mark
+        # for different aircraft.
+        au_casa_model = row.get("Model", "").strip()
+        simple_raw = r.json().get(aircraft_simple_key(icao_hex))
+        if simple_raw is not None and not _type_check_passes(simple_raw, au_casa_model):
+            logger.debug(
+                "Type sanity check failed for %s (icao_hex=%s, casa_model=%r); skipping.",
+                registration, icao_hex, au_casa_model,
+            )
+            skipped += 1
+            continue
+
         record = _build_record(row, icao_hex, registration)
-        batch.append((icao_hex_key(icao_hex), record))
+        record["source"] = "au-casa"
+
+        pipe.json().set(aircraft_detail_key(icao_hex), "$", record)
+        pipe.expire(aircraft_detail_key(icao_hex), ttl)
+        pipe_size += 1
         count += 1
-        if len(batch) == 10000:
-            _flush()
-            batch.clear()
+
+        if pipe_size >= 10000:
+            _flush_pipe()
             logger.info("  ... %d records written.", count)
 
-    if batch:
-        _flush()
+    if pipe_size:
+        _flush_pipe()
 
+    if skipped:
+        logger.info("Skipped %d records that failed type sanity check.", skipped)
     logger.info("Finished writing %d records to Redis.", count)
     return count
 


### PR DESCRIPTION
## Summary

- Switch RediSearch lookup from `idx:aircraft` (`icao_hex:` prefix) to `idx:aircraft:simple` (`aircraft:simple:` prefix) to resolve registration → icao_hex via Mictronics data
- Add type sanity check after resolving icao_hex: fetch `aircraft:simple:{icao_hex}` and compare type tokens (regex `[A-Z]{1,4}\d{2,4}`) between the Mictronics simple record and the CASA model string — skips records where both sides have tokens but share none (detects false cross-registry joins)
- Write full fresh records fire-and-forget to `aircraft:detail:{icao_hex}` — removes read-before-write deep-merge pattern
- Add `"source": "au-casa"` to every record written
- Ensure `idx:aircraft:detail` RediSearch index with `aircraft:detail:` prefix (replaces old `idx:aircraft` / `icao_hex:` index)

## Test plan

- [ ] No tests exist in `data-runners/au-casa/tests/`; verify logic manually by inspecting the diff
- [ ] Confirm all `AIRCRAFT_SEARCH_INDEX` / `icao_hex_key` references are removed from `data-runners/au-casa/main.py`
- [ ] Confirm `aircraft_detail_key`, `aircraft_simple_key`, `AIRCRAFT_SIMPLE_SEARCH_INDEX`, `AIRCRAFT_DETAIL_SEARCH_INDEX` are the only redis_keys imports
- [ ] Confirm `source: "au-casa"` appears in built records
- [ ] Confirm type sanity check helper functions are unit-testable in isolation

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)