### PR TITLE
ch-bazl: add engine manufacturer, operator, crew seats, fix registrant name parse

### DIFF
--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -235,7 +235,6 @@ def _build_record(row: dict) -> Optional[dict]:
         powerplant_fields["model"] = engine_model
 
     registrant = _parse_registrant(row.get(" Main Owner", ""))
-    operator = _parse_registrant(row.get(" Main Operator", ""))
 
     record: dict = {"icao_hex": raw_hex, "registration": registration}
     if aircraft_fields:
@@ -244,8 +243,6 @@ def _build_record(row: dict) -> Optional[dict]:
         record["powerplant"] = powerplant_fields
     if registrant:
         record["registrant"] = registrant
-    if operator:
-        record["operator"] = operator
 
     return record
 

--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -264,8 +264,8 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             skipped += 1
             continue
 
-        raw_hex = row.get(" Aircraft Address HEX", "").strip()
-        if not raw_hex:
+        raw_hex = row.get(" Aircraft Address HEX", "").strip().upper()
+        if not raw_hex or len(raw_hex) != 6 or not all(c in "0123456789ABCDEF" for c in raw_hex):
             registration = row.get(" Registration", "?").strip()
             logger.warning("Skipping %s — no ICAO hex assigned.", registration)
             skipped += 1

--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -85,6 +85,7 @@ def download_register(session: requests.Session) -> list[dict]:
             "aircraftStatus": ["Registered"],
         },
     }
+    logger.info("Downloading from %s", API_URL)
     response = session.post(API_URL, json=payload)
     response.raise_for_status()
 
@@ -130,9 +131,10 @@ def _parse_engine_model(raw: str) -> Optional[str]:
 
 
 def _parse_registrant(raw: str) -> Optional[dict]:
-    """Best-effort parse of BAZL's unstructured owner address string.
+    """Best-effort parse of BAZL's unstructured owner/operator address string.
 
     Format: Name[, Canton]?, Street, PostalCode City, Switzerland
