### PR TITLE
br-anac: map CDCLS to aircraft.category

### DIFF
--- a/data-runners/br-anac/main.py
+++ b/data-runners/br-anac/main.py
@@ -62,6 +62,14 @@ _AIRCRAFT_TYPE_MAP: dict[str, str] = {
     "S": "Seaplane",
 }
 
+_AIRCRAFT_CATEGORY_MAP: dict[str, str] = {
+    "L": "Land",
+    "H": "Land",
+    "A": "Amphibian",
+    "G": "Land",
+    "S": "Sea",
+}
+
 _ENGINE_TYPE_MAP: dict[str, str] = {
     "P": "Piston",
     "J": "Turbo-jet",
@@ -193,9 +201,17 @@ def _build_record(icao_hex: str, registration: str, row: dict) -> dict:
     """Build the aircraft:detail:{hex} enrichment record from a RAB row."""
     aircraft_type, engine_count, engine_type = _decode_cdcls(row.get("CDCLS"))
 
+    cdcls_raw = (row.get("CDCLS") or "").strip().upper()
+    if cdcls_raw == "RPA":
+        aircraft_category: Optional[str] = "Land"
+    else:
+        aircraft_category = _AIRCRAFT_CATEGORY_MAP.get(cdcls_raw[:1]) if cdcls_raw else None
+
     aircraft_fields: dict = {}
     if aircraft_type:
         aircraft_fields["type"] = aircraft_type
+    if aircraft_category:
+        aircraft_fields["category"] = aircraft_category
     manufacturer = (row.get("NMFABRICANTE") or "").strip()
     if manufacturer:
         aircraft_fields["manufacturer"] = manufacturer

--- a/data-runners/br-anac/tests/test_br_anac.py
+++ b/data-runners/br-anac/tests/test_br_anac.py
@@ -401,6 +401,34 @@ class TestBuildRecord:
         assert "type" not in record.get("aircraft", {})
         assert "powerplant" not in record
 
+    def test_aircraft_category_land_from_l(self):
+        record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="L1P"))
+        assert record["aircraft"]["category"] == "Land"
+
+    def test_aircraft_category_land_from_h(self):
+        record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="H1T"))
+        assert record["aircraft"]["category"] == "Land"
+
+    def test_aircraft_category_amphibian(self):
+        record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="A1P"))
+        assert record["aircraft"]["category"] == "Amphibian"
+
+    def test_aircraft_category_land_from_g(self):
+        record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="G1P"))
+        assert record["aircraft"]["category"] == "Land"
+
+    def test_aircraft_category_sea(self):
+        record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="S1P"))
+        assert record["aircraft"]["category"] == "Sea"
+
+    def test_aircraft_category_rpa_is_land(self):
+        record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="RPA"))
+        assert record["aircraft"]["category"] == "Land"
+
+    def test_null_cdcls_omits_category(self):
+        record = _build_record("E491A0", "PP-AJH", _make_row(cdcls=None))
+        assert "category" not in record.get("aircraft", {})
+
 
 # ---------------------------------------------------------------------------
 # Tests: write_to_redis

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -2202,6 +2202,18 @@ records:
                     "1": Land
                     "2": Sea
                     "3": Amphibian
+              - source: br-anac
+                field: CDCLS
+                transform:
+                  type: decode_table
+                  description: "Position 1 (index 0) of CDCLS is the landing type; special value 'RPA' maps to Land"
+                  values:
+                    "L": Land
+                    "H": Land
+                    "A": Amphibian
+                    "G": Land
+                    "S": Sea
+                    "RPA": Land
               - source: uk-caa
                 endpoint: details
                 field: AircraftDetails.AircraftClass


### PR DESCRIPTION
Closes #246

## Summary
- Added `_AIRCRAFT_CATEGORY_MAP` keyed on CDCLS position 0 (landing type character): `L`/`H`/`G` → `Land`, `A` → `Amphibian`, `S` → `Sea`
- Special case `RPA` → `Land` handled before the map lookup in `_build_record`
- Added `aircraft.category` source entry for `br-anac` in `specs/data-dictionary.yaml` with `decode_table` transform
- Added 7 tests covering all mapped values plus null/omit case

## Test plan
- [ ] 90 tests pass
- [ ] `L`, `H`, `G` → `Land`; `A` → `Amphibian`; `S` → `Sea`; `RPA` → `Land`
- [ ] Null CDCLS produces no `category` field
- [ ] Data-dictionary br-anac entry present under `aircraft.category`

🤖 Generated with [Claude Code](https://claude.com/claude-code)