### PR TITLE
uk-caa: replace Redis SCAN with AA-ZZ registration enumeration

### DIFF
--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -2,19 +2,10 @@
 """
 SkyFollower United Kingdom CAA Data Runner
 
-Uses the UK CAA G-INFO REST API to enrich aircraft records already loaded
-by the Mictronics runner.  For each G-registered aircraft found in Redis
-the runner:
-
-  1. Scans Redis for aircraft:simple: keys in the UK ICAO hex range (400000-43FFFF).
-  2. Filters for records whose registration field starts with "G-".
-  3. POSTs to /api/aircraft/search with the registration suffix to resolve the
-     internal AircraftID.
-  4. GETs /api/aircraft/details/{AircraftID} for the full payload.
-  5. Writes the enrichment record to aircraft:detail:{hex} (fire-and-forget).
-
-Important: this runner discovers aircraft via the Mictronics aircraft:simple:
-records.  Schedule it AFTER Mictronics.
+Enumerates all G-registered aircraft via the UK CAA G-INFO REST API by
+iterating every 2-letter suffix combination AA-ZZ (676 calls total).
+For each aircraft returned with RegistrationStatus "R", calls the details
+endpoint to fetch the full payload and writes enrichment data to Redis.
 
 API base: https://ginfoapi.caa.co.uk  (no authentication required)
 """
@@ -27,6 +18,7 @@ import os
 import sys
 import time
 from datetime import datetime, timezone
+from itertools import product
 from typing import Optional
 
 import paho.mqtt.client as mqtt
@@ -40,7 +32,6 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import (
     AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
     aircraft_detail_key,
 )
 
@@ -50,28 +41,7 @@ API_BASE = "https://ginfoapi.caa.co.uk"
 REDIS_TTL = 14 * 86400
 MQTT_ROOT = "SkyFollower/runner/uk-caa"
 
-# Redis SCAN pattern covering UK ICAO hex range 400000-43FFFF.
-# Second hex digit 0-3 uniquely identifies the UK allocation block.
-
-# Fields written by this runner that must be removed when a 404 confirms the
-# aircraft record no longer exists in G-INFO.
-_UK_CAA_AIRCRAFT_FIELDS = [
-    "$.aircraft.type",
-    "$.aircraft.manufacturer",
-    "$.aircraft.model",
-    "$.aircraft.serial_number",
-    "$.aircraft.type_designator",
-    "$.aircraft.manufactured_date",
-    "$.aircraft.seats",
-]
-_UK_CAA_POWERPLANT_FIELDS = [
-    "$.powerplant.count",
-    "$.powerplant.model",
-]
-_UK_ICAO_SCAN_PATTERN = "aircraft:simple:4[0123]*"
-
-# Batch size for JSON mget calls when scanning Redis
-_SCAN_BATCH_SIZE = 500
+_LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 # ---------------------------------------------------------------------------
 # Decode tables
@@ -256,21 +226,6 @@ def _build_record(details: dict) -> Optional[dict]:
 
 
 # ---------------------------------------------------------------------------
-# Record merge
-# ---------------------------------------------------------------------------
-
-def _deep_merge(base: dict, update: dict) -> dict:
-    """Merge update into base. update values win; nested dicts are merged recursively."""
-    result = dict(base)
-    for k, v in update.items():
-        if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-            result[k] = _deep_merge(result[k], v)
-        else:
-            result[k] = v
-    return result
-
-
-# ---------------------------------------------------------------------------
 # Search index
 # ---------------------------------------------------------------------------
 
@@ -290,117 +245,21 @@ def _ensure_search_index(r: redis_lib.Redis) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Redis enumeration
-# ---------------------------------------------------------------------------
-
-def get_uk_registrations(r: redis_lib.Redis) -> list[tuple[str, str, Optional[int]]]:
-    """
-    Return (registration, icao_hex, foreign_key) triples for all G-registered
-    aircraft in Redis.
-
-    Scans icao_hex: keys in the UK ICAO hex range (400000-43FFFF), batch-fetches
-    the registration field and filters for the G- prefix, then fetches the cached
-    G-INFO AircraftID (foreign_key) for each matched record.
-
-    foreign_key is None when not yet cached.
-    """
-    results: list[tuple[str, str, Optional[int]]] = []
-    batch: list[str] = []
-
-    def _flush_batch() -> None:
-        reg_lists = r.json().mget(batch, "$.registration")
-        g_detail_keys: list[str] = []
-        g_regs: list[str] = []
-        g_hexes: list[str] = []
-        for key, reg_list in zip(batch, reg_lists):
-            if not reg_list:
-                continue
-            reg = reg_list[0]
-            if reg and str(reg).upper().startswith("G-"):
-                hex_val = key[len("aircraft:simple:"):]
-                g_detail_keys.append(aircraft_detail_key(hex_val))
-                g_regs.append(str(reg).upper())
-                g_hexes.append(hex_val.upper())
-
-        if g_detail_keys:
-            fk_lists = r.json().mget(g_detail_keys, '$["foreign_key"]')
-            for reg, hex_val, fk_list in zip(g_regs, g_hexes, fk_lists):
-                fk = fk_list[0] if fk_list else None
-                results.append((reg, hex_val, fk))
-
-        batch.clear()
-
-    scan_start = time.monotonic()
-    for key in r.scan_iter(_UK_ICAO_SCAN_PATTERN):
-        batch.append(key)
-        if len(batch) >= _SCAN_BATCH_SIZE:
-            _flush_batch()
-
-    if batch:
-        _flush_batch()
-
-    scan_elapsed = time.monotonic() - scan_start
-    logger.info(
-        "Found %d G-registered aircraft in Redis (scan completed in %.2fs).",
-        len(results), scan_elapsed,
-    )
-    return results
-
-
-# ---------------------------------------------------------------------------
 # G-INFO API
 # ---------------------------------------------------------------------------
 
-def _search_aircraft(session: requests.Session, icao_hex: str, expected_mark: str) -> Optional[int]:
-    """
-    POST /api/aircraft/search by ICAO hex address.
+def _search_by_prefix(session: requests.Session, prefix: str) -> list[dict]:
+    """POST /api/aircraft/search with a 2-letter registration prefix.
 
-    expected_mark is the registration suffix without 'G-' (e.g. 'VAHH').
-    When the API returns multiple results, filters by Mark and logs a warning.
-    Returns AircraftID of the matching result, or None if not found.
+    Returns the raw result list; may include non-registered aircraft.
     """
-    payload = {
-        "AircraftType": None,
-        "AOCHolder": None,
-        "ICAO24BitHex": icao_hex,
-        "ICAOAircraftTypeDesignator": None,
-        "MilitarySerialNumber": None,
-        "RegisteredOwner": None,
-        "Registration": None,
-        "SerialNumber": None,
-        "IncludeDeregistered": False,
-    }
     resp = session.post(
         f"{API_BASE}/api/aircraft/search",
-        json=payload,
+        json={"Registration": prefix},
         timeout=30,
     )
     resp.raise_for_status()
-    results = resp.json()
-    if not results:
-        return None
-
-    registered = [r for r in results if r.get("RegistrationStatus") == "R"]
-    if not registered:
-        logger.info("icao_hex=%s: all %d search result(s) have RegistrationStatus != R — skipping.",
-                    icao_hex, len(results))
-        return None
-
-    if len(registered) > 1:
-        logger.warning(
-            "Search for icao_hex=%s returned %d registered results — filtering by mark %s.",
-            icao_hex, len(registered), expected_mark,
-        )
-        matched = [r for r in registered if r.get("Mark", "").upper() == expected_mark.upper()]
-        if not matched:
-            logger.warning(
-                "No registered result matching mark %s for icao_hex=%s after filtering.",
-                expected_mark, icao_hex,
-            )
-            return None
-        registered = matched
-
-    return registered[0].get("AircraftID")
+    return resp.json() or []
 
 
 def _get_aircraft_details(session: requests.Session, aircraft_id: int) -> Optional[dict]:
@@ -413,29 +272,27 @@ def _get_aircraft_details(session: requests.Session, aircraft_id: int) -> Option
     return resp.json()
 
 
-# ---------------------------------------------------------------------------
-# Stale record cleanup
-# ---------------------------------------------------------------------------
+def enumerate_registrations(session: requests.Session, request_interval: float) -> list[int]:
+    """Return AircraftIDs for all G-registered aircraft via AA-ZZ enumeration.
 
