### PR TITLE
ch-bazl: write to aircraft:detail, remove deep-merge, add search index

### DIFF
--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -27,8 +27,10 @@ from typing import Optional
 import paho.mqtt.client as mqtt
 import redis as redis_lib
 import requests
+from redis.commands.search.field import TagField
+from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import icao_hex_key
+from shared.redis_keys import aircraft_detail_key, AIRCRAFT_DETAIL_SEARCH_INDEX
 
 logger = logging.getLogger("ch-bazl")
 
@@ -233,21 +235,6 @@ def _build_record(row: dict) -> Optional[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Record merge
-# ---------------------------------------------------------------------------
-
-def _deep_merge(base: dict, update: dict) -> dict:
-    """Merge update into base. update values win; nested dicts merged recursively."""
-    result = dict(base)
-    for k, v in update.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-            result[k] = _deep_merge(result[k], v)
-        else:
-            result[k] = v
-    return result
-
-
-# ---------------------------------------------------------------------------
 # Redis writer
 # ---------------------------------------------------------------------------
 
@@ -271,12 +258,10 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             errors += 1
             continue
 
-        key = icao_hex_key(record["icao_hex"])
+        record["source"] = "ch-bazl"
+        key = aircraft_detail_key(record["icao_hex"])
         try:
-            existing_list = r.json().mget([key], "$")
-            existing_raw = existing_list[0] if existing_list else None
-            merged = _deep_merge(existing_raw[0], record) if existing_raw else record
-            r.json().set(key, "$", merged)
+            r.json().set(key, "$", record)
             r.expire(key, ttl)
             count += 1
         except Exception as exc:
@@ -289,6 +274,25 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
 
     logger.info("Finished: %d written, %d skipped, %d errors.", count, skipped, errors)
     return count
+
+
+# ---------------------------------------------------------------------------
+# Search index
+# ---------------------------------------------------------------------------
+
+def _ensure_search_index(r: redis_lib.Redis) -> None:
+    """Create the aircraft:detail JSON search index if it does not already exist."""
+    try:
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+    except Exception:
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+            fields=[
+                TagField("$.icao_hex", as_name="icao_hex"),
+                TagField("$.registration", as_name="registration"),
+            ],
+            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+        )
+        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -410,6 +414,7 @@ def main() -> None:
         port=rc.get("port", 6379),
         decode_responses=True,
     )
+    _ensure_search_index(r)
 
     ttl_days = cfg.get("redis_ttl_days", 14)
     ttl = ttl_days * 86400

--- a/data-runners/ch-bazl/tests/test_ch_bazl.py
+++ b/data-runners/ch-bazl/tests/test_ch_bazl.py
@@ -43,7 +43,7 @@ _parse_seats = _mod._parse_seats
 _parse_engine_model = _mod._parse_engine_model
 _parse_registrant = _mod._parse_registrant
 _build_record = _mod._build_record
-_deep_merge = _mod._deep_merge
+_ensure_search_index = _mod._ensure_search_index
 write_to_redis = _mod.write_to_redis
 publish_completion_stats = _mod.publish_completion_stats
 REDIS_TTL = _mod.REDIS_TTL
@@ -86,13 +86,8 @@ def _make_row(
     }
 
 
-def _make_redis(existing=None):
-    r = MagicMock()
-    # r.json().mget([key], "$") returns [[dict]] when key exists, [None] otherwise
-    mget_result = [[existing]] if existing is not None else [None]
-    r.json.return_value.mget.return_value = mget_result
-    r.json.return_value.get.return_value = None
-    return r
+def _make_redis():
+    return MagicMock()
 
 
 # ---------------------------------------------------------------------------
@@ -354,30 +349,6 @@ class TestBuildRecord:
 
 
 # ---------------------------------------------------------------------------
