### PR TITLE
README: add in-development warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# ⚠️ In Development ⚠️
+
+This repo is in active development.  Its full of bugs, incomplete implementation, invalid documentation, and just generally isn't ready for you to fork or test.  Star the repo and check back in a few weeks!
+
 # SkyFollower
 
 SkyFollower is a locally-hosted ADS-B aircraft tracking system. It receives


### PR DESCRIPTION
Closes #228

## Summary
- Adds a prominent ⚠️ banner at the top of README.md warning visitors that the repo is in active development, full of bugs and incomplete implementation, and not yet ready to fork or test

## Test plan
- [ ] Banner appears at the top of the rendered README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)