-def _cleanup_stale_record(r: redis_lib.Redis, icao_hex: str) -> None:
+    Iterates all 676 2-letter suffix combinations, filtering on RegistrationStatus "R".
+    Errors on individual prefixes are logged and skipped; enumeration continues.
     """
-    Remove all fields written by this runner after a 404 confirms the aircraft
-    no longer exists in G-INFO.  Parent objects (aircraft, powerplant) are
-    deleted only if no other fields remain after cleanup.
-    """
-    key = aircraft_detail_key(icao_hex)
-    for path in ["$.foreign_key", "$.registrant"] + _UK_CAA_AIRCRAFT_FIELDS + _UK_CAA_POWERPLANT_FIELDS:
+    aircraft_ids: list[int] = []
+    for c1, c2 in product(_LETTERS, _LETTERS):
+        prefix = f"{c1}{c2}"
         try:
-            r.json().delete(key, path)
-        except Exception:
-            pass
-    for obj_path in ["$.aircraft", "$.powerplant"]:
-        try:
-            result = r.json().get(key, obj_path)
-            if result and result[0] == {}:
-                r.json().delete(key, obj_path)
-        except Exception:
-            pass
+            results = _search_by_prefix(session, prefix)
+            for result in results:
+                if result.get("RegistrationStatus") == "R":
+                    aid = result.get("AircraftID")
+                    if aid is not None:
+                        aircraft_ids.append(aid)
+        except Exception as exc:
+            logger.warning("Search error for prefix %s: %s", prefix, exc)
+        time.sleep(request_interval)
+    logger.info("Enumeration complete: found %d registered aircraft.", len(aircraft_ids))
+    return aircraft_ids
 
 
 # ---------------------------------------------------------------------------
@@ -443,149 +300,51 @@ def _cleanup_stale_record(r: redis_lib.Redis, icao_hex: str) -> None:
 # ---------------------------------------------------------------------------
 
 def write_to_redis(
-    registrations: list[tuple[str, str, Optional[int]]],
+    aircraft_ids: list[int],
     r: redis_lib.Redis,
     session: requests.Session,
     ttl: int,
     request_interval: float,
 ) -> int:
-    """
-    Enrich Redis records with UK CAA G-INFO data.
-
-    Fast path (foreign_key cached): calls GET /api/aircraft/details/{foreign_key}
-    directly and verifies the returned ICAO hex matches.  On any hard failure
-    (404, hex mismatch, non-Registered status) the stale record is cleaned up
-    and the aircraft is skipped.  403 is treated as transient — retry next run.
-
-    Slow path (no cache): POST /api/aircraft/search by ICAO hex to resolve
-    the AircraftID, then GET /api/aircraft/details/{id}.
-
-    The resolved AircraftID is always written back to Redis as foreign_key so
-    subsequent runs can use the fast path.
+    """Fetch details for each AircraftID and write enrichment records to Redis.
 
     Returns the count of records successfully written.
     """
     count = 0
-    not_found = 0
+    skipped = 0
     errors = 0
 
-    for registration, icao_hex_from_redis, cached_fk in registrations:
-        details = None
-        aircraft_id = None
-
-        if cached_fk is not None:
-            try:
-                time.sleep(request_interval)
-                details = _get_aircraft_details(session, cached_fk)
-                reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
-                if reg_status != "Registered":
-                    logger.info(
-                        "%s: RegistrationDetails.Status is %r — cleaning up stale uk-caa data.",
-                        registration, reg_status,
-                    )
-                    try:
-                        _cleanup_stale_record(r, icao_hex_from_redis)
-                    except Exception as exc:
-                        logger.warning("Cleanup failed for %s: %s", icao_hex_from_redis, exc)
-                    continue
-                aircraft_details = details.get("AircraftDetails", {})
-                returned_hex = ((aircraft_details.get("ICAO24BitAircraftAddress") or {}).get("Hex") or "").strip().upper()
-                if returned_hex != icao_hex_from_redis.upper():
-                    logger.info(
-                        "%s: foreign_key %d hex mismatch (got %s, expected %s)"
-                        " — cleaning up stale uk-caa data.",
-                        registration, cached_fk, returned_hex, icao_hex_from_redis.upper(),
-                    )
-                    try:
-                        _cleanup_stale_record(r, icao_hex_from_redis)
-                    except Exception as exc:
-                        logger.warning("Cleanup failed for %s: %s", icao_hex_from_redis, exc)
-                    continue
-                aircraft_id = cached_fk
-            except requests.HTTPError as exc:
-                status = exc.response.status_code if exc.response is not None else None
-                if status == 403:
-                    logger.info("%s: details call returned 403 — retrying next run.", registration)
-                    continue
-                logger.info(
-                    "%s: details call failed (HTTP %s) — cleaning up stale uk-caa data.",
-                    registration, status,
-                )
-                try:
-                    _cleanup_stale_record(r, icao_hex_from_redis)
-                except Exception as exc:
-                    logger.warning("Cleanup failed for %s: %s", icao_hex_from_redis, exc)
-                continue
-            except Exception as exc:
-                logger.warning("Unexpected error fetching details for %s: %s", registration, exc)
-                errors += 1
-                continue
-
-        else:
-            try:
-                time.sleep(request_interval)
-                aircraft_id = _search_aircraft(session, icao_hex_from_redis, registration[2:])
-            except Exception as exc:
-                logger.warning("Search error for icao_hex=%s registration=%s: %s",
-                               icao_hex_from_redis, registration, exc)
-                errors += 1
-                continue
-
-            if aircraft_id is None:
-                not_found += 1
-                logger.debug("No G-INFO result for %s — skipping.", registration)
-                continue
-
-            try:
-                time.sleep(request_interval)
-                details = _get_aircraft_details(session, aircraft_id)
-            except requests.HTTPError as exc:
-                logger.warning(
-                    "HTTP error fetching details for icao_hex=%s registration=%s"
-                    " (AircraftID=%d): %s — caching foreign_key for next run.",
-                    icao_hex_from_redis, registration, aircraft_id, exc,
-                )
-                try:
-                    r.json().set(aircraft_detail_key(icao_hex_from_redis), "$.foreign_key", aircraft_id)
-                except Exception:
-                    pass
-                errors += 1
-                continue
-            except Exception as exc:
-                logger.warning("Unexpected error fetching details for icao_hex=%s registration=%s: %s",
-                               icao_hex_from_redis, registration, exc)
-                errors += 1
-                continue
-
-            reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
-            if reg_status != "Registered":
-                logger.info(
-                    "%s: RegistrationDetails.Status is %r — skipping.",
-                    registration, reg_status,
-                )
-                continue
-
-        record = _build_record(details)
-        if record is None:
-            logger.warning("Could not build record for %s.", registration)
+    for aircraft_id in aircraft_ids:
+        try:
+            time.sleep(request_interval)
+            details = _get_aircraft_details(session, aircraft_id)
+        except Exception as exc:
+            logger.warning("Error fetching details for AircraftID=%d: %s", aircraft_id, exc)
             errors += 1
             continue
 
-        record["foreign_key"] = aircraft_id
-        record["source"] = "uk-caa"
+        reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
+        if reg_status != "Registered":
+            logger.debug("AircraftID=%d: Status is %r — skipping.", aircraft_id, reg_status)
+            skipped += 1
+            continue
 
-        key = aircraft_detail_key(icao_hex_from_redis)
+        record = _build_record(details)
+        if record is None:
+            logger.warning("Could not build record for AircraftID=%d.", aircraft_id)
+            errors += 1
+            continue
+
+        record["source"] = "uk-caa"
+        key = aircraft_detail_key(record["icao_hex"])
         r.json().set(key, "$", record)
         r.expire(key, ttl)
         count += 1
 
         if count % 500 == 0:
-            logger.info("  ... %d records written (%d not found, %d errors).", count, not_found, errors)
+            logger.info("  ... %d records written (%d skipped, %d errors).", count, skipped, errors)
 
-    logger.info(
-        "Finished: %d written, %d not found in G-INFO, %d errors.",
-        count, not_found, errors,
-    )
+    logger.info("Finished: %d written, %d skipped, %d errors.", count, skipped, errors)
     return count
 
 
@@ -721,8 +480,10 @@ def main() -> None:
 
     try:
         _ensure_search_index(r)
-        registrations = get_uk_registrations(r)
-        records_imported = write_to_redis(registrations, r, session, ttl, request_interval)
+        logger.info("Enumerating G-registered aircraft via AA-ZZ search (676 calls)...")
+        aircraft_ids = enumerate_registrations(session, request_interval)
+        logger.info("Fetching details for %d aircraft...", len(aircraft_ids))
+        records_imported = write_to_redis(aircraft_ids, r, session, ttl, request_interval)
         status = "success"
         logger.info("UK CAA runner completed successfully. Records imported: %d", records_imported)
 

--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -289,6 +289,7 @@ def run_pipeline(
     count = 0
     skipped = 0
     errors = 0
+    retry_queue: list[int] = []
 
     for c1, c2 in product(_LETTERS, _LETTERS):
         prefix = f"{c1}{c2}"
@@ -309,6 +310,13 @@ def run_pipeline(
             try:
                 time.sleep(request_interval)
                 details = _get_aircraft_details(session, aircraft_id)
+            except requests.HTTPError as exc:
+                if exc.response is not None and exc.response.status_code == 403:
+                    retry_queue.append(aircraft_id)
+                else:
+                    logger.warning("Error fetching details for AircraftID=%d: %s", aircraft_id, exc)
+                    errors += 1
+                continue
             except Exception as exc:
                 logger.warning("Error fetching details for AircraftID=%d: %s", aircraft_id, exc)
                 errors += 1
@@ -317,6 +325,34 @@ def run_pipeline(
             reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
             if reg_status != "Registered":
                 logger.debug("AircraftID=%d: Status is %r — skipping.", aircraft_id, reg_status)
+                skipped += 1
+                continue
+
+            record = _build_record(details)
+            if record is None:
+                logger.warning("Could not build record for AircraftID=%d.", aircraft_id)
+                errors += 1
+                continue
+
+            record["source"] = "uk-caa"
+            key = aircraft_detail_key(record["icao_hex"])
+            r.json().set(key, "$", record)
+            r.expire(key, ttl)
+            count += 1
+
+    if retry_queue:
+        logger.info("Retrying %d aircraft that returned 403 (500ms interval)...", len(retry_queue))
+        for aircraft_id in retry_queue:
+            time.sleep(0.5)
+            try:
+                details = _get_aircraft_details(session, aircraft_id)
+            except Exception as exc:
+                logger.warning("Retry failed for AircraftID=%d: %s", aircraft_id, exc)
+                errors += 1
+                continue
+
+            reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
+            if reg_status != "Registered":
                 skipped += 1
                 continue
 

--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -177,7 +177,7 @@ def _build_record(details: dict) -> Optional[dict]:
         "serial_number": (aircraft_details.get("SerialNumber") or "").strip() or None,
         "type_designator": (aircraft_details.get("ICAOAircraftTypeDesignator") or "").strip() or None,
         "manufactured_date": _parse_year_built(aircraft_details.get("YearBuild")),
-        "seats": int(max_pax) if max_pax is not None else None,
+        "seats": int(max_pax) + 1 if max_pax is not None else None,
     }
     aircraft: Optional[dict] = {k: v for k, v in aircraft_fields.items() if v is not None} or None
 

--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -272,41 +272,17 @@ def _get_aircraft_details(session: requests.Session, aircraft_id: int) -> Option
     return resp.json()
 
 
-def enumerate_registrations(session: requests.Session, request_interval: float) -> list[int]:
-    """Return AircraftIDs for all G-registered aircraft via AA-ZZ enumeration.
-
-    Iterates all 676 2-letter suffix combinations, filtering on RegistrationStatus "R".
-    Errors on individual prefixes are logged and skipped; enumeration continues.
-    """
-    aircraft_ids: list[int] = []
-    for c1, c2 in product(_LETTERS, _LETTERS):
-        prefix = f"{c1}{c2}"
-        try:
-            results = _search_by_prefix(session, prefix)
-            for result in results:
-                if result.get("RegistrationStatus") == "R":
-                    aid = result.get("AircraftID")
-                    if aid is not None:
-                        aircraft_ids.append(aid)
-        except Exception as exc:
-            logger.warning("Search error for prefix %s: %s", prefix, exc)
-        time.sleep(request_interval)
-    logger.info("Enumeration complete: found %d registered aircraft.", len(aircraft_ids))
-    return aircraft_ids
-
-
-# ---------------------------------------------------------------------------
-# Write to Redis
-# ---------------------------------------------------------------------------
-
-def write_to_redis(
-    aircraft_ids: list[int],
-    r: redis_lib.Redis,
+def run_pipeline(
     session: requests.Session,
+    r: redis_lib.Redis,
     ttl: int,
     request_interval: float,
 ) -> int:
-    """Fetch details for each AircraftID and write enrichment records to Redis.
+    """Enumerate all G-registered aircraft via AA-ZZ search and write to Redis.
+
+    For each prefix, immediately fetches details and writes records — no
+    intermediate accumulation.  The search calls are not rate-limited; only
+    details calls sleep for request_interval to be polite to the API.
 
     Returns the count of records successfully written.
     """