-# Tests: _deep_merge
-# ---------------------------------------------------------------------------
-
-class TestDeepMerge:
-    def test_update_wins_on_flat_key(self):
-        result = _deep_merge({"a": 1}, {"a": 2})
-        assert result["a"] == 2
-
-    def test_preserves_base_key_not_in_update(self):
-        result = _deep_merge({"a": 1, "b": 2}, {"a": 9})
-        assert result["b"] == 2
-
-    def test_nested_dicts_merged(self):
-        result = _deep_merge({"a": {"x": 1, "y": 2}}, {"a": {"y": 9}})
-        assert result["a"]["x"] == 1
-        assert result["a"]["y"] == 9
-
-    def test_base_not_mutated(self):
-        base = {"a": 1}
-        _deep_merge(base, {"a": 2})
-        assert base["a"] == 1
-
-
-# ---------------------------------------------------------------------------
 # Tests: write_to_redis
 # ---------------------------------------------------------------------------
 
@@ -402,7 +373,7 @@ class TestWriteToRedis:
         r = _make_redis()
         write_to_redis([_make_row(icao_hex="4B1916")], r, REDIS_TTL)
         key = r.json.return_value.set.call_args.args[0]
-        assert key == "icao_hex:4B1916"
+        assert key == "aircraft:detail:4B1916"
 
     def test_uses_root_json_path(self):
         r = _make_redis()
@@ -412,15 +383,13 @@ class TestWriteToRedis:
     def test_sets_ttl(self):
         r = _make_redis()
         write_to_redis([_make_row()], r, REDIS_TTL)
-        r.expire.assert_called_once_with("icao_hex:4B1916", REDIS_TTL)
+        r.expire.assert_called_once_with("aircraft:detail:4B1916", REDIS_TTL)
 
-    def test_merges_with_existing(self):
-        existing = {"icao_hex": "4B1916", "military": False}
-        r = _make_redis(existing=existing)
+    def test_source_field_set(self):
+        r = _make_redis()
         write_to_redis([_make_row()], r, REDIS_TTL)
         written = r.json.return_value.set.call_args.args[2]
-        assert written["military"] is False
-        assert written["registration"] == "HB-JNA"
+        assert written["source"] == "ch-bazl"
 
     def test_invalid_row_counts_as_error(self):
         r = _make_redis()
@@ -441,7 +410,33 @@ class TestWriteToRedis:
         r = _make_redis()
         write_to_redis([_make_row(icao_hex="4b1916")], r, REDIS_TTL)
         key = r.json.return_value.set.call_args.args[0]
-        assert key == "icao_hex:4B1916"
+        assert key == "aircraft:detail:4B1916"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _ensure_search_index
+# ---------------------------------------------------------------------------
+
+class TestEnsureSearchIndex:
+    def test_skips_create_when_index_exists(self):
+        r = MagicMock()
+        r.ft.return_value.info.return_value = {"index_name": "idx:aircraft:detail"}
+        _ensure_search_index(r)
+        r.ft.return_value.create_index.assert_not_called()
+
+    def test_creates_index_when_missing(self):
+        r = MagicMock()
+        r.ft.return_value.info.side_effect = Exception("Unknown index name")
+        _ensure_search_index(r)
+        r.ft.return_value.create_index.assert_called_once()
+
+    def test_create_index_uses_correct_prefix(self):
+        r = MagicMock()
+        r.ft.return_value.info.side_effect = Exception("Unknown index name")
+        _ensure_search_index(r)
+        call_kwargs = r.ft.return_value.create_index.call_args.kwargs
+        definition = call_kwargs["definition"]
+        assert "aircraft:detail:" in definition.args
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Migrates `data-runners/ch-bazl/main.py` from the deprecated `icao_hex:{hex}` Redis key to `aircraft:detail:{hex}` via `aircraft_detail_key()`
- Removes the read-before-write deep-merge pattern; each run now fire-and-forgets the full fresh record
- Stamps every written record with `"source": "ch-bazl"`
- Adds `_ensure_search_index()` that creates `AIRCRAFT_DETAIL_SEARCH_INDEX` (`idx:aircraft:detail`) with prefix `aircraft:detail:` on startup, indexing `$.icao_hex` and `$.registration` as TagFields
- Updates tests: removes `TestDeepMerge` and merge-related assertions; adds `TestEnsureSearchIndex` and `test_source_field_set`; all 80 tests pass

Closes #105

## Test plan

- [x] Run `cd data-runners/ch-bazl && python3 -m pytest tests/ -v` — all 80 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)