### PR TITLE
data-dictionary: remove redundant transforms block from ca-tc source definition

### DIFF
--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -122,10 +122,6 @@ sources:
           31: DATE_MANUFACTURE_ASSEMBLY
           42: MODE_S_TRANSPONDER_BINARY
           46: TRIMMED_MARK
-        transforms:
-          MODE_S_TRANSPONDER_BINARY: "24-char binary string — format(int(value, 2), '06X') → ICAO hex"
-          TRIMMED_MARK: "MARK without leading spaces; prepend 'C-' to form full registration"
-          DATE_MANUFACTURE_ASSEMBLY: "YYYY/MM/DD — replace '/' with '-' for ISO 8601"
       - name: carsownr.txt
         format: csv
         description: "Owner/registrant records; joined to carscurr.txt by MARK_LINK = MARK; filter ACTIVE_FLAG='A'"


### PR DESCRIPTION
Closes #215

## Summary
- Remove file-level `transforms:` block from `sources.ca-tc.files[0]` (carscurr.txt)
- Transform logic for `MODE_S_TRANSPONDER_BINARY`, `TRIMMED_MARK`, and `DATE_MANUFACTURE_ASSEMBLY` is already fully documented with structured `transform:` blocks in `records.flight.fields`
- No records changes needed

## Test plan
- [ ] `transforms:` block no longer present under `sources.ca-tc.files[0]`
- [ ] Records entries for ca-tc unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)