### PR TITLE
at-austrocontrol: update aircraft.type — Eigenstartfähiger Motorsegler → Powered Glider

### DIFF
--- a/data-runners/at-austrocontrol/main.py
+++ b/data-runners/at-austrocontrol/main.py
@@ -58,7 +58,7 @@ _AIRCRAFT_TYPE_MAP: dict[str, str] = {
     "Flugzeug": "Airplane",
     "Hubschrauber": "Helicopter",
     "Tragschrauber": "Gyroplane",
-    "Eigenstartfähiger Motorsegler": "Glider",
+    "Eigenstartfähiger Motorsegler": "Powered Glider",
     "Nicht eigenstartfähiger Motorsegler": "Glider",
 }
 

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -1932,7 +1932,7 @@ records:
                     "Flugzeug": Airplane
                     "Hubschrauber": Helicopter
                     "Tragschrauber": Gyroplane
-                    "Eigenstartfähiger Motorsegler": Glider
+                    "Eigenstartfähiger Motorsegler": Powered Glider
                     "Nicht eigenstartfähiger Motorsegler": Glider
               - source: br-anac
                 file: dados_aeronaves.json


### PR DESCRIPTION
Closes #241

## Summary
- `Eigenstartfähiger Motorsegler` (self-launching motor glider) now maps to `Powered Glider` (was `Glider`) in both the data-dictionary decode table and the runner type map

## Test plan
- [ ] `"Eigenstartfähiger Motorsegler": "Powered Glider"` in `data-runners/at-austrocontrol/main.py`
- [ ] `"Eigenstartfähiger Motorsegler": Powered Glider` in `specs/data-dictionary.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)