### PR TITLE
data-dictionary: clean bs-caa source column description

### DIFF
--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -292,7 +292,7 @@ sources:
         columns:
           "AIRCRAFT REGISTRATION NUMBER": full C6-prefix registration mark
           "REGISTERED OWNER OF AIRCRAFT": registered owner name
-          "AIRCRAFT TYPE - MAKE/MODEL":   combined make and model free-text (stored as aircraft.model)
+          "AIRCRAFT TYPE - MAKE/MODEL":   Combined make and model designation (single free-text field)
           "SERIAL #":                     manufacturer serial number
 
   ch-bazl:


### PR DESCRIPTION
Closes #214

## Summary
- Remove "stored as aircraft.model" prose from `sources.bs-caa.files[0].columns` `AIRCRAFT TYPE - MAKE/MODEL`
- Records section already complete; no new entries needed

## Test plan
- [ ] No "stored as" prose in the affected column description
- [ ] Records entries for bs-caa unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)