### PR TITLE
bs-caa: write to aircraft:detail, add type sanity check

### DIFF
--- a/data-runners/bs-caa/main.py
+++ b/data-runners/bs-caa/main.py
@@ -3,8 +3,9 @@
 SkyFollower Bahamas CAA Data Runner
 
 Downloads the Civil Aviation Authority of the Bahamas (CAA) aircraft register PDF,
-parses aircraft data, and deep-merges enrichment records into Redis using the ICAO
-hex resolved via RediSearch (Mode S address is not published in this register).
+parses aircraft data, and writes enrichment records to aircraft:detail:{icao_hex} keys
+in Redis. ICAO hex is resolved via a RediSearch lookup against the Mictronics
+aircraft:simple index (Mode S address is not published in this register).
 
 The Bahamas register contains only owner name, registration, combined make/model,
 and serial number. No manufacturer, type designator, or powerplant data is available.
@@ -40,7 +41,12 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
-from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+from shared.redis_keys import (
+    AIRCRAFT_DETAIL_SEARCH_INDEX,
+    AIRCRAFT_SIMPLE_SEARCH_INDEX,
+    aircraft_detail_key,
+    aircraft_simple_key,
+)
 
 logger = logging.getLogger("bs-caa")
 
@@ -161,27 +167,12 @@ def _build_record(icao_hex: str, registration: str, row: dict) -> dict:
     if owner:
         registrant_fields["names"] = [owner]
 
-    record: dict = {"icao_hex": icao_hex, "registration": registration}
+    record: dict = {"icao_hex": icao_hex, "registration": registration, "source": "bs-caa"}
     if aircraft_fields:
         record["aircraft"] = aircraft_fields
     if registrant_fields:
         record["registrant"] = registrant_fields
     return record
-
-
-# ---------------------------------------------------------------------------
-# Deep merge
-# ---------------------------------------------------------------------------
-
-def _deep_merge(base: dict, update: dict) -> dict:
-    """Merge update into base. update values win; nested dicts merged recursively."""
-    result = dict(base)
-    for k, v in update.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-            result[k] = _deep_merge(result[k], v)
-        else:
-            result[k] = v
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -200,22 +191,48 @@ def _escape_tag(value: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Type sanity helpers
+# ---------------------------------------------------------------------------
+
+_TYPE_TOKEN_RE = re.compile(r'[A-Z]{1,4}\d{2,4}')
+
+
+def _type_tokens(model_str: str) -> set:
+    return {t.split('-')[0] for t in _TYPE_TOKEN_RE.findall(model_str.upper())}
+
+
+def _type_check_passes(simple_record: dict, detail_model_str: str) -> bool:
+    if not detail_model_str:
+        return True
+    simple_tokens = _type_tokens(
+        (simple_record.get("type_designator") or "") + " " +
+        (simple_record.get("manufacturer_model") or "")
+    )
+    if not simple_tokens:
+        return True
+    detail_tokens = _type_tokens(detail_model_str)
+    if not detail_tokens:
+        return True
+    return bool(simple_tokens & detail_tokens)
+
+
+# ---------------------------------------------------------------------------
 # Search index
 # ---------------------------------------------------------------------------
 
 def _ensure_search_index(r: redis_lib.Redis) -> None:
-    """Create the aircraft JSON search index if it does not already exist."""
+    """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -237,13 +254,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                hex_val = doc.id.replace("icao_hex:", "")
+                hex_val = doc.id.replace("aircraft:simple:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = hex_val
@@ -258,7 +275,7 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
 # ---------------------------------------------------------------------------
 
 def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
-    """Enrich existing Redis records with Bahamas CAA data. Returns count of records written."""
+    """Write Bahamas CAA data to aircraft:detail keys in Redis. Returns count of records written."""
     reg_row_map: dict[str, dict] = {}
     for row in rows:
         reg = row.get("AIRCRAFT REGISTRATION NUMBER", "").strip()
@@ -277,30 +294,33 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     )
 
     count = 0
-    batch: list[tuple[str, dict]] = []
-
-    def _flush() -> None:
-        keys = [k for k, _ in batch]
-        existing_list = r.json().mget(keys, "$")
-        pipe = r.pipeline()
-        for (key, new_record), existing_raw in zip(batch, existing_list):
-            merged = _deep_merge(existing_raw[0], new_record) if existing_raw else new_record
-            pipe.json().set(key, "$", merged)
-            pipe.expire(key, ttl)
-        pipe.execute()
+    pipe = r.pipeline()
+    pipe_count = 0
 
     for registration, hex_val in reg_icao_map.items():
         row = reg_row_map[registration]
+        make_model = row.get("AIRCRAFT TYPE - MAKE/MODEL", "").strip()
+
+        simple_raw = r.json().get(aircraft_simple_key(hex_val))
+        if not simple_raw or not _type_check_passes(simple_raw, make_model):
+            logger.debug("Type sanity check failed for %s, skipping", registration)
+            continue
+
         record = _build_record(hex_val, registration, row)
-        batch.append((icao_hex_key(hex_val), record))
+        key = aircraft_detail_key(hex_val)
+        pipe.json().set(key, "$", record)
+        pipe.expire(key, ttl)
         count += 1
-        if len(batch) == 10000:
-            _flush()
-            batch.clear()
+        pipe_count += 1
+
+        if pipe_count >= 10000:
+            pipe.execute()
+            pipe = r.pipeline()
+            pipe_count = 0
             logger.info("  ... %d records written.", count)
 
-    if batch:
-        _flush()
+    if pipe_count:
+        pipe.execute()
 
     logger.info("Finished writing %d records to Redis.", count)
     return count


### PR DESCRIPTION
## Summary

- Switch RediSearch lookup from `idx:aircraft` to `idx:aircraft:simple` (`AIRCRAFT_SIMPLE_SEARCH_INDEX`) so registration → icao_hex resolution uses the Mictronics key space
- After resolving icao_hex, fetch `aircraft:simple:{icao_hex}` and run a type sanity check comparing the bs-caa make/model string against the simple record's `type_designator`/`manufacturer_model` fields; skip the aircraft if the check fails
- Write output to `aircraft:detail:{icao_hex}` via `aircraft_detail_key()` instead of the deprecated `icao_hex:` key space
- Remove the read-before-write deep-merge pattern; writes are now fire-and-forget
- Add `"source": "bs-caa"` to every record written to Redis
- Update `_ensure_search_index` to create/check `AIRCRAFT_DETAIL_SEARCH_INDEX` (`idx:aircraft:detail`) with prefix `aircraft:detail:`
- Remove deprecated `AIRCRAFT_SEARCH_INDEX`, `icao_hex_key`, and `_deep_merge` imports/helpers

Closes #111

## Test plan

- [ ] No automated tests exist for this runner yet — code change only
- [ ] Verify `_type_check_passes` logic: empty model string always returns True; model tokens with no overlap return False; matching tokens return True
- [ ] Confirm imports resolve correctly against `shared/redis_keys.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)