### PR TITLE
fix: remove stale icao_hex_key import and test from test_redis_keys.py

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -31,10 +31,10 @@ print(msg.icao_hex, msg.source)
 ```
 
 ```python
-from shared.redis_keys import icao_hex_key, config_rules_key
+from shared.redis_keys import aircraft_simple_key, config_rules_key
 
 # Build a Redis key for a specific aircraft
-key = icao_hex_key("A8AE7F")          # → "icao_hex:A8AE7F"
+key = aircraft_simple_key("A8AE7F")    # → "aircraft:simple:A8AE7F"
 
 # Get the key for the active rules configuration
 rules_key = config_rules_key()         # → "config:rules"

--- a/shared/tests/test_redis_keys.py
+++ b/shared/tests/test_redis_keys.py
@@ -11,7 +11,6 @@ from shared.redis_keys import (
     config_rules_key,
     config_rules_version_key,
     flight_key,
-    icao_hex_key,
     metrics_aircraft_type_misses_key,
     metrics_flights_archived_key,
     metrics_registration_misses_key,
@@ -34,10 +33,6 @@ class TestEnrichmentKeys:
 
     def test_aircraft_detail_search_index_name(self):
         assert AIRCRAFT_DETAIL_SEARCH_INDEX == "idx:aircraft:detail"
-
-    def test_icao_hex_key_deprecated_still_works(self):
-        assert icao_hex_key("a8ae7f") == "icao_hex:A8AE7F"
-        assert icao_hex_key("A8AE7F") == "icao_hex:A8AE7F"
 
     def test_operator_key(self):
         assert operator_key("dal") == "operator:DAL"


### PR DESCRIPTION
## What's wrong

`shared/tests/test_redis_keys.py` imports `icao_hex_key` from `shared.redis_keys`, but that function was removed when the Redis key scheme was renamed from `icao_hex:{hex}` to `aircraft:simple:{hex}` / `aircraft:detail:{hex}`. The entire test module fails to collect:

```
ImportError: cannot import name 'icao_hex_key' from 'shared.redis_keys'
```

The `shared/README.md` usage example also references the removed function.

## What this does

- Removes the stale `icao_hex_key` import and its `test_icao_hex_key_deprecated_still_works` test from `test_redis_keys.py`
- Updates `shared/README.md` to show `aircraft_simple_key` instead of `icao_hex_key`

No production code changes — this is purely a test/docs fix.

## How to verify

```bash
python -m pytest shared/tests/test_redis_keys.py -v
```

All 19 tests pass after the change (vs. the module failing to import before).

Fixes #222
