### PR TITLE
bg-caa: update aircraft.type decode table mapping

### DIFF
--- a/data-runners/bg-caa/main.py
+++ b/data-runners/bg-caa/main.py
@@ -57,13 +57,12 @@ BATCH_SIZE = 100
 _WHITESPACE_RE = re.compile(r"\s+")
 
 _CATEGORY_MAP = {
-    "experimental": None,
     "glider": "Glider",
     "gyroplane": "Gyroplane",
     "hot-air balloon": "Balloon",
     "large aeroplane": "Airplane",
     "motor-hanglider": "Weight-Shift-Control",
-    "paramotor-trike": "Weight-Shift-Control",
+    "paramotor-trike": "Paramotor Trike",
     "powered sailplane": "Powered Glider",
     "rotorcraft": "Rotorcraft",
     "sailplane": "Glider",

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -1991,10 +1991,9 @@ records:
               - source: bg-caa
                 file: "Aircraft_Register_{YYYYMMDD}.xlsx"
                 field: "Категория ВС (col 5)"
-                skip_if_value: Experimental
                 transform:
                   type: decode_table
-                  description: "Case-insensitive category label"
+                  description: "Case-insensitive category label; unmapped values omitted"
                   values:
                     "Small Aeroplane": Airplane
                     "Large Aeroplane": Airplane
@@ -2007,7 +2006,7 @@ records:
                     "Gyroplane": Gyroplane
                     "Hot-air Balloon": Balloon
                     "Motor-hanglider": Weight-Shift-Control
-                    "Paramotor-Trike": Weight-Shift-Control
+                    "Paramotor-Trike": Paramotor Trike
               - source: lv-caa
                 field: Aircraft_Model_Category
               - source: rs-cad


### PR DESCRIPTION
Closes #237

## Summary
- `Paramotor-Trike` now maps to `Paramotor Trike` (was `Weight-Shift-Control`) in both the data-dictionary decode table and the runner `_CATEGORY_MAP`
- Removed `skip_if_value: Experimental` from data-dictionary and `"experimental": None` from runner — unmapped values are silently omitted by the existing `if aircraft_type:` guard

## Test plan
- [ ] `Paramotor-Trike` → `Paramotor Trike` in `_CATEGORY_MAP`
- [ ] `experimental` key absent from `_CATEGORY_MAP`
- [ ] `skip_if_value: Experimental` absent from data-dictionary bg-caa entry
- [ ] `"Paramotor-Trike": Paramotor Trike` in data-dictionary decode table

🤖 Generated with [Claude Code](https://claude.com/claude-code)