### PR TITLE
uk-caa: map AircraftClass to aircraft.category

### DIFF
--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -47,6 +47,12 @@ _LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 # Decode tables
 # ---------------------------------------------------------------------------
 
+_AIRCRAFT_CATEGORIES: dict[str, str] = {
+    "FIXED-WING LANDPLANE": "Land",
+    "FIXED-WING SEAPLANE": "Sea",
+    "FIXED-WING AMPHIBIAN": "Amphibian",
+}
+
 _AIRCRAFT_CLASSES: dict[str, str] = {
     "FIXED-WING LANDPLANE": "Airplane",
     "FIXED-WING SEAPLANE": "Airplane",
@@ -132,6 +138,12 @@ def _decode_aircraft_class(raw: str) -> Optional[str]:
     return _AIRCRAFT_CLASSES.get(value, raw.strip().title() or None)
 
 
+def _decode_aircraft_category(raw: str) -> Optional[str]:
+    """Map UK CAA AircraftClass to canonical aircraft.category; returns None for non-fixed-wing."""
+    value = raw.strip().upper() if raw else ""
+    return _AIRCRAFT_CATEGORIES.get(value)
+
+
 def _decode_country(raw: str) -> Optional[str]:
     """Map full English country name to ISO 3166-1 alpha-2; returns raw name if unmapped."""
     value = raw.strip().upper() if raw else ""
@@ -170,8 +182,10 @@ def _build_record(details: dict) -> Optional[dict]:
 
     # aircraft sub-object
     max_pax = aircraft_details.get("MaximumPassengers")
+    aircraft_class_raw = aircraft_details.get("AircraftClass", "")
     aircraft_fields = {
-        "type": _decode_aircraft_class(aircraft_details.get("AircraftClass", "")),
+        "type": _decode_aircraft_class(aircraft_class_raw),
+        "category": _decode_aircraft_category(aircraft_class_raw),
         "manufacturer": (aircraft_details.get("Manufacturer") or "").strip() or None,
         "model": (aircraft_details.get("Type") or "").strip() or None,
         "serial_number": (aircraft_details.get("SerialNumber") or "").strip() or None,

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -49,6 +49,7 @@ def _load_main():
 _mod = _load_main()
 
 _decode_aircraft_class = _mod._decode_aircraft_class
+_decode_aircraft_category = _mod._decode_aircraft_category
 _decode_country = _mod._decode_country
 _parse_year_built = _mod._parse_year_built
 _build_record = _mod._build_record
@@ -166,6 +167,30 @@ class TestDecodeAircraftClass:
 
     def test_none_returns_none(self):
         assert _decode_aircraft_class(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _decode_aircraft_category
+# ---------------------------------------------------------------------------
+
+class TestDecodeAircraftCategory:
+    def test_landplane(self):
+        assert _decode_aircraft_category("FIXED-WING LANDPLANE") == "Land"
+
+    def test_seaplane(self):
+        assert _decode_aircraft_category("FIXED-WING SEAPLANE") == "Sea"
+
+    def test_amphibian(self):
+        assert _decode_aircraft_category("FIXED-WING AMPHIBIAN") == "Amphibian"
+
+    def test_rotorcraft_returns_none(self):
+        assert _decode_aircraft_category("ROTORCRAFT") is None
+
+    def test_empty_returns_none(self):
+        assert _decode_aircraft_category("") is None
+
+    def test_case_insensitive(self):
+        assert _decode_aircraft_category("fixed-wing landplane") == "Land"
 
     def test_unknown_passes_through(self):
         result = _decode_aircraft_class("SOME UNKNOWN CLASS")

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -2202,6 +2202,16 @@ records:
                     "1": Land
                     "2": Sea
                     "3": Amphibian
+              - source: uk-caa
+                endpoint: details
+                field: AircraftDetails.AircraftClass
+                transform:
+                  type: decode_table
+                  description: "Fixed-wing class determines landing category; rotorcraft and other types omitted"
+                  values:
+                    "FIXED-WING LANDPLANE": Land
+                    "FIXED-WING SEAPLANE": Sea
+                    "FIXED-WING AMPHIBIAN": Amphibian
 
           manufacturer:
             type: string


### PR DESCRIPTION
Closes #245

## Summary
- Added `_AIRCRAFT_CATEGORIES` dict mapping the three fixed-wing AircraftClass values to canonical category strings (`Land`, `Sea`, `Amphibian`)
- Added `_decode_aircraft_category()` function; rotorcraft and other types return `None` (omitted)
- Wired `category` into `aircraft_fields` in `_build_record` alongside existing `type` decode — both read the same `AircraftClass` field
- Added `aircraft.category` source entry for `uk-caa` in `specs/data-dictionary.yaml` with a `decode_table` transform
- Added 6 tests in `TestDecodeAircraftCategory`

## Test plan
- [ ] 86 tests pass
- [ ] `FIXED-WING LANDPLANE` → `Land`, `FIXED-WING SEAPLANE` → `Sea`, `FIXED-WING AMPHIBIAN` → `Amphibian`
- [ ] Rotorcraft and other classes produce no `category` field
- [ ] data-dictionary uk-caa entry present under `aircraft.category`

🤖 Generated with [Claude Code](https://claude.com/claude-code)