### PR TITLE
us-faa: write to aircraft:detail, remove deep-merge

### DIFF
--- a/data-runners/us-faa/main.py
+++ b/data-runners/us-faa/main.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, aircraft_detail_key
 
 logger = logging.getLogger("us-faa")
 
@@ -347,21 +347,6 @@ def stage_data(files: dict[str, bytes], db_path: str) -> sqlite3.Connection:
 
 
 # ---------------------------------------------------------------------------
-# Record merge
-# ---------------------------------------------------------------------------
-
-def _deep_merge(base: dict, update: dict) -> dict:
-    """Merge update into base. update values win; nested dicts are merged recursively."""
-    result = dict(base)
-    for k, v in update.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-            result[k] = _deep_merge(result[k], v)
-        else:
-            result[k] = v
-    return result
-
-
-# ---------------------------------------------------------------------------
 # Build Redis record
 # ---------------------------------------------------------------------------
 
@@ -442,18 +427,18 @@ def build_aircraft_record(
 # ---------------------------------------------------------------------------
 
 def _ensure_search_index(r: redis_lib.Redis) -> None:
-    """Create the aircraft JSON search index if it does not already exist."""
+    """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -487,12 +472,9 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     batch: list[tuple[str, dict]] = []
 
     def _flush():
-        keys = [k for k, _ in batch]
-        existing_list = r.json().mget(keys, "$")
         pipe = r.pipeline()
-        for (key, new_record), existing_raw in zip(batch, existing_list):
-            merged = _deep_merge(existing_raw[0], new_record) if existing_raw else new_record
-            pipe.json().set(key, "$", merged)
+        for key, record in batch:
+            pipe.json().set(key, "$", record)
             pipe.expire(key, ttl)
         pipe.execute()
 
@@ -500,7 +482,8 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
         acft_row = row if row["manufacturer"] is not None else None
         eng_row = engines_by_code.get(row["code_engine"]) if row["code_engine"] else None
         record = build_aircraft_record(row, acft_row, eng_row)
-        key = icao_hex_key(record["icao_hex"])
+        record["source"] = "us-faa"
+        key = aircraft_detail_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/us-faa/tests/test_us_faa.py
+++ b/data-runners/us-faa/tests/test_us_faa.py
@@ -537,13 +537,13 @@ class TestBuildAircraftRecord:
 # ---------------------------------------------------------------------------
 
 class TestRedisKeys:
-    def test_icao_hex_key_format(self):
-        from shared.redis_keys import icao_hex_key
-        assert icao_hex_key("a8ae7f") == "icao_hex:A8AE7F"
+    def test_aircraft_detail_key_format(self):
+        from shared.redis_keys import aircraft_detail_key
+        assert aircraft_detail_key("a8ae7f") == "aircraft:detail:A8AE7F"
 
-    def test_aircraft_search_index_name(self):
-        from shared.redis_keys import AIRCRAFT_SEARCH_INDEX
-        assert AIRCRAFT_SEARCH_INDEX == "idx:aircraft"
+    def test_aircraft_detail_search_index_name(self):
+        from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX
+        assert AIRCRAFT_DETAIL_SEARCH_INDEX == "idx:aircraft:detail"
 
 
 # ---------------------------------------------------------------------------
@@ -555,14 +555,10 @@ class TestWriteToRedis:
         with tempfile.TemporaryDirectory() as tmpdir:
             return stage_data(_make_files(), os.path.join(tmpdir, "staging.db"))
 
-    def _mock_redis(self, existing: Optional[dict] = None):
+    def _mock_redis(self):
         r = MagicMock()
         r_json = MagicMock()
         r.json.return_value = r_json
-        r_json.mget.side_effect = lambda keys, path: [
-            [existing] if existing and k == f"icao_hex:{existing['icao_hex']}" else None
-            for k in keys
-        ]
 
         pipe = MagicMock()
         pipe_json = MagicMock()
@@ -577,12 +573,12 @@ class TestWriteToRedis:
         assert write_to_redis(conn, r, REDIS_TTL) == 3
         conn.close()
 
-    def test_icao_hex_json_set_written(self):
+    def test_aircraft_detail_key_written(self):
         conn = self._make_db()
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "icao_hex:A8AE7F" in keys
+        assert "aircraft:detail:A8AE7F" in keys
         conn.close()
 
     def test_json_set_uses_root_path(self):
@@ -617,31 +613,27 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["icao_hex:A8AE7F"]
+        record = calls["aircraft:detail:A8AE7F"]
         assert isinstance(record, dict)
-        assert "source" not in record
+        assert record["source"] == "us-faa"
         assert record["registration"] == "N659DL"
         conn.close()
 
-    def test_merges_with_existing_record(self):
-        """FAA fields overwrite existing; unowned fields from other runners are preserved."""
+    def test_does_not_read_before_write(self):
+        """write_to_redis must fire-and-forget; no mget read before writing."""
         conn = self._make_db()
-        existing = {
-            "icao_hex": "A8AE7F",
-            "military": False,
-            "aircraft": {"type_designator": "B737", "wake_turbulence_category": "Medium"},
-        }
-        r, _, pipe_json = self._mock_redis(existing=existing)
+        r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
-        calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["icao_hex:A8AE7F"]
-        # military is mictronics-owned — preserved from existing since FAA omits it
-        assert record["military"] is False
-        # mictronics aircraft fields are preserved alongside FAA aircraft fields
-        assert record["aircraft"]["type_designator"] == "B737"
-        assert record["aircraft"]["wake_turbulence_category"] == "Medium"
-        # FAA aircraft fields are present
-        assert record["aircraft"]["manufacturer"] == "BOEING"
+        r.json().mget.assert_not_called()
+        conn.close()
+
+    def test_source_field_set_on_all_records(self):
+        """Every record written to Redis must carry source='us-faa'."""
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        records = [c.args[2] for c in pipe_json.set.call_args_list]
+        assert all(rec.get("source") == "us-faa" for rec in records)
         conn.close()
 
 


### PR DESCRIPTION
## Summary

- Replaces the deprecated `icao_hex:{hex}` write target with `aircraft:detail:{hex}` via `aircraft_detail_key()`
- Removes the read-before-write deep-merge pattern; each run now fire-and-forgets the full fresh record
- Adds `"source": "us-faa"` to every record written to Redis
- Updates `_ensure_search_index` to use `AIRCRAFT_DETAIL_SEARCH_INDEX` with prefix `aircraft:detail:`
- Updates all tests to reflect the new key format, source field, and no-merge behaviour

Closes #103

## Test plan

- [ ] All 61 existing unit tests pass (`python3 -m pytest tests/ -v`)
- [ ] New `test_does_not_read_before_write` confirms mget is never called
- [ ] New `test_source_field_set_on_all_records` confirms `source="us-faa"` on every record
- [ ] `test_aircraft_detail_key_written` confirms records land at `aircraft:detail:A8AE7F`

🤖 Generated with [Claude Code](https://claude.com/claude-code)