### PR TITLE
data-dictionary: add file-level filter block to mv-caa source

### DIFF
--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -606,25 +606,28 @@ sources:
     url: "https://www.caa.gov.mv/operations/registration-of-aircraft-and-mortgages"
     format: pdf
     cadence: weekly_tuesday
-    notes: "PDF URL discovered by scraping index page each run (filename is an opaque hash); landscape-format PDF; ~8 pages, ~138 records; pdfplumber extract_table() used; rows filtered to Status == 'Valid'; owner field is multiline — first line stored as registrant.names[0], remaining lines joined and stored as registrant.street; Legal Owner, MTOW, mortgage/AREDI columns not stored; no ICAO hex — resolved via RediSearch reverse-lookup against Mictronics records; must run after Mictronics"
+    notes: "PDF URL discovered by scraping index page each run (filename is an opaque hash); landscape-format PDF; ~8 pages, ~138 records; pdfplumber extract_table() used; owner field is multiline — first line stored as registrant.names[0], remaining lines joined and stored as registrant.street; Legal Owner, MTOW, mortgage/AREDI columns not stored; no ICAO hex — resolved via RediSearch reverse-lookup against Mictronics records; must run after Mictronics"
     files:
       - name: "Aircraft register PDF (opaque hash filename; discovered via index page)"
         format: pdf_table
-    columns:
-      0: "Sequence number; not stored"
-      1: "Certificate number; not stored"
-      2: "Registration mark (8Q-prefix; lookup key)"
-      3: "Manufacturer and model designation (may contain embedded newlines)"
-      4: "Maximum takeoff weight; not stored"
-      5: "Manufacturer serial number"
-      6: "Year of manufacture (4-digit integer)"
-      7: "Owner name and address (multiline; first line is name, last line is country, middle lines are street address)"
-      8: "Legal owner; not stored"
-      9: "Registration basis; not stored"
-      "10-12": "Mortgage and AREDI columns; not stored"
-      13: "Original issue date; not stored"
-      14: "Last revision date; not stored"
-      15: "Registration status; records filtered to 'Valid' only; not stored"
+        columns:
+          0: "Sequence number; not stored"
+          1: "Certificate number; not stored"
+          2: "Registration mark (8Q-prefix; lookup key)"
+          3: "Manufacturer and model designation (may contain embedded newlines)"
+          4: "Maximum takeoff weight; not stored"
+          5: "Manufacturer serial number"
+          6: "Year of manufacture (4-digit integer)"
+          7: "Owner name and address (multiline; first line is name, last line is country, middle lines are street address)"
+          8: "Legal owner; not stored"
+          9: "Registration basis; not stored"
+          "10-12": "Mortgage and AREDI columns; not stored"
+          13: "Original issue date; not stored"
+          14: "Last revision date; not stored"
+          15: "Registration status; not stored"
+        filter:
+          field: "15"
+          skip_if_not_value: Valid
 
   md-caa:
     description: "Moldova CAA aircraft register — ER-prefix registrations"


### PR DESCRIPTION
Closes #264

## Summary
- Move `columns:` inside `files[0]` to fix structural inconsistency (was at source level)
- Clean column 15 description — remove "records filtered to 'Valid' only" filter prose
- Add `filter: { field: "15", skip_if_not_value: Valid }` at file level (`skip_if_not_value` is a new operator)
- Remove filter prose from `notes:`

## Test plan
- [ ] `columns:` is now nested inside `files[0]`
- [ ] Column 15 description contains no filter prose
- [ ] `filter:` block present with `skip_if_not_value: Valid`
- [ ] Filter prose removed from `notes:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)