### PR TITLE
data-dictionary: clean br-anac fields block

### DIFF
--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -215,16 +215,16 @@ sources:
     notes: "JSON array, UTF-8 BOM encoded, ~43MB, ~34,551 total records; no ICAO hex — resolved via RediSearch against Mictronics records; must run after Mictronics; active filter: DTCANC is null AND CDINTERDICAO does not start with R (trademark reservation) or M (cancelled); MARCA stored without hyphen (PPAJH) — insert hyphen after position 2 (PP-AJH); CDCLS encodes aircraft type (position 1), engine count (position 2), and propulsion (position 3); PROPRIETARIOSJSON uses non-standard /\"\" escape for double-quotes"
     fields:
       MARCA:              Registration mark without hyphen (e.g. PPAJH → PP-AJH)
-      DTCANC:             Cancellation date; null = still active
-      CDINTERDICAO:       Status code; R=trademark reservation, M=cancelled — exclude both
+      DTCANC:             Cancellation date; not stored
+      CDINTERDICAO:       Interdiction status code; not stored
       NMFABRICANTE:       Aircraft manufacturer name
       DSMODELO:           Aircraft model designation
       CDTIPOICAO:         ICAO type designator (4-char)
       NRSERIE:            Serial number
       NRASSENTOS:         Number of seats (numeric string)
       NRANOFABRICACAO:    Year of manufacture (4-digit string; may be null)
-      CDCLS:              Aircraft classification code — position 1=landing type, position 2=engine count, position 3=propulsion; special value RPA=drone
-      PROPRIETARIOSJSON:  JSON array of owners; non-standard /\"\" escaping for double-quotes; first entry NOME used as registrant name
+      CDCLS:              Aircraft classification code
+      PROPRIETARIOSJSON:  JSON array of owners; uses non-standard /\"\" escaping for double-quotes
 
   au-casa:
     description: "Australia Civil Aviation Safety Authority (CASA) aircraft register — VH-prefix registrations"


### PR DESCRIPTION
Closes #218

## Summary
- `DTCANC` and `CDINTERDICAO`: retained as not-stored documentation (per not-stored columns policy); filter prose removed from descriptions — structured `filter:` blocks for these are tracked in #267
- `CDCLS`: trimmed description to high-level only; position/decode detail already in `records.flight.fields` `decode_character` transforms
- `PROPRIETARIOSJSON`: removed "first entry NOME used as registrant name" field-mapping prose; kept non-standard escaping note
- No records changes

## Test plan
- [ ] `DTCANC` and `CDINTERDICAO` present with clean "not stored" descriptions
- [ ] `CDCLS` description contains no position/decode detail
- [ ] `PROPRIETARIOSJSON` description contains no field-mapping prose
- [ ] Records entries for br-anac unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)