### PR TITLE
uk-caa: write to aircraft:detail, update SCAN pattern to aircraft:simple:4*

### DIFF
--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -6,15 +6,15 @@ Uses the UK CAA G-INFO REST API to enrich aircraft records already loaded
 by the Mictronics runner.  For each G-registered aircraft found in Redis
 the runner:
 
-  1. Scans Redis for icao_hex: keys in the UK ICAO hex range (400000-43FFFF).
+  1. Scans Redis for aircraft:simple: keys in the UK ICAO hex range (400000-43FFFF).
   2. Filters for records whose registration field starts with "G-".
   3. POSTs to /api/aircraft/search with the registration suffix to resolve the
      internal AircraftID.
   4. GETs /api/aircraft/details/{AircraftID} for the full payload.
-  5. Deep-merges the enrichment into the existing icao_hex:{hex} JSON key.
+  5. Writes the enrichment record to aircraft:detail:{hex} (fire-and-forget).
 
-Important: this runner can only enrich records that already exist in Redis
-(populated by the Mictronics runner).  Schedule it AFTER Mictronics.
+Important: this runner discovers aircraft via the Mictronics aircraft:simple:
+records.  Schedule it AFTER Mictronics.
 
 API base: https://ginfoapi.caa.co.uk  (no authentication required)
 """
@@ -38,7 +38,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_SEARCH_INDEX, icao_hex_key
+from shared.redis_keys import (
+    AIRCRAFT_DETAIL_SEARCH_INDEX,
+    AIRCRAFT_SIMPLE_SEARCH_INDEX,
+    aircraft_detail_key,
+)
 
 logger = logging.getLogger("uk-caa")
 
@@ -64,7 +68,7 @@ _UK_CAA_POWERPLANT_FIELDS = [
     "$.powerplant.count",
     "$.powerplant.model",
 ]
-_UK_ICAO_SCAN_PATTERN = "icao_hex:4[0123]*"
+_UK_ICAO_SCAN_PATTERN = "aircraft:simple:4[0123]*"
 
 # Batch size for JSON mget calls when scanning Redis
 _SCAN_BATCH_SIZE = 500
@@ -181,7 +185,7 @@ def _parse_year_built(year: Optional[int]) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 def _build_record(details: dict) -> Optional[dict]:
-    """Build the icao_hex:{hex} enrichment record from a G-INFO details payload."""
+    """Build the aircraft:detail:{hex} enrichment record from a G-INFO details payload."""
     aircraft_details = details.get("AircraftDetails", {})
 
     icao_addr = aircraft_details.get("ICAO24BitAircraftAddress") or {}
@@ -271,18 +275,18 @@ def _deep_merge(base: dict, update: dict) -> dict:
 # ---------------------------------------------------------------------------
 
 def _ensure_search_index(r: redis_lib.Redis) -> None:
-    """Create the aircraft JSON search index if it does not already exist."""
+    """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["icao_hex:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -305,7 +309,7 @@ def get_uk_registrations(r: redis_lib.Redis) -> list[tuple[str, str, Optional[in
 
     def _flush_batch() -> None:
         reg_lists = r.json().mget(batch, "$.registration")
-        g_keys: list[str] = []
+        g_detail_keys: list[str] = []
         g_regs: list[str] = []
         g_hexes: list[str] = []
         for key, reg_list in zip(batch, reg_lists):
@@ -313,13 +317,13 @@ def get_uk_registrations(r: redis_lib.Redis) -> list[tuple[str, str, Optional[in
                 continue
             reg = reg_list[0]
             if reg and str(reg).upper().startswith("G-"):
-                hex_val = key[len("icao_hex:"):]
-                g_keys.append(key)
+                hex_val = key[len("aircraft:simple:"):]
+                g_detail_keys.append(aircraft_detail_key(hex_val))
                 g_regs.append(str(reg).upper())
                 g_hexes.append(hex_val.upper())
 
-        if g_keys:
-            fk_lists = r.json().mget(g_keys, '$["foreign_key"]')
+        if g_detail_keys:
+            fk_lists = r.json().mget(g_detail_keys, '$["foreign_key"]')
             for reg, hex_val, fk_list in zip(g_regs, g_hexes, fk_lists):
                 fk = fk_list[0] if fk_list else None
                 results.append((reg, hex_val, fk))
@@ -419,7 +423,7 @@ def _cleanup_stale_record(r: redis_lib.Redis, icao_hex: str) -> None:
     no longer exists in G-INFO.  Parent objects (aircraft, powerplant) are
     deleted only if no other fields remain after cleanup.
     """
-    key = icao_hex_key(icao_hex)
+    key = aircraft_detail_key(icao_hex)
     for path in ["$.foreign_key", "$.registrant"] + _UK_CAA_AIRCRAFT_FIELDS + _UK_CAA_POWERPLANT_FIELDS:
         try:
             r.json().delete(key, path)
@@ -542,7 +546,7 @@ def write_to_redis(
                     icao_hex_from_redis, registration, aircraft_id, exc,
                 )
                 try:
-                    r.json().set(icao_hex_key(icao_hex_from_redis), "$.foreign_key", aircraft_id)
+                    r.json().set(aircraft_detail_key(icao_hex_from_redis), "$.foreign_key", aircraft_id)
                 except Exception:
                     pass
                 errors += 1
@@ -568,12 +572,10 @@ def write_to_redis(
             continue
 
         record["foreign_key"] = aircraft_id
+        record["source"] = "uk-caa"
 
-        key = icao_hex_key(icao_hex_from_redis)
-        existing_list = r.json().mget([key], "$")
-        existing_raw = existing_list[0] if existing_list else None
-        merged = _deep_merge(existing_raw[0], record) if existing_raw else record
-        r.json().set(key, "$", merged)
+        key = aircraft_detail_key(icao_hex_from_redis)
+        r.json().set(key, "$", record)
         r.expire(key, ttl)
         count += 1
 

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -385,8 +385,8 @@ class TestGetUkRegistrations:
 
     def test_returns_g_registrations(self):
         r = self._make_redis(
-            ["icao_hex:406B48"],
-            {"icao_hex:406B48": "G-VAHH"},
+            ["aircraft:simple:406B48"],
+            {"aircraft:simple:406B48": "G-VAHH"},
         )
         results = get_uk_registrations(r)
         regs = [reg for reg, _, _ in results]
@@ -394,8 +394,8 @@ class TestGetUkRegistrations:
 
     def test_filters_non_g_registrations(self):
         r = self._make_redis(
-            ["icao_hex:406B48", "icao_hex:400001"],
-            {"icao_hex:406B48": "N12345", "icao_hex:400001": "G-ABCD"},
+            ["aircraft:simple:406B48", "aircraft:simple:400001"],
+            {"aircraft:simple:406B48": "N12345", "aircraft:simple:400001": "G-ABCD"},
         )
         results = get_uk_registrations(r)
         regs = [reg for reg, _, _ in results]
@@ -404,43 +404,43 @@ class TestGetUkRegistrations:
 
     def test_icao_hex_uppercased(self):
         r = self._make_redis(
-            ["icao_hex:406b48"],
-            {"icao_hex:406b48": "G-VAHH"},
+            ["aircraft:simple:406b48"],
+            {"aircraft:simple:406b48": "G-VAHH"},
         )
         results = get_uk_registrations(r)
         assert results[0][1] == "406B48"
 
     def test_registration_uppercased(self):
         r = self._make_redis(
-            ["icao_hex:406B48"],
-            {"icao_hex:406B48": "g-vahh"},
+            ["aircraft:simple:406B48"],
+            {"aircraft:simple:406B48": "g-vahh"},
         )
         results = get_uk_registrations(r)
         assert results[0][0] == "G-VAHH"
 
     def test_missing_registration_skipped(self):
-        r = self._make_redis(["icao_hex:406B48"], {})
+        r = self._make_redis(["aircraft:simple:406B48"], {})
         results = get_uk_registrations(r)
         assert results == []
 
     def test_uses_uk_icao_scan_pattern(self):
         r = self._make_redis([], {})
         get_uk_registrations(r)
-        r.scan_iter.assert_called_once_with("icao_hex:4[0123]*")
+        r.scan_iter.assert_called_once_with("aircraft:simple:4[0123]*")
 
     def test_returns_cached_foreign_key(self):
         r = self._make_redis(
-            ["icao_hex:406B48"],
-            {"icao_hex:406B48": "G-VAHH"},
-            fk_map={"icao_hex:406B48": 66819},
+            ["aircraft:simple:406B48"],
+            {"aircraft:simple:406B48": "G-VAHH"},
+            fk_map={"aircraft:detail:406B48": 66819},
         )
         results = get_uk_registrations(r)
         assert results[0][2] == 66819
 
     def test_returns_none_foreign_key_when_absent(self):
         r = self._make_redis(
-            ["icao_hex:406B48"],
-            {"icao_hex:406B48": "G-VAHH"},
+            ["aircraft:simple:406B48"],
+            {"aircraft:simple:406B48": "G-VAHH"},
         )
         results = get_uk_registrations(r)
         assert results[0][2] is None
@@ -588,7 +588,7 @@ class TestWriteToRedis:
         with patch("time.sleep"):
             write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
         key_arg = r.json.return_value.set.call_args.args[0]
-        assert key_arg == "icao_hex:406B48"
+        assert key_arg == "aircraft:detail:406B48"
 
     def test_slow_path_json_set_uses_root_path(self):
         r = self._make_redis()
@@ -602,18 +602,22 @@ class TestWriteToRedis:
         session = self._make_session(_make_details())
         with patch("time.sleep"):
             write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
-        r.expire.assert_called_once_with("icao_hex:406B48", REDIS_TTL)
+        r.expire.assert_called_once_with("aircraft:detail:406B48", REDIS_TTL)
 
-    def test_slow_path_merges_with_existing(self):
-        existing = {"icao_hex": "406B48", "military": False, "aircraft": {"wake_turbulence_category": "Heavy"}}
-        r = self._make_redis(existing=existing)
+    def test_slow_path_writes_source_field(self):
+        r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
             write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
         written = r.json.return_value.set.call_args.args[2]
-        assert written["military"] is False
-        assert written["aircraft"]["wake_turbulence_category"] == "Heavy"
-        assert written["aircraft"]["manufacturer"] == "BOEING COMPANY"
+        assert written["source"] == "uk-caa"
+
+    def test_slow_path_fire_and_forget_no_mget(self):
+        r = self._make_redis()
+        session = self._make_session(_make_details())
+        with patch("time.sleep"):
+            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
+        r.json.return_value.mget.assert_not_called()
 
     def test_slow_path_searches_by_icao_hex(self):
         r = self._make_redis()
@@ -689,7 +693,7 @@ class TestWriteToRedis:
             count = write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
 
         assert count == 0
-        r.json.return_value.set.assert_called_once_with("icao_hex:406B48", "$.foreign_key", 66819)
+        r.json.return_value.set.assert_called_once_with("aircraft:detail:406B48", "$.foreign_key", 66819)
 
     # ------------------------------------------------------------------
     # Fast path (cached foreign_key)


### PR DESCRIPTION
## Summary
- SCAN pattern updated from `icao_hex:4[0123]*` to `aircraft:simple:4[0123]*` — runner now discovers UK aircraft via Mictronics simple records
- Write key changed from `icao_hex:{hex}` to `aircraft:detail:{hex}` via `aircraft_detail_key()` (fire-and-forget, no read-merge)
- FK cache lookup reads from `aircraft:detail:` keys (where uk-caa writes)
- `_ensure_search_index` updated to `AIRCRAFT_DETAIL_SEARCH_INDEX` with `aircraft:detail:` prefix
- `source: "uk-caa"` added to every record written to Redis
- Imports updated: `aircraft_detail_key`, `AIRCRAFT_DETAIL_SEARCH_INDEX`, `AIRCRAFT_SIMPLE_SEARCH_INDEX`; removed `icao_hex_key` and `AIRCRAFT_SEARCH_INDEX`

## Test plan
- [ ] All 97 existing tests pass with no failures
- [ ] `test_uses_uk_icao_scan_pattern` verifies new `aircraft:simple:4[0123]*` pattern
- [ ] `test_slow_path_json_set_correct_key` verifies write goes to `aircraft:detail:406B48`
- [ ] `test_slow_path_writes_source_field` verifies `"source": "uk-caa"` in written record
- [ ] `test_slow_path_fire_and_forget_no_mget` verifies no read before write
- [ ] `test_returns_cached_foreign_key` verifies FK read from `aircraft:detail:` key

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)