### PR TITLE
data-dictionary: clean sg-caas source definition and add to records fields

### DIFF
--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -728,12 +728,12 @@ sources:
         format: xlsx
         columns:
           "Aircraft Registration": Registration mark in 9V-prefix format
-          "Aircraft S/N":          Manufacturer serial number (stored as aircraft.serial_number)
-          "Aircraft Model":        Model designation (stored as aircraft.model)
-          "Operator":              Registered operator (stored as registrant.names[0])
-          "Aircraft Manufacturer": Manufacturer name (stored as aircraft.manufacturer)
-          "Engine Model":          Engine model designation (stored as powerplant.model)
-          "Engine Manufacturer":   Engine manufacturer name (stored as powerplant.manufacturer)
+          "Aircraft S/N":          Manufacturer serial number
+          "Aircraft Model":        Model designation
+          "Operator":              Registered operator
+          "Aircraft Manufacturer": Manufacturer name
+          "Engine Model":          Engine model designation
+          "Engine Manufacturer":   Engine manufacturer name
 
   sk-nsat:
     description: "Slovakia NSAT (Národný bezpečnostný úrad pre letectvo) aircraft register — OM-prefix registrations"
@@ -1122,6 +1122,12 @@ records:
                 transform:
                   type: wrap_array
                   description: "NOME of first owner entry; /\\\"\\\" un-escaped to double-quote before JSON parse; 'Indisponível' treated as absent; wrapped in a one-element list"
+              - source: sg-caas
+                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                field: Operator
+                transform:
+                  type: wrap_array
+                  description: "Single operator name — wrap in a one-element list"
 
           street:
             type: "array[string]"
@@ -1636,6 +1642,9 @@ records:
               - source: es-aesa
                 file: aeronaves_inscritas.pdf
                 field: Modelo
+              - source: sg-caas
+                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                field: Aircraft Model
 
           seats:
             type: integer
@@ -1736,6 +1745,9 @@ records:
               - source: es-aesa
                 file: aeronaves_inscritas.pdf
                 field: Fabricante
+              - source: sg-caas
+                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                field: Aircraft Manufacturer
 
           type_designator:
             type: string
@@ -1824,6 +1836,9 @@ records:
                   type: skip_if_value
                   value: "NO\nDISPONIBLE"
                   description: "Value 'NO\\nDISPONIBLE' (with embedded newline) treated as absent"
+              - source: sg-caas
+                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                field: "Aircraft S/N"
 
           manufactured_date:
             type: datetime
@@ -2102,6 +2117,9 @@ records:
               - source: es-aesa
                 file: aeronaves_inscritas.pdf
                 field: "Modelo Motor"
+              - source: sg-caas
+                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                field: Engine Model
 
           manufacturer:
             type: string
@@ -2130,6 +2148,9 @@ records:
               - source: es-aesa
                 file: aeronaves_inscritas.pdf
                 field: "Marca Motor"
+              - source: sg-caas
+                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                field: Engine Manufacturer
 
           power_type:
             type: string


### PR DESCRIPTION
Closes #189

## Summary
- Remove "stored as" prose from all 6 column descriptions in `sources.sg-caas.files[0].columns`
- Add `sg-caas` to `records.flight.fields` for 6 fields: `aircraft.model`, `aircraft.manufacturer`, `aircraft.serial_number`, `powerplant.model`, `powerplant.manufacturer`, and `registrant.names` (wrap_array — single operator name)

## Test plan
- [ ] Source column descriptions contain no "stored as" prose
- [ ] All 6 records entries present with correct file (`Aircraft-Register-as-at-{MonYYYY}.xlsx`) and field names
- [ ] `registrant.names` entry uses `wrap_array` transform matching the pattern of other single-name sources (nz-caa, au-casa, bs-caa, ky-caa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)