### PR TITLE
au-casa: update aircraft.type decode table — Motor-Glider → Powered Glider

### DIFF
--- a/data-runners/au-casa/main.py
+++ b/data-runners/au-casa/main.py
@@ -61,7 +61,7 @@ _AIRCRAFT_TYPES: dict[str, str] = {
     "Rotorcraft": "Helicopter",
     "Glider": "Glider",
     "Manned Free Balloon": "Balloon",
-    "Motor-Glider": "Glider",
+    "Motor-Glider": "Powered Glider",
 }
 
 # Engtype → powerplant.type; None = omit field; pass through unknown values

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -1879,7 +1879,7 @@ records:
                     "Rotorcraft": Helicopter
                     "Glider": Glider
                     "Manned Free Balloon": Balloon
-                    "Motor-Glider": Glider
+                    "Motor-Glider": Powered Glider
               - source: uk-caa
                 endpoint: details
                 field: AircraftDetails.AircraftClass


### PR DESCRIPTION
Closes #239

## Summary
- `Motor-Glider` now maps to `Powered Glider` (was `Glider`) in both the data-dictionary decode table and the runner `_AIRFRAME_TYPES` map

## Test plan
- [ ] `"Motor-Glider": "Powered Glider"` in `data-runners/au-casa/main.py`
- [ ] `"Motor-Glider": Powered Glider` in `specs/data-dictionary.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)