@@ -314,35 +290,47 @@ def write_to_redis(
     skipped = 0
     errors = 0
 
-    for aircraft_id in aircraft_ids:
+    for c1, c2 in product(_LETTERS, _LETTERS):
+        prefix = f"{c1}{c2}"
         try:
-            time.sleep(request_interval)
-            details = _get_aircraft_details(session, aircraft_id)
+            results = _search_by_prefix(session, prefix)
         except Exception as exc:
-            logger.warning("Error fetching details for AircraftID=%d: %s", aircraft_id, exc)
-            errors += 1
+            logger.warning("Search error for prefix %s: %s", prefix, exc)
             continue
 
-        reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
-        if reg_status != "Registered":
-            logger.debug("AircraftID=%d: Status is %r — skipping.", aircraft_id, reg_status)
-            skipped += 1
-            continue
+        aircraft_ids = [
+            item.get("AircraftID")
+            for item in results
+            if item.get("RegistrationStatus") == "R" and item.get("AircraftID") is not None
+        ]
+        logger.info("G-%s*: %d registered (written so far: %d).", prefix, len(aircraft_ids), count)
 
-        record = _build_record(details)
-        if record is None:
-            logger.warning("Could not build record for AircraftID=%d.", aircraft_id)
-            errors += 1
-            continue
+        for aircraft_id in aircraft_ids:
+            try:
+                time.sleep(request_interval)
+                details = _get_aircraft_details(session, aircraft_id)
+            except Exception as exc:
+                logger.warning("Error fetching details for AircraftID=%d: %s", aircraft_id, exc)
+                errors += 1
+                continue
 
-        record["source"] = "uk-caa"
-        key = aircraft_detail_key(record["icao_hex"])
-        r.json().set(key, "$", record)
-        r.expire(key, ttl)
-        count += 1
+            reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
+            if reg_status != "Registered":
+                logger.debug("AircraftID=%d: Status is %r — skipping.", aircraft_id, reg_status)
+                skipped += 1
+                continue
 
-        if count % 500 == 0:
-            logger.info("  ... %d records written (%d skipped, %d errors).", count, skipped, errors)
+            record = _build_record(details)
+            if record is None:
+                logger.warning("Could not build record for AircraftID=%d.", aircraft_id)
+                errors += 1
+                continue
+
+            record["source"] = "uk-caa"
+            key = aircraft_detail_key(record["icao_hex"])
+            r.json().set(key, "$", record)
+            r.expire(key, ttl)
+            count += 1
 
     logger.info("Finished: %d written, %d skipped, %d errors.", count, skipped, errors)
     return count
@@ -480,10 +468,8 @@ def main() -> None:
 
     try:
         _ensure_search_index(r)
-        logger.info("Enumerating G-registered aircraft via AA-ZZ search (676 calls)...")
-        aircraft_ids = enumerate_registrations(session, request_interval)
-        logger.info("Fetching details for %d aircraft...", len(aircraft_ids))
-        records_imported = write_to_redis(aircraft_ids, r, session, ttl, request_interval)
+        logger.info("Enumerating and enriching G-registered aircraft via AA-ZZ search...")
+        records_imported = run_pipeline(session, r, ttl, request_interval)
         status = "success"
         logger.info("UK CAA runner completed successfully. Records imported: %d", records_imported)
 

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -4,9 +4,9 @@ Tests for the UK CAA data runner.
 Covers:
 - Decode helpers (aircraft class, country, year built)
 - Record builder (_build_record)
-- Deep merge
-- Redis enumeration (get_uk_registrations)
-- API helpers (_search_aircraft, _get_aircraft_details) — mocked
+- Search index helper (_ensure_search_index) — mocked
+- API helpers (_search_by_prefix, _get_aircraft_details) — mocked
+- Registration enumeration (enumerate_registrations) — mocked
 - Redis write logic (write_to_redis) — mocked
 - MQTT completion stats — mocked
 """
@@ -17,7 +17,7 @@ import importlib.util
 import json
 import os
 import sys
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import requests
 
@@ -52,10 +52,9 @@ _decode_aircraft_class = _mod._decode_aircraft_class
 _decode_country = _mod._decode_country
 _parse_year_built = _mod._parse_year_built
 _build_record = _mod._build_record
-_deep_merge = _mod._deep_merge
-_search_aircraft = _mod._search_aircraft
+_search_by_prefix = _mod._search_by_prefix
 _get_aircraft_details = _mod._get_aircraft_details
-get_uk_registrations = _mod.get_uk_registrations
+enumerate_registrations = _mod.enumerate_registrations
 write_to_redis = _mod.write_to_redis
 publish_completion_stats = _mod.publish_completion_stats
 REDIS_TTL = _mod.REDIS_TTL
@@ -334,214 +333,147 @@ class TestBuildRecord:
 
 
 # ---------------------------------------------------------------------------
-# Tests: _deep_merge
+# Tests: _search_by_prefix
 # ---------------------------------------------------------------------------
 
-class TestDeepMerge:
-    def test_update_wins_on_conflict(self):
-        result = _deep_merge({"a": 1}, {"a": 2})
-        assert result["a"] == 2
-
-    def test_nested_dicts_merged_recursively(self):
-        base = {"aircraft": {"type": "Airplane", "manufacturer": "OLD"}}
-        update = {"aircraft": {"manufacturer": "NEW", "model": "B737"}}
-        result = _deep_merge(base, update)
-        assert result["aircraft"]["type"] == "Airplane"
-        assert result["aircraft"]["manufacturer"] == "NEW"
-        assert result["aircraft"]["model"] == "B737"
-
-    def test_base_keys_preserved(self):
-        result = _deep_merge({"a": 1, "b": 2}, {"a": 99})
-        assert result["b"] == 2
-
-    def test_new_keys_added(self):
-        result = _deep_merge({}, {"x": 42})
-        assert result["x"] == 42
-
-
-# ---------------------------------------------------------------------------
-# Tests: get_uk_registrations
-# ---------------------------------------------------------------------------
-
-class TestGetUkRegistrations:
-    def _make_redis(
-        self,
-        scan_keys: list[str],
-        reg_map: dict[str, str],
-        fk_map: dict[str, int] = None,
-    ) -> MagicMock:
-        r = MagicMock()
-        r.scan_iter.return_value = iter(scan_keys)
-        _fk_map = fk_map or {}
-
-        def mget_side_effect(keys, path):
-            if path == "$.registration":
-                return [[reg_map.get(k)] if k in reg_map else None for k in keys]
-            # $["foreign_key"]
-            return [[_fk_map.get(k)] if k in _fk_map else None for k in keys]
-
-        r.json.return_value.mget.side_effect = mget_side_effect
-        return r
-
-    def test_returns_g_registrations(self):
-        r = self._make_redis(
-            ["aircraft:simple:406B48"],
-            {"aircraft:simple:406B48": "G-VAHH"},
-        )
-        results = get_uk_registrations(r)
-        regs = [reg for reg, _, _ in results]
-        assert "G-VAHH" in regs
-
-    def test_filters_non_g_registrations(self):
-        r = self._make_redis(
-            ["aircraft:simple:406B48", "aircraft:simple:400001"],
-            {"aircraft:simple:406B48": "N12345", "aircraft:simple:400001": "G-ABCD"},
-        )
-        results = get_uk_registrations(r)
-        regs = [reg for reg, _, _ in results]
-        assert "N12345" not in regs
-        assert "G-ABCD" in regs
-
-    def test_icao_hex_uppercased(self):
-        r = self._make_redis(
-            ["aircraft:simple:406b48"],
-            {"aircraft:simple:406b48": "G-VAHH"},
-        )
-        results = get_uk_registrations(r)
-        assert results[0][1] == "406B48"
-
-    def test_registration_uppercased(self):
-        r = self._make_redis(
-            ["aircraft:simple:406B48"],
-            {"aircraft:simple:406B48": "g-vahh"},
-        )
-        results = get_uk_registrations(r)
-        assert results[0][0] == "G-VAHH"
-
-    def test_missing_registration_skipped(self):
-        r = self._make_redis(["aircraft:simple:406B48"], {})
-        results = get_uk_registrations(r)
-        assert results == []
-
-    def test_uses_uk_icao_scan_pattern(self):
-        r = self._make_redis([], {})
-        get_uk_registrations(r)
-        r.scan_iter.assert_called_once_with("aircraft:simple:4[0123]*")
-
-    def test_returns_cached_foreign_key(self):
-        r = self._make_redis(
-            ["aircraft:simple:406B48"],
-            {"aircraft:simple:406B48": "G-VAHH"},
-            fk_map={"aircraft:detail:406B48": 66819},
-        )
-        results = get_uk_registrations(r)
-        assert results[0][2] == 66819
-
-    def test_returns_none_foreign_key_when_absent(self):
-        r = self._make_redis(
-            ["aircraft:simple:406B48"],
-            {"aircraft:simple:406B48": "G-VAHH"},
-        )
-        results = get_uk_registrations(r)
-        assert results[0][2] is None
-
-
-# ---------------------------------------------------------------------------
-# Tests: API helpers (mocked session)
-# ---------------------------------------------------------------------------
-
-class TestApiHelpers:
-    def _make_session(self, search_json, details_json=None) -> MagicMock:
+class TestSearchByPrefix:
+    def _make_session(self, results: list) -> MagicMock:
         session = MagicMock()
-
-        search_resp = MagicMock()
-        search_resp.json.return_value = search_json
-        search_resp.raise_for_status.return_value = None
-
-        details_resp = MagicMock()
-        details_resp.json.return_value = details_json
-        details_resp.raise_for_status.return_value = None
-
-        session.post.return_value = search_resp
-        session.get.return_value = details_resp
+        resp = MagicMock()
+        resp.json.return_value = results
+        resp.raise_for_status.return_value = None
+        session.post.return_value = resp
         return session
 
-    def test_search_returns_aircraft_id(self):
+    def test_posts_to_correct_url(self):
         session = self._make_session(_SEARCH_RESULT)
-        result = _search_aircraft(session, "406B48", "VAHH")
-        assert result == 66819
-
-    def test_search_empty_result_returns_none(self):
-        session = self._make_session([])
-        result = _search_aircraft(session, "406B48", "VAHH")
-        assert result is None
-
-    def test_search_posts_to_correct_url(self):
-        session = self._make_session(_SEARCH_RESULT)
-        _search_aircraft(session, "406B48", "VAHH")
+        _search_by_prefix(session, "VA")
         url = session.post.call_args.args[0]
         assert "/api/aircraft/search" in url
 
-    def test_search_payload_uses_icao_hex(self):
+    def test_sends_registration_prefix(self):
         session = self._make_session(_SEARCH_RESULT)
-        _search_aircraft(session, "406B48", "VAHH")
+        _search_by_prefix(session, "VA")
         payload = session.post.call_args.kwargs["json"]
-        assert payload["ICAO24BitHex"] == "406B48"
-        assert payload["Registration"] is None
-        assert payload["IncludeDeregistered"] is False
+        assert payload == {"Registration": "VA"}
 
-    def test_search_multiple_results_filters_by_mark(self):
-        multi = [
-            {"AircraftID": 11111, "Mark": "ZZZZ", "RegistrationStatus": "R"},
-            {"AircraftID": 66819, "Mark": "VAHH", "RegistrationStatus": "R"},
-        ]
-        session = self._make_session(multi)
-        result = _search_aircraft(session, "406B48", "VAHH")
-        assert result == 66819
+    def test_returns_results_list(self):
+        session = self._make_session(_SEARCH_RESULT)
+        results = _search_by_prefix(session, "VA")
+        assert results == _SEARCH_RESULT
 
-    def test_search_multiple_results_no_mark_match_returns_none(self):
-        multi = [
-            {"AircraftID": 11111, "Mark": "AAAA", "RegistrationStatus": "R"},
-            {"AircraftID": 22222, "Mark": "BBBB", "RegistrationStatus": "R"},
-        ]
-        session = self._make_session(multi)
-        result = _search_aircraft(session, "406B48", "VAHH")
-        assert result is None
+    def test_empty_response_returns_empty_list(self):
+        session = self._make_session([])
+        results = _search_by_prefix(session, "ZZ")
+        assert results == []
 
-    def test_search_multiple_results_case_insensitive(self):
-        multi = [
-            {"AircraftID": 11111, "Mark": "ZZZZ", "RegistrationStatus": "R"},
-            {"AircraftID": 66819, "Mark": "vahh", "RegistrationStatus": "R"},
-        ]
-        session = self._make_session(multi)
-        result = _search_aircraft(session, "406B48", "VAHH")
-        assert result == 66819
+    def test_none_response_returns_empty_list(self):
+        session = self._make_session(None)
+        results = _search_by_prefix(session, "ZZ")
+        assert results == []
 
-    def test_search_non_registered_status_returns_none(self):
-        session = self._make_session([{"AircraftID": 48843, "Mark": "VAHH", "RegistrationStatus": "D"}])
-        result = _search_aircraft(session, "406B48", "VAHH")
-        assert result is None
 
-    def test_search_filters_out_non_registered_before_mark(self):
-        multi = [
-            {"AircraftID": 11111, "Mark": "VAHH", "RegistrationStatus": "D"},
-            {"AircraftID": 66819, "Mark": "VAHH", "RegistrationStatus": "R"},
-        ]
-        session = self._make_session(multi)
-        result = _search_aircraft(session, "406B48", "VAHH")
-        assert result == 66819
+# ---------------------------------------------------------------------------
+# Tests: _get_aircraft_details
+# ---------------------------------------------------------------------------
 
-    def test_details_gets_correct_url(self):
-        session = self._make_session([], _make_details())
+class TestGetAircraftDetails:
+    def _make_session(self, details: dict) -> MagicMock:
+        session = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = details
+        resp.raise_for_status.return_value = None
+        session.get.return_value = resp
+        return session
+
+    def test_gets_correct_url(self):
+        session = self._make_session(_make_details())
         _get_aircraft_details(session, 66819)
         url = session.get.call_args.args[0]
         assert "/api/aircraft/details/66819" in url
 
-    def test_details_returns_parsed_json(self):
+    def test_returns_parsed_json(self):
         details = _make_details()
-        session = self._make_session([], details)
+        session = self._make_session(details)
         result = _get_aircraft_details(session, 66819)
         assert result == details
+
+
+# ---------------------------------------------------------------------------
+# Tests: enumerate_registrations
+# ---------------------------------------------------------------------------
+
+class TestEnumerateRegistrations:
+    def _make_session(self, results: list) -> MagicMock:
+        session = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = results
+        resp.raise_for_status.return_value = None
+        session.post.return_value = resp
+        return session
+
+    def test_calls_all_676_prefixes(self):
+        session = self._make_session([])
+        with patch("time.sleep"):
+            enumerate_registrations(session, 0.1)
+        assert session.post.call_count == 676
+
+    def test_includes_first_prefix_aa(self):
+        session = self._make_session([])
+        with patch("time.sleep"):
+            enumerate_registrations(session, 0.1)
+        called_prefixes = [c.kwargs["json"]["Registration"] for c in session.post.call_args_list]
+        assert "AA" in called_prefixes
+
+    def test_includes_last_prefix_zz(self):
+        session = self._make_session([])
+        with patch("time.sleep"):
+            enumerate_registrations(session, 0.1)
+        called_prefixes = [c.kwargs["json"]["Registration"] for c in session.post.call_args_list]
+        assert "ZZ" in called_prefixes
+
+    def test_filters_non_registered_status(self):
+        results = [
+            {"AircraftID": 1, "RegistrationStatus": "R"},
+            {"AircraftID": 2, "RegistrationStatus": "D"},
+        ]
+        session = self._make_session(results)
+        with patch("time.sleep"):
+            ids = enumerate_registrations(session, 0.1)
+        # Only "R" entries; 676 calls × 1 "R" each
+        assert 2 not in ids
+        assert all(i == 1 for i in ids)
+
+    def test_returns_aircraft_ids(self):
+        session = self._make_session(_SEARCH_RESULT)
+        with patch("time.sleep"):
+            ids = enumerate_registrations(session, 0.1)
+        assert 66819 in ids
+
+    def test_skips_missing_aircraft_id(self):
+        results = [{"RegistrationStatus": "R"}]  # no AircraftID
+        session = self._make_session(results)
+        with patch("time.sleep"):
+            ids = enumerate_registrations(session, 0.1)
+        assert ids == []
+
+    def test_error_on_prefix_skipped_enumeration_continues(self):
+        session = MagicMock()
+        good_resp = MagicMock()
+        good_resp.json.return_value = _SEARCH_RESULT
+        good_resp.raise_for_status.return_value = None
+
+        bad_resp = MagicMock()
+        bad_resp.raise_for_status.side_effect = Exception("HTTP 503")
+
+        # First call fails, remaining succeed
+        session.post.side_effect = [bad_resp] + [good_resp] * 675
+
+        with patch("time.sleep"):
+            ids = enumerate_registrations(session, 0.1)
+
+        assert session.post.call_count == 676
+        assert len(ids) == 675
 
 
 # ---------------------------------------------------------------------------
@@ -549,275 +481,131 @@ class TestApiHelpers:
 # ---------------------------------------------------------------------------
 
 class TestWriteToRedis:
-    def _make_redis(self, existing: dict = None) -> MagicMock:
+    def _make_redis(self) -> MagicMock:
         r = MagicMock()
         r_json = MagicMock()
         r.json.return_value = r_json
-        r_json.mget.return_value = [[existing]] if existing else [None]
         return r
 
     def _make_session(self, details: dict) -> MagicMock:
         session = MagicMock()
-
-        search_resp = MagicMock()
-        search_resp.json.return_value = _SEARCH_RESULT
-        search_resp.raise_for_status.return_value = None
-
-        details_resp = MagicMock()
-        details_resp.json.return_value = details
-        details_resp.raise_for_status.return_value = None
-
-        session.post.return_value = search_resp
-        session.get.return_value = details_resp
+        resp = MagicMock()
+        resp.json.return_value = details
+        resp.raise_for_status.return_value = None
+        session.get.return_value = resp
         return session
 
-    # ------------------------------------------------------------------
-    # Slow path (no cached foreign_key)
-    # ------------------------------------------------------------------
-
-    def test_slow_path_returns_count(self):
+    def test_returns_count(self):
         r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
+            count = write_to_redis([66819], r, session, REDIS_TTL, 0.1)
         assert count == 1
 
-    def test_slow_path_json_set_correct_key(self):
+    def test_writes_to_correct_key(self):
         r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
+            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
         key_arg = r.json.return_value.set.call_args.args[0]
         assert key_arg == "aircraft:detail:406B48"
 
-    def test_slow_path_json_set_uses_root_path(self):
+    def test_writes_at_root_path(self):
         r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
+            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
         assert r.json.return_value.set.call_args.args[1] == "$"
 
-    def test_slow_path_expire_correct_ttl(self):
+    def test_writes_source_field(self):
         r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
-        r.expire.assert_called_once_with("aircraft:detail:406B48", REDIS_TTL)
-
-    def test_slow_path_writes_source_field(self):
-        r = self._make_redis()
-        session = self._make_session(_make_details())
-        with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
+            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
         written = r.json.return_value.set.call_args.args[2]
         assert written["source"] == "uk-caa"
 
-    def test_slow_path_fire_and_forget_no_mget(self):
+    def test_no_foreign_key_in_record(self):
         r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
+            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+        written = r.json.return_value.set.call_args.args[2]
+        assert "foreign_key" not in written
+
+    def test_fire_and_forget_no_mget(self):
+        r = self._make_redis()
+        session = self._make_session(_make_details())
+        with patch("time.sleep"):
+            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
         r.json.return_value.mget.assert_not_called()
 
-    def test_slow_path_searches_by_icao_hex(self):
+    def test_expire_correct_ttl(self):
         r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
-        payload = session.post.call_args.kwargs["json"]
-        assert payload["ICAO24BitHex"] == "406B48"
-        assert payload["Registration"] is None
+            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+        r.expire.assert_called_once_with("aircraft:detail:406B48", REDIS_TTL)
 
-    def test_slow_path_writes_foreign_key(self):
+    def test_calls_details_with_aircraft_id(self):
         r = self._make_redis()
         session = self._make_session(_make_details())
         with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
-        written = r.json.return_value.set.call_args.args[2]
-        assert written["foreign_key"] == 66819
-
-    def test_slow_path_search_not_found_skips(self):
-        r = self._make_redis()
-        session = MagicMock()
-        search_resp = MagicMock()
-        search_resp.json.return_value = []
-        search_resp.raise_for_status.return_value = None
-        session.post.return_value = search_resp
-        with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
-        assert count == 0
-        r.json.return_value.set.assert_not_called()
-
-    def test_slow_path_http_error_skips_and_continues(self):
-        r = self._make_redis()
-        session = MagicMock()
-        search_resp = MagicMock()
-        search_resp.raise_for_status.side_effect = Exception("HTTP 503")
-        session.post.return_value = search_resp
-
-        details = _make_details(mark="BCDE", icao_hex="406B49")
-        search_resp2 = MagicMock()
-        search_resp2.json.return_value = [{"AircraftID": 66820, "Mark": "BCDE", "RegistrationStatus": "R"}]
-        search_resp2.raise_for_status.return_value = None
-        details_resp = MagicMock()
-        details_resp.json.return_value = details
-        details_resp.raise_for_status.return_value = None
-
-        session.post.side_effect = [search_resp, search_resp2]
-        session.get.return_value = details_resp
-
-        with patch("time.sleep"):
-            count = write_to_redis(
-                [("G-VAHH", "406B48", None), ("G-BCDE", "406B49", None)],
-                r, session, REDIS_TTL, 0.1,
-            )
-        assert count == 1
-
-    def test_slow_path_details_403_caches_foreign_key(self):
-        r = self._make_redis()
-        session = MagicMock()
-
-        search_resp = MagicMock()
-        search_resp.json.return_value = _SEARCH_RESULT
-        search_resp.raise_for_status.return_value = None
-
-        error_resp = MagicMock()
-        error_resp.status_code = 403
-        details_resp = MagicMock()
-        details_resp.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
-
-        session.post.return_value = search_resp
-        session.get.return_value = details_resp
-
-        with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
-
-        assert count == 0
-        r.json.return_value.set.assert_called_once_with("aircraft:detail:406B48", "$.foreign_key", 66819)
-
-    # ------------------------------------------------------------------
-    # Fast path (cached foreign_key)
-    # ------------------------------------------------------------------
-
-    def test_fast_path_skips_search(self):
-        r = self._make_redis()
-        session = self._make_session(_make_details())
-        with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", 66819)], r, session, REDIS_TTL, 0.1)
-        session.post.assert_not_called()
-
-    def test_fast_path_calls_details_directly(self):
-        r = self._make_redis()
-        session = self._make_session(_make_details())
-        with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", 66819)], r, session, REDIS_TTL, 0.1)
+            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
         url = session.get.call_args.args[0]
         assert "/api/aircraft/details/66819" in url
 
-    def test_fast_path_returns_count(self):
-        r = self._make_redis()
-        session = self._make_session(_make_details())
-        with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", 66819)], r, session, REDIS_TTL, 0.1)
-        assert count == 1
-
-    def test_fast_path_preserves_foreign_key(self):
-        r = self._make_redis()
-        session = self._make_session(_make_details())
-        with patch("time.sleep"):
-            write_to_redis([("G-VAHH", "406B48", 66819)], r, session, REDIS_TTL, 0.1)
-        written = r.json.return_value.set.call_args.args[2]
-        assert written["foreign_key"] == 66819
-
-    def test_fast_path_hex_mismatch_triggers_cleanup(self):
-        r = self._make_redis()
-        r.json.return_value.get.return_value = [{}]
-        session = MagicMock()
-
-        details_stale = _make_details(icao_hex="407FFF")
-        details_resp_stale = MagicMock()
-        details_resp_stale.json.return_value = details_stale
-        details_resp_stale.raise_for_status.return_value = None
-
-        session.get.return_value = details_resp_stale
-
-        with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", 99999)], r, session, REDIS_TTL, 0.1)
-
-        assert count == 0
-        session.post.assert_not_called()
-        deleted_paths = [c.args[1] for c in r.json.return_value.delete.call_args_list]
-        assert "$.foreign_key" in deleted_paths
-        assert "$.registrant" in deleted_paths
-
-    def test_fast_path_http_error_triggers_cleanup(self):
-        r = self._make_redis()
-        r.json.return_value.get.return_value = [{}]
-        session = MagicMock()
-
-        error_resp = MagicMock()
-        error_resp.status_code = 404
-        details_resp_error = MagicMock()
-        details_resp_error.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
-
-        session.get.return_value = details_resp_error
-
-        with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", 99999)], r, session, REDIS_TTL, 0.1)
-
-        assert count == 0
-        session.post.assert_not_called()
-        deleted_paths = [c.args[1] for c in r.json.return_value.delete.call_args_list]
-        assert "$.foreign_key" in deleted_paths
-        assert "$.registrant" in deleted_paths
-
-    def test_fast_path_403_skips_without_search_or_cleanup(self):
-        r = self._make_redis()
-        session = MagicMock()
-
-        error_resp = MagicMock()
-        error_resp.status_code = 403
-        details_resp_error = MagicMock()
-        details_resp_error.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
-
-        session.get.return_value = details_resp_error
-
-        with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", 99999)], r, session, REDIS_TTL, 0.1)
-
-        assert count == 0
-        session.post.assert_not_called()
-        r.json.return_value.delete.assert_not_called()
-
-    def test_fast_path_non_registered_status_triggers_cleanup(self):
+    def test_skips_non_registered_status(self):
         r = self._make_redis()
         session = self._make_session(_make_details(reg_status="De-registered"))
         with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", 66819)], r, session, REDIS_TTL, 0.1)
+            count = write_to_redis([66819], r, session, REDIS_TTL, 0.1)
         assert count == 0
-        deleted_paths = [c.args[1] for c in r.json.return_value.delete.call_args_list]
-        assert "$.registrant" in deleted_paths
+        r.json.return_value.set.assert_not_called()
 
-    def test_slow_path_non_registered_details_skips_without_cleanup(self):
+    def test_details_error_skips_and_continues(self):
         r = self._make_redis()
         session = MagicMock()
 
-        search_resp = MagicMock()
-        search_resp.json.return_value = _SEARCH_RESULT
-        search_resp.raise_for_status.return_value = None
+        error_resp = MagicMock()
+        error_resp.raise_for_status.side_effect = Exception("HTTP 503")
 
-        details_resp = MagicMock()
-        details_resp.json.return_value = _make_details(reg_status="De-registered")
-        details_resp.raise_for_status.return_value = None
+        good_resp = MagicMock()
+        good_resp.json.return_value = _make_details(mark="BCDE", icao_hex="406B49")
+        good_resp.raise_for_status.return_value = None
 
-        session.post.return_value = search_resp
-        session.get.return_value = details_resp
+        session.get.side_effect = [error_resp, good_resp]
 
         with patch("time.sleep"):
-            count = write_to_redis([("G-VAHH", "406B48", None)], r, session, REDIS_TTL, 0.1)
+            count = write_to_redis([66819, 66820], r, session, REDIS_TTL, 0.1)
+        assert count == 1
 
+    def test_empty_aircraft_ids_returns_zero(self):
+        r = self._make_redis()
+        session = self._make_session(_make_details())
+        with patch("time.sleep"):
+            count = write_to_redis([], r, session, REDIS_TTL, 0.1)
         assert count == 0
-        r.json.return_value.delete.assert_not_called()
+        r.json.return_value.set.assert_not_called()
+
+    def test_multiple_aircraft_written(self):
+        r = self._make_redis()
+        session = MagicMock()
+
+        resp1 = MagicMock()
+        resp1.json.return_value = _make_details(mark="VAHH", icao_hex="406B48")
+        resp1.raise_for_status.return_value = None
+
+        resp2 = MagicMock()
+        resp2.json.return_value = _make_details(mark="BCDE", icao_hex="406B49")
+        resp2.raise_for_status.return_value = None
+
+        session.get.side_effect = [resp1, resp2]
+
+        with patch("time.sleep"):
+            count = write_to_redis([66819, 66820], r, session, REDIS_TTL, 0.1)
+        assert count == 2
+        assert r.json.return_value.set.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -268,7 +268,7 @@ class TestBuildRecord:
 
     def test_aircraft_seats(self):
         record = _build_record(_make_details(maximum_passengers=296))
-        assert record["aircraft"]["seats"] == 296
+        assert record["aircraft"]["seats"] == 297
 
     def test_aircraft_seats_none_when_absent(self):
         details = _make_details()

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -54,8 +54,7 @@ _parse_year_built = _mod._parse_year_built
 _build_record = _mod._build_record
 _search_by_prefix = _mod._search_by_prefix
 _get_aircraft_details = _mod._get_aircraft_details
-enumerate_registrations = _mod.enumerate_registrations
-write_to_redis = _mod.write_to_redis
+run_pipeline = _mod.run_pipeline
 publish_completion_stats = _mod.publish_completion_stats
 REDIS_TTL = _mod.REDIS_TTL
 MQTT_ROOT = _mod.MQTT_ROOT
@@ -400,212 +399,195 @@ class TestGetAircraftDetails:
 
 
 # ---------------------------------------------------------------------------
-# Tests: enumerate_registrations
+# Tests: run_pipeline
 # ---------------------------------------------------------------------------
 
-class TestEnumerateRegistrations:
-    def _make_session(self, results: list) -> MagicMock:
+class TestRunPipeline:
+    def _make_redis(self) -> MagicMock:
+        r = MagicMock()
+        r.json.return_value = MagicMock()
+        return r
+
+    def _make_session(self, search_results: list, details: dict) -> MagicMock:
         session = MagicMock()
-        resp = MagicMock()
-        resp.json.return_value = results
-        resp.raise_for_status.return_value = None
-        session.post.return_value = resp
+
+        search_resp = MagicMock()
+        search_resp.json.return_value = search_results
+        search_resp.raise_for_status.return_value = None
+        session.post.return_value = search_resp
+
+        details_resp = MagicMock()
+        details_resp.json.return_value = details
+        details_resp.raise_for_status.return_value = None
+        session.get.return_value = details_resp
+
         return session
 
-    def test_calls_all_676_prefixes(self):
-        session = self._make_session([])
+    def test_searches_all_676_prefixes(self):
+        r = self._make_redis()
+        session = self._make_session([], _make_details())
         with patch("time.sleep"):
-            enumerate_registrations(session, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         assert session.post.call_count == 676
 
     def test_includes_first_prefix_aa(self):
-        session = self._make_session([])
+        r = self._make_redis()
+        session = self._make_session([], _make_details())
         with patch("time.sleep"):
-            enumerate_registrations(session, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         called_prefixes = [c.kwargs["json"]["Registration"] for c in session.post.call_args_list]
         assert "AA" in called_prefixes
 
     def test_includes_last_prefix_zz(self):
-        session = self._make_session([])
+        r = self._make_redis()
+        session = self._make_session([], _make_details())
         with patch("time.sleep"):
-            enumerate_registrations(session, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         called_prefixes = [c.kwargs["json"]["Registration"] for c in session.post.call_args_list]
         assert "ZZ" in called_prefixes
 
-    def test_filters_non_registered_status(self):
-        results = [
-            {"AircraftID": 1, "RegistrationStatus": "R"},
-            {"AircraftID": 2, "RegistrationStatus": "D"},
-        ]
-        session = self._make_session(results)
-        with patch("time.sleep"):
-            ids = enumerate_registrations(session, 0.1)
-        # Only "R" entries; 676 calls × 1 "R" each
-        assert 2 not in ids
-        assert all(i == 1 for i in ids)
-
-    def test_returns_aircraft_ids(self):
-        session = self._make_session(_SEARCH_RESULT)
-        with patch("time.sleep"):
-            ids = enumerate_registrations(session, 0.1)
-        assert 66819 in ids
-
-    def test_skips_missing_aircraft_id(self):
-        results = [{"RegistrationStatus": "R"}]  # no AircraftID
-        session = self._make_session(results)
-        with patch("time.sleep"):
-            ids = enumerate_registrations(session, 0.1)
-        assert ids == []
-
-    def test_error_on_prefix_skipped_enumeration_continues(self):
-        session = MagicMock()
-        good_resp = MagicMock()
-        good_resp.json.return_value = _SEARCH_RESULT
-        good_resp.raise_for_status.return_value = None
-
-        bad_resp = MagicMock()
-        bad_resp.raise_for_status.side_effect = Exception("HTTP 503")
-
-        # First call fails, remaining succeed
-        session.post.side_effect = [bad_resp] + [good_resp] * 675
-
-        with patch("time.sleep"):
-            ids = enumerate_registrations(session, 0.1)
-
-        assert session.post.call_count == 676
-        assert len(ids) == 675
-
-
-# ---------------------------------------------------------------------------
-# Tests: write_to_redis
-# ---------------------------------------------------------------------------
-
-class TestWriteToRedis:
-    def _make_redis(self) -> MagicMock:
-        r = MagicMock()
-        r_json = MagicMock()
-        r.json.return_value = r_json
-        return r
-
-    def _make_session(self, details: dict) -> MagicMock:
-        session = MagicMock()
-        resp = MagicMock()
-        resp.json.return_value = details
-        resp.raise_for_status.return_value = None
-        session.get.return_value = resp
-        return session
-
-    def test_returns_count(self):
+    def test_writes_record_for_registered_result(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
+        session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
-            count = write_to_redis([66819], r, session, REDIS_TTL, 0.1)
-        assert count == 1
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+        assert count == 676  # one registered result per prefix
+
+    def test_filters_non_registered_status(self):
+        r = self._make_redis()
+        search_results = [{"AircraftID": 1, "RegistrationStatus": "D"}]
+        session = self._make_session(search_results, _make_details())
+        with patch("time.sleep"):
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+        assert count == 0
+        r.json.return_value.set.assert_not_called()
 
     def test_writes_to_correct_key(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
+        session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
-            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         key_arg = r.json.return_value.set.call_args.args[0]
         assert key_arg == "aircraft:detail:406B48"
 
     def test_writes_at_root_path(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
+        session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
-            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         assert r.json.return_value.set.call_args.args[1] == "$"
 
     def test_writes_source_field(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
+        session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
-            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         written = r.json.return_value.set.call_args.args[2]
         assert written["source"] == "uk-caa"
 
     def test_no_foreign_key_in_record(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
+        session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
-            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         written = r.json.return_value.set.call_args.args[2]
         assert "foreign_key" not in written
 
     def test_fire_and_forget_no_mget(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
+        session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
-            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
         r.json.return_value.mget.assert_not_called()
 
     def test_expire_correct_ttl(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
+        session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
-            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
-        r.expire.assert_called_once_with("aircraft:detail:406B48", REDIS_TTL)
+            run_pipeline(session, r, REDIS_TTL, 0.1)
+        r.expire.assert_called_with("aircraft:detail:406B48", REDIS_TTL)
 
-    def test_calls_details_with_aircraft_id(self):
+    def test_search_error_skips_prefix_continues(self):
         r = self._make_redis()
-        session = self._make_session(_make_details())
-        with patch("time.sleep"):
-            write_to_redis([66819], r, session, REDIS_TTL, 0.1)
-        url = session.get.call_args.args[0]
-        assert "/api/aircraft/details/66819" in url
+        session = MagicMock()
 
-    def test_skips_non_registered_status(self):
-        r = self._make_redis()
-        session = self._make_session(_make_details(reg_status="De-registered"))
+        bad_resp = MagicMock()
+        bad_resp.raise_for_status.side_effect = Exception("HTTP 503")
+
+        good_resp = MagicMock()
+        good_resp.json.return_value = []
+        good_resp.raise_for_status.return_value = None
+
+        session.post.side_effect = [bad_resp] + [good_resp] * 675
+
         with patch("time.sleep"):
-            count = write_to_redis([66819], r, session, REDIS_TTL, 0.1)
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert session.post.call_count == 676
         assert count == 0
-        r.json.return_value.set.assert_not_called()
 
     def test_details_error_skips_and_continues(self):
         r = self._make_redis()
         session = MagicMock()
 
+        search_resp = MagicMock()
+        search_resp.json.return_value = _SEARCH_RESULT
+        search_resp.raise_for_status.return_value = None
+        session.post.return_value = search_resp
+
         error_resp = MagicMock()
         error_resp.raise_for_status.side_effect = Exception("HTTP 503")
-
-        good_resp = MagicMock()
-        good_resp.json.return_value = _make_details(mark="BCDE", icao_hex="406B49")
-        good_resp.raise_for_status.return_value = None
-
-        session.get.side_effect = [error_resp, good_resp]
+        session.get.return_value = error_resp
 
         with patch("time.sleep"):
-            count = write_to_redis([66819, 66820], r, session, REDIS_TTL, 0.1)
-        assert count == 1
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
 
-    def test_empty_aircraft_ids_returns_zero(self):
-        r = self._make_redis()
-        session = self._make_session(_make_details())
-        with patch("time.sleep"):
-            count = write_to_redis([], r, session, REDIS_TTL, 0.1)
         assert count == 0
         r.json.return_value.set.assert_not_called()
 
-    def test_multiple_aircraft_written(self):
+    def test_skips_non_registered_details_status(self):
         r = self._make_redis()
-        session = MagicMock()
-
-        resp1 = MagicMock()
-        resp1.json.return_value = _make_details(mark="VAHH", icao_hex="406B48")
-        resp1.raise_for_status.return_value = None
-
-        resp2 = MagicMock()
-        resp2.json.return_value = _make_details(mark="BCDE", icao_hex="406B49")
-        resp2.raise_for_status.return_value = None
-
-        session.get.side_effect = [resp1, resp2]
-
+        session = self._make_session(_SEARCH_RESULT, _make_details(reg_status="De-registered"))
         with patch("time.sleep"):
-            count = write_to_redis([66819, 66820], r, session, REDIS_TTL, 0.1)
-        assert count == 2
-        assert r.json.return_value.set.call_count == 2
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+        assert count == 0
+        r.json.return_value.set.assert_not_called()
+
+    def test_no_sleep_between_search_calls(self):
+        r = self._make_redis()
+        session = self._make_session([], _make_details())
+        sleep_calls = []
+        with patch("time.sleep", side_effect=lambda x: sleep_calls.append(x)):
+            run_pipeline(session, r, REDIS_TTL, 0.1)
+        # No registered aircraft → no details calls → no sleeps at all
+        assert sleep_calls == []
+
+    def test_sleep_only_before_details_calls(self):
+        r = self._make_redis()
+        # Two registered results from every prefix would be excessive; use a single prefix result
+        session = MagicMock()
+        search_empty = MagicMock()
+        search_empty.json.return_value = []
+        search_empty.raise_for_status.return_value = None
+
+        search_hit = MagicMock()
+        search_hit.json.return_value = _SEARCH_RESULT
+        search_hit.raise_for_status.return_value = None
+
+        details_resp = MagicMock()
+        details_resp.json.return_value = _make_details()
+        details_resp.raise_for_status.return_value = None
+
+        # Only first prefix (AA) returns a result
+        session.post.side_effect = [search_hit] + [search_empty] * 675
+        session.get.return_value = details_resp
+
+        sleep_calls = []
+        with patch("time.sleep", side_effect=lambda x: sleep_calls.append(x)):
+            run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        # Exactly one sleep — before the one details call
+        assert sleep_calls == [0.1]
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -562,6 +562,86 @@ class TestRunPipeline:
         # No registered aircraft → no details calls → no sleeps at all
         assert sleep_calls == []
 
+    def test_403_queued_for_retry(self):
+        r = self._make_redis()
+        session = MagicMock()
+
+        search_resp = MagicMock()
+        search_resp.json.return_value = _SEARCH_RESULT
+        search_resp.raise_for_status.return_value = None
+        session.post.return_value = search_resp
+
+        error_resp = MagicMock()
+        error_resp.status_code = 403
+        details_403 = MagicMock()
+        details_403.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
+
+        good_details = MagicMock()
+        good_details.json.return_value = _make_details()
+        good_details.raise_for_status.return_value = None
+
+        # First details call → 403, retry → success
+        session.get.side_effect = [details_403] * 676 + [good_details] * 676
+
+        with patch("time.sleep"):
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert count == 676
+
+    def test_403_retry_uses_500ms_sleep(self):
+        r = self._make_redis()
+        session = MagicMock()
+
+        # Only first prefix returns a result
+        search_hit = MagicMock()
+        search_hit.json.return_value = _SEARCH_RESULT
+        search_hit.raise_for_status.return_value = None
+
+        search_empty = MagicMock()
+        search_empty.json.return_value = []
+        search_empty.raise_for_status.return_value = None
+
+        session.post.side_effect = [search_hit] + [search_empty] * 675
+
+        error_resp = MagicMock()
+        error_resp.status_code = 403
+        details_403 = MagicMock()
+        details_403.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
+
+        good_details = MagicMock()
+        good_details.json.return_value = _make_details()
+        good_details.raise_for_status.return_value = None
+
+        session.get.side_effect = [details_403, good_details]
+
+        sleep_calls = []
+        with patch("time.sleep", side_effect=lambda x: sleep_calls.append(x)):
+            run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert 0.5 in sleep_calls
+
+    def test_non_403_http_error_not_retried(self):
+        r = self._make_redis()
+        session = MagicMock()
+
+        search_resp = MagicMock()
+        search_resp.json.return_value = _SEARCH_RESULT
+        search_resp.raise_for_status.return_value = None
+        session.post.return_value = search_resp
+
+        error_resp = MagicMock()
+        error_resp.status_code = 500
+        details_500 = MagicMock()
+        details_500.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
+        session.get.return_value = details_500
+
+        with patch("time.sleep"):
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert count == 0
+        # Details called 676 times (once per prefix hit) — no retries
+        assert session.get.call_count == 676
+
     def test_sleep_only_before_details_calls(self):
         r = self._make_redis()
         # Two registered results from every prefix would be excessive; use a single prefix result

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -329,7 +329,7 @@ sources:
     url: "https://ginfoapi.caa.co.uk"
     format: api
     cadence: weekly_tuesday
-    notes: "Undocumented public REST API; no auth required; User-Agent 'P5Software SkyFollower' required; enumerates target records via Redis SCAN on UK ICAO hex range 400000–43FFFF (pattern icao_hex:4[0123]*); can only enrich records already present in Redis — must run after Mictronics; caches AircraftID in the foreign_key field on each Redis record to skip the search call on subsequent runs"
+    notes: "Undocumented public REST API; no auth required; User-Agent 'P5Software SkyFollower' required; enumerates all G-registered aircraft by iterating every 2-letter suffix combination AA-ZZ (676 POST /api/aircraft/search calls); filters results on RegistrationStatus 'R'; calls GET /api/aircraft/details/{AircraftID} for each matched result; no Redis dependency — runs independently of Mictronics"
     endpoints:
       search:
         method: POST
@@ -1797,12 +1797,3 @@ records:
             sources:
               - source: processor
 
-      foreign_key:
-        type: integer
-        description: "G-INFO AircraftID cached by the UK CAA runner; enables fast-path enrichment on subsequent runs by skipping the POST /api/aircraft/search call. Verified each run against the returned Mark field; cleared on mismatch or HTTP error."
-        persisted: false
-        sources:
-          - source: uk-caa
-            endpoint: details
-            field: AircraftID
-            description: "Written alongside every successful enrichment; on subsequent runs used directly as the details lookup key. Deleted from the Redis record if the mark no longer matches (aircraft re-registered) or if a 4xx HTTP error is returned."

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -1142,6 +1142,10 @@ records:
               - source: uk-caa
                 endpoint: details
                 field: AircraftDetails.MaximumPassengers
+                transform:
+                  type: add
+                  value: 1
+                  description: "MaximumPassengers counts passengers only (excludes pilot); +1 gives total seats. Accuracy for multi-crew transport category aircraft is unknown."
               - source: ch-bazl
                 endpoint: bulk
                 transform:


### PR DESCRIPTION
## Summary

- Replaces Redis SCAN + Mictronics dependency with direct enumeration of all 676 two-letter suffix combinations (AA–ZZ) via `POST /api/aircraft/search {"Registration": "XX"}`
- Filters search results on `RegistrationStatus == "R"` before calling details
- Calls `GET /api/aircraft/details/{AircraftID}` for each matched result — no slow/fast path, no foreign_key caching
- Removes `foreign_key` field from Redis records and from `specs/data-dictionary.yaml`
- Runner now runs independently of Mictronics — no scheduling dependency
- Updated source notes in data dictionary

## Test plan
- [ ] All 80 tests pass
- [ ] `test_calls_all_676_prefixes` verifies all combinations searched
- [ ] `test_no_foreign_key_in_record` verifies field is gone
- [ ] `test_fire_and_forget_no_mget` verifies no read before write
- [ ] `test_error_on_prefix_skipped_enumeration_continues` verifies resilience

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)