### PR TITLE
nz-caa: update aircraft.type decode table — Power Glider → Powered Glider

### DIFF
--- a/data-runners/nz-caa/main.py
+++ b/data-runners/nz-caa/main.py
@@ -50,7 +50,7 @@ _AIRCRAFT_TYPES: dict[str, str] = {
     "Microlight Class 1": "Microlight",
     "Microlight Class 2": "Microlight",
     "Glider": "Glider",
-    "Power Glider": "Glider",
+    "Power Glider": "Powered Glider",
     "Amateur Built Glider": "Glider",
     "Gyroplane (Gyrocopter)": "Gyroplane",
     "Balloon (hot-air)": "Balloon",

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -1848,7 +1848,7 @@ records:
                     "Microlight Class 1": Microlight
                     "Microlight Class 2": Microlight
                     "Glider": Glider
-                    "Power Glider": Glider
+                    "Power Glider": Powered Glider
                     "Amateur Built Glider": Glider
                     "Gyroplane (Gyrocopter)": Gyroplane
                     "Balloon (hot-air)": Balloon


### PR DESCRIPTION
Closes #240

## Summary
- `Power Glider` now maps to `Powered Glider` (was `Glider`) in both the data-dictionary decode table and the runner type map

## Test plan
- [ ] `"Power Glider": "Powered Glider"` in `data-runners/nz-caa/main.py`
- [ ] `"Power Glider": Powered Glider` in `specs/data-dictionary.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)