+    When no street is present: Name[, Canton]?, PostalCode City, Switzerland
     """
     if not raw or raw.strip() in ("", "N/A", "-"):
         return None
@@ -155,11 +157,17 @@ def _parse_registrant(raw: str) -> Optional[dict]:
         postal_code = postal_city[:4]
         city = postal_city[5:].strip() or None
 
-    if parts:
-        street = parts.pop()
+    # Strip canton abbreviations from remaining parts
+    non_canton = [p for p in parts if not _CANTON_RE.match(p)]
 
-    # Remaining parts are the name; strip 2-letter canton abbreviations
-    name_parts = [p for p in parts if not _CANTON_RE.match(p)]
+    # Only treat the last part as street when 2+ non-canton parts remain;
+    # if only 1 remains it is the name (no street line in this record)
+    if len(non_canton) >= 2:
+        street = non_canton[-1]
+        name_parts = non_canton[:-1]
+    else:
+        name_parts = non_canton
+
     name = ", ".join(name_parts) if name_parts else None
 
     fields: dict = {}
@@ -209,7 +217,9 @@ def _build_record(row: dict) -> Optional[dict]:
     serial_number = row.get(" Serial Number", "").strip()
     if serial_number:
         aircraft_fields["serial_number"] = serial_number
-    seats = _parse_seats(row.get(" MOPSC", ""))
+    mopsc = _parse_seats(row.get(" MOPSC", ""))
+    crew = _parse_seats(row.get(" Minimum Crew", ""))
+    seats = (mopsc or 0) + (crew or 0) if (mopsc is not None or crew is not None) else None
     if seats is not None:
         aircraft_fields["seats"] = seats
 
@@ -217,11 +227,15 @@ def _build_record(row: dict) -> Optional[dict]:
     engine_type = _decode_engine_type(row.get(" Engine Category", ""))
     if engine_type:
         powerplant_fields["type"] = engine_type
+    engine_manufacturer = row.get(" Engine manufacturer", "").strip()
+    if engine_manufacturer:
+        powerplant_fields["manufacturer"] = engine_manufacturer
     engine_model = _parse_engine_model(row.get(" Engine", ""))
     if engine_model:
         powerplant_fields["model"] = engine_model
 
     registrant = _parse_registrant(row.get(" Main Owner", ""))
+    operator = _parse_registrant(row.get(" Main Operator", ""))
 
     record: dict = {"icao_hex": raw_hex, "registration": registration}
     if aircraft_fields:
@@ -230,6 +244,8 @@ def _build_record(row: dict) -> Optional[dict]:
         record["powerplant"] = powerplant_fields
     if registrant:
         record["registrant"] = registrant
+    if operator:
+        record["operator"] = operator
 
     return record
 

--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -264,6 +264,13 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             skipped += 1
             continue
 
+        raw_hex = row.get(" Aircraft Address HEX", "").strip()
+        if not raw_hex:
+            registration = row.get(" Registration", "?").strip()
+            logger.warning("Skipping %s — no ICAO hex assigned.", registration)
+            skipped += 1
+            continue
+
         record = _build_record(row)
         if record is None:
             registration = row.get(" Registration", "?").strip()

--- a/data-runners/ch-bazl/tests/test_ch_bazl.py
+++ b/data-runners/ch-bazl/tests/test_ch_bazl.py
@@ -385,15 +385,6 @@ class TestBuildRecord:
         record = _build_record(_make_row())
         assert record["registrant"]["names"] == ["Swiss International Air Lines Ltd."]
 
-    def test_operator_populated(self):
-        record = _build_record(_make_row(
-            operator="Edelweiss Air AG, 8058 Zürich-Flughafen, Switzerland"
-        ))
-        assert record["operator"]["names"] == ["Edelweiss Air AG"]
-
-    def test_operator_absent_when_empty(self):
-        record = _build_record(_make_row(operator=""))
-        assert "operator" not in record
 
     def test_short_hex_returns_none(self):
         assert _build_record(_make_row(icao_hex="4B19")) is None

--- a/data-runners/ch-bazl/tests/test_ch_bazl.py
+++ b/data-runners/ch-bazl/tests/test_ch_bazl.py
@@ -65,9 +65,12 @@ def _make_row(
     year="2016",
     serial="44582",
     mopsc="320",
+    minimum_crew="2",
     engine_category="Jet Engine",
+    engine_manufacturer="GE AVIATION",
     engine="GE90-115BL",
     owner="Swiss International Air Lines Ltd., Obstgartenstrasse 25, 8302 Kloten, Switzerland",
+    operator="Swiss International Air Lines Ltd., Obstgartenstrasse 25, 8302 Kloten, Switzerland",
 ) -> dict:
     return {
         " Registration": registration,
@@ -80,9 +83,12 @@ def _make_row(
         " Year of Manufacture": year,
         " Serial Number": serial,
         " MOPSC": mopsc,
+        " Minimum Crew": minimum_crew,
         " Engine Category": engine_category,
+        " Engine manufacturer": engine_manufacturer,
         " Engine": engine,
         " Main Owner": owner,
+        " Main Operator": operator,
     }
 
 
@@ -238,6 +244,28 @@ class TestParseEngineModel:
 
 
 # ---------------------------------------------------------------------------
+# Tests: download_register URL logging
+# ---------------------------------------------------------------------------
+
+class TestDownloadRegisterLogging:
+    def test_logs_api_url(self):
+        mock_response = MagicMock()
+        mock_response.content = (
+            " Registration; Aircraft Address HEX; Status\r\n"
+        ).encode("utf-16")
+        mock_session = MagicMock()
+        mock_session.post.return_value = mock_response
+
+        with patch("ch_bazl_main.logger") as mock_logger:
+            try:
+                _mod.download_register(mock_session)
+            except Exception:
+                pass
+            logged_messages = [str(c) for c in mock_logger.info.call_args_list]
+            assert any(_mod.API_URL in msg for msg in logged_messages)
+
+
+# ---------------------------------------------------------------------------
 # Tests: _parse_registrant
 # ---------------------------------------------------------------------------
 
@@ -274,6 +302,14 @@ class TestParseRegistrant:
 
     def test_na_returns_none(self):
         assert _parse_registrant("N/A") is None
+
+    def test_name_only_no_street(self):
+        raw = "Edelweiss Air AG, 8058 Zürich-Flughafen, Switzerland"
+        result = _parse_registrant(raw)
+        assert result["names"] == ["Edelweiss Air AG"]
+        assert "street" not in result
+        assert result["postal_code"] == "8058"
+        assert result["city"] == "Zürich-Flughafen"
 
     def test_country_always_ch(self):
         raw = "Swiss International Air Lines Ltd., Obstgartenstrasse 25, 8302 Kloten, Switzerland"
@@ -317,13 +353,29 @@ class TestBuildRecord:
         record = _build_record(_make_row())
         assert record["aircraft"]["serial_number"] == "44582"
 
-    def test_seats(self):
-        record = _build_record(_make_row(mopsc="320"))
+    def test_seats_mopsc_plus_crew(self):
+        record = _build_record(_make_row(mopsc="3", minimum_crew="1"))
+        assert record["aircraft"]["seats"] == 4
+
+    def test_seats_mopsc_only_when_no_crew(self):
+        record = _build_record(_make_row(mopsc="320", minimum_crew=""))
         assert record["aircraft"]["seats"] == 320
+
+    def test_seats_none_when_both_empty(self):
+        record = _build_record(_make_row(mopsc="", minimum_crew=""))
+        assert "seats" not in record.get("aircraft", {})
 
     def test_engine_type(self):
         record = _build_record(_make_row(engine_category="Jet Engine"))
         assert record["powerplant"]["type"] == "Turbo-jet"
+
+    def test_engine_manufacturer(self):
+        record = _build_record(_make_row(engine_manufacturer="AVCO LYCOMING"))
+        assert record["powerplant"]["manufacturer"] == "AVCO LYCOMING"
+
+    def test_engine_manufacturer_absent_when_empty(self):
+        record = _build_record(_make_row(engine_manufacturer=""))
+        assert "manufacturer" not in record.get("powerplant", {})
 
     def test_engine_model(self):
         record = _build_record(_make_row(engine="GE90-115BL"))
@@ -333,6 +385,16 @@ class TestBuildRecord:
         record = _build_record(_make_row())
         assert record["registrant"]["names"] == ["Swiss International Air Lines Ltd."]
 
+    def test_operator_populated(self):
+        record = _build_record(_make_row(
+            operator="Edelweiss Air AG, 8058 Zürich-Flughafen, Switzerland"
+        ))
+        assert record["operator"]["names"] == ["Edelweiss Air AG"]
+
+    def test_operator_absent_when_empty(self):
+        record = _build_record(_make_row(operator=""))
+        assert "operator" not in record
+
     def test_short_hex_returns_none(self):
         assert _build_record(_make_row(icao_hex="4B19")) is None
 
@@ -340,11 +402,11 @@ class TestBuildRecord:
         assert _build_record(_make_row(registration="")) is None
 
     def test_no_engine_omits_powerplant(self):
-        record = _build_record(_make_row(engine_category="", engine=""))
+        record = _build_record(_make_row(engine_category="", engine_manufacturer="", engine=""))
         assert "powerplant" not in record
 
     def test_glider_no_engine_omits_powerplant(self):
-        record = _build_record(_make_row(aircraft_type="Glider", engine_category="", engine=""))
+        record = _build_record(_make_row(aircraft_type="Glider", engine_category="", engine_manufacturer="", engine=""))
         assert "powerplant" not in record
 
 

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -281,7 +281,7 @@ sources:
     url: "https://app02.bazl.admin.ch/web/bazl-backend/lfr/csv"
     format: api
     cadence: weekly_tuesday
-    notes: "Undocumented public REST API; no auth required; returns UTF-16 BE encoded semicolon-delimited CSV via POST with JSON body; single bulk download of all registered aircraft (~3,100 records); 'Main Owner' address is a single unstructured string parsed best-effort (Name[, Canton]?, Street, PostalCode City, Switzerland); canton abbreviation (2-letter) stripped from name; MOPSC = Maximum Operational Passenger Seating Configuration"
+    notes: "Undocumented public REST API; no auth required; returns UTF-16 BE encoded semicolon-delimited CSV via POST with JSON body; single bulk download of all registered aircraft (~3,100 records); 'Main Owner' address is a single unstructured string parsed best-effort (Name[, Canton]?, Street, PostalCode City, Switzerland); canton abbreviation (2-letter) stripped from name; when only one non-canton segment remains after extracting the postal line it is treated as the name (no street present); MOPSC = Maximum Operational Passenger Seating Configuration; seats = MOPSC + Minimum Crew; aircraft without a Mode S transponder have no ICAO hex in the registry and are skipped"
     endpoints:
       bulk:
         method: POST
@@ -637,7 +637,7 @@ records:
                 field: " Main Owner"
                 transform:
                   type: parse_address_name
-                  description: "Best-effort parse of 'Name[, Canton]?, Street, PostalCode City, Switzerland'; all comma-segments before the street; 2-letter canton abbreviations filtered out; wrapped in a one-element list"
+                  description: "Best-effort parse of 'Name[, Canton]?, Street, PostalCode City, Switzerland'; 2-letter canton abbreviations filtered out; if only one non-canton segment remains after extracting the postal line it is the name (no street); wrapped in a one-element list"
               - source: at-austrocontrol
                 endpoint: bulk
                 field: halter
@@ -1144,8 +1144,13 @@ records:
                 field: AircraftDetails.MaximumPassengers
               - source: ch-bazl
                 endpoint: bulk
-                field: " MOPSC"
-                description: "Maximum Operational Passenger Seating Configuration"
+                transform:
+                  type: sum
+                  fields:
+                    - field: " MOPSC"
+                      description: "Maximum Operational Passenger Seating Configuration"
+                    - field: " Minimum Crew"
+                      description: "Minimum required flight crew"
 
           category:
             type: string
@@ -1536,6 +1541,9 @@ records:
               - source: au-casa
                 file: acrftreg
                 field: Engmanu
+              - source: ch-bazl
+                endpoint: bulk
+                field: " Engine manufacturer"
 
           power_type:
             type: string


### PR DESCRIPTION
## Summary

- Logs `API_URL` at download time so the source endpoint is visible in container output
- Fixes `_parse_registrant`: when only one non-canton part remains after extracting the postal line, it is the name — not the street (e.g. `Edelweiss Air AG, 8058 Zürich-Flughafen, Switzerland` previously put the name in `street`)
- Parses `' Main Operator'` into `record["operator"]` using the same structure as `registrant`
- `seats` = MOPSC + Minimum Crew (adds crew seats to passenger count; e.g. HB-CLP: 3 + 1 = 4)
- Adds `powerplant.manufacturer` from `' Engine manufacturer'` column (previously not captured)

Closes #144

## Test plan
- [ ] Build: `docker build -t skyfollower-ch-bazl:local -f data-runners/ch-bazl/Dockerfile .`
- [ ] Run: `docker run --rm -v $(pwd)/config/runners/settings.local.json:/app/settings.json -v /tmp/ch-bazl-data:/app/data skyfollower-ch-bazl:local`
- [ ] Verify `aircraft:detail:4B0675` (HB-CLP): `seats=4`, `powerplant.manufacturer="AVCO LYCOMING"`
- [ ] Verify `aircraft:detail:4B1856` (HB-JFQ): `powerplant.manufacturer="PRATT & WHITNEY CANADA CORP."`
- [ ] Verify operator with postal-only address (e.g. Edelweiss Air AG) has name in `names`, not `street`

🤖 Generated with [Claude Code](https://claude.com/claude-code)