### PR TITLE
defect: nest powerplant under aircraft in runners and data dictionary

### DIFF
--- a/data-runners/au-casa/main.py
+++ b/data-runners/au-casa/main.py
@@ -219,7 +219,7 @@ def _escape_tag(value: str) -> str:
 def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
     """Build the enrichment record from a CASA CSV row."""
     # aircraft sub-object
-    aircraft_fields = {
+    aircraft_fields: dict = {
         "type": _decode_aircraft_type(row.get("Airframe", "")),
         "manufacturer": row.get("Manu", "").strip() or None,
         "model": row.get("Model", "").strip() or None,
@@ -227,7 +227,6 @@ def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
         "manufactured_date": _parse_manufactured_date(row.get("Yearmanu", "")),
         "type_designator": row.get("ICAOtypedesig", "").strip() or None,
     }
-    aircraft = {k: v for k, v in aircraft_fields.items() if v is not None} or None
 
     # powerplant sub-object
     powerplant_fields = {
@@ -237,6 +236,10 @@ def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
         "model": row.get("Engmodel", "").strip() or None,
     }
     powerplant = {k: v for k, v in powerplant_fields.items() if v is not None} or None
+    if powerplant:
+        aircraft_fields["powerplant"] = powerplant
+
+    aircraft = {k: v for k, v in aircraft_fields.items() if v is not None} or None
 
     # registrant sub-object
     name = row.get("regholdname", "").strip() or None
@@ -257,8 +260,6 @@ def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
     record: dict = {"icao_hex": icao_hex, "registration": registration}
     if aircraft:
         record["aircraft"] = aircraft
-    if powerplant:
-        record["powerplant"] = powerplant
     if registrant:
         record["registrant"] = registrant
     return record

--- a/data-runners/br-anac/main.py
+++ b/data-runners/br-anac/main.py
@@ -243,7 +243,7 @@ def _build_record(icao_hex: str, registration: str, row: dict) -> dict:
     if aircraft_fields:
         record["aircraft"] = aircraft_fields
     if powerplant_fields:
-        record["powerplant"] = powerplant_fields
+        aircraft_fields["powerplant"] = powerplant_fields
     if nome:
         record["registrant"] = {"names": [nome]}
     return record

--- a/data-runners/br-anac/tests/test_br_anac.py
+++ b/data-runners/br-anac/tests/test_br_anac.py
@@ -377,15 +377,15 @@ class TestBuildRecord:
 
     def test_powerplant_count_from_cdcls(self):
         record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="L2P"))
-        assert record["powerplant"]["count"] == 2
+        assert record["aircraft"]["powerplant"]["count"] == 2
 
     def test_powerplant_type_from_cdcls(self):
         record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="H1T"))
-        assert record["powerplant"]["type"] == "Turbo-shaft"
+        assert record["aircraft"]["powerplant"]["type"] == "Turbo-shaft"
 
     def test_no_powerplant_for_glider(self):
         record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="L00"))
-        assert "powerplant" not in record
+        assert "powerplant" not in record.get("aircraft", {})
 
     def test_registrant_from_proprietariosjson(self):
         raw = json.dumps([{"NOME": "João Silva"}]).replace('"', '/""')
@@ -399,7 +399,7 @@ class TestBuildRecord:
     def test_null_cdcls_omits_type_and_powerplant(self):
         record = _build_record("E491A0", "PP-AJH", _make_row(cdcls=None))
         assert "type" not in record.get("aircraft", {})
-        assert "powerplant" not in record
+        assert "powerplant" not in record.get("aircraft", {})
 
     def test_aircraft_category_land_from_l(self):
         record = _build_record("E491A0", "PP-AJH", _make_row(cdcls="L1P"))

--- a/data-runners/ca-transport-canada/main.py
+++ b/data-runners/ca-transport-canada/main.py
@@ -402,12 +402,16 @@ def build_aircraft_record(acft_row: sqlite3.Row, owner_rows: list[sqlite3.Row]) 
             "manufacturer": acft_row["engine_manufacturer"] or None,
         }
 
+    if powerplant is not None:
+        if aircraft is None:
+            aircraft = {}
+        aircraft["powerplant"] = powerplant
+
     return {
         "icao_hex": acft_row["icao_hex"],
         "registration": acft_row["registration"],
         "registrant": registrant,
         "aircraft": aircraft,
-        "powerplant": powerplant,
     }
 
 

--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -240,7 +240,7 @@ def _build_record(row: dict) -> Optional[dict]:
     if aircraft_fields:
         record["aircraft"] = aircraft_fields
     if powerplant_fields:
-        record["powerplant"] = powerplant_fields
+        aircraft_fields["powerplant"] = powerplant_fields
     if registrant:
         record["registrant"] = registrant
 

--- a/data-runners/ch-bazl/tests/test_ch_bazl.py
+++ b/data-runners/ch-bazl/tests/test_ch_bazl.py
@@ -367,19 +367,19 @@ class TestBuildRecord:
 
     def test_engine_type(self):
         record = _build_record(_make_row(engine_category="Jet Engine"))
-        assert record["powerplant"]["type"] == "Turbo-jet"
+        assert record["aircraft"]["powerplant"]["type"] == "Turbo-jet"
 
     def test_engine_manufacturer(self):
         record = _build_record(_make_row(engine_manufacturer="AVCO LYCOMING"))
-        assert record["powerplant"]["manufacturer"] == "AVCO LYCOMING"
+        assert record["aircraft"]["powerplant"]["manufacturer"] == "AVCO LYCOMING"
 
     def test_engine_manufacturer_absent_when_empty(self):
         record = _build_record(_make_row(engine_manufacturer=""))
-        assert "manufacturer" not in record.get("powerplant", {})
+        assert "manufacturer" not in record.get("aircraft", {}).get("powerplant", {})
 
     def test_engine_model(self):
         record = _build_record(_make_row(engine="GE90-115BL"))
-        assert record["powerplant"]["model"] == "GE90-115BL"
+        assert record["aircraft"]["powerplant"]["model"] == "GE90-115BL"
 
     def test_registrant_name(self):
         record = _build_record(_make_row())
@@ -394,11 +394,11 @@ class TestBuildRecord:
 
     def test_no_engine_omits_powerplant(self):
         record = _build_record(_make_row(engine_category="", engine_manufacturer="", engine=""))
-        assert "powerplant" not in record
+        assert "powerplant" not in record.get("aircraft", {})
 
     def test_glider_no_engine_omits_powerplant(self):
         record = _build_record(_make_row(aircraft_type="Glider", engine_category="", engine_manufacturer="", engine=""))
-        assert "powerplant" not in record
+        assert "powerplant" not in record.get("aircraft", {})
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/es-aesa/main.py
+++ b/data-runners/es-aesa/main.py
@@ -188,7 +188,7 @@ def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
     if aircraft_fields:
         record["aircraft"] = aircraft_fields
     if powerplant_fields:
-        record["powerplant"] = powerplant_fields
+        aircraft_fields["powerplant"] = powerplant_fields
 
     return record
 

--- a/data-runners/es-aesa/tests/test_es_aesa.py
+++ b/data-runners/es-aesa/tests/test_es_aesa.py
@@ -194,9 +194,9 @@ class TestBuildRecord:
         assert record["aircraft"]["model"] == "A320"
         assert record["aircraft"]["serial_number"] == "1234"
         assert record["aircraft"]["manufactured_date"] == "2019-01-01"
-        assert record["powerplant"]["manufacturer"] == "CFM"
-        assert record["powerplant"]["model"] == "CFM56-5B"
-        assert record["powerplant"]["count"] == 2
+        assert record["aircraft"]["powerplant"]["manufacturer"] == "CFM"
+        assert record["aircraft"]["powerplant"]["model"] == "CFM56-5B"
+        assert record["aircraft"]["powerplant"]["count"] == 2
         assert record["aircraft"]["type"] == "Airplane"
 
     def test_no_registrant_key(self):
@@ -228,13 +228,13 @@ class TestBuildRecord:
     def test_powerplant_count_is_integer(self):
         row = _make_row(num_mot="4")
         record = _build_record(row, "340123", "EC-ABC")
-        assert record["powerplant"]["count"] == 4
-        assert isinstance(record["powerplant"]["count"], int)
+        assert record["aircraft"]["powerplant"]["count"] == 4
+        assert isinstance(record["aircraft"]["powerplant"]["count"], int)
 
     def test_invalid_powerplant_count_omitted(self):
         row = _make_row(num_mot="N/A")
         record = _build_record(row, "340123", "EC-ABC")
-        assert "count" not in record.get("powerplant", {})
+        assert "count" not in record.get("aircraft", {}).get("powerplant", {})
 
     def test_unknown_clase_omits_type(self):
         row = _make_row(clase="DESCONOCIDO")

--- a/data-runners/nl-ilt/main.py
+++ b/data-runners/nl-ilt/main.py
@@ -244,7 +244,7 @@ def _build_record(row: dict) -> Optional[dict]:
     if aircraft_fields:
         record["aircraft"] = aircraft_fields
     if powerplant_fields:
-        record["powerplant"] = powerplant_fields
+        aircraft_fields["powerplant"] = powerplant_fields
 
     return record
 

--- a/data-runners/sg-caas/main.py
+++ b/data-runners/sg-caas/main.py
@@ -169,7 +169,7 @@ def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
     if aircraft_fields:
         record["aircraft"] = aircraft_fields
     if powerplant_fields:
-        record["powerplant"] = powerplant_fields
+        aircraft_fields["powerplant"] = powerplant_fields
     if registrant_fields:
         record["registrant"] = registrant_fields
 

--- a/data-runners/sg-caas/tests/test_sg_caas.py
+++ b/data-runners/sg-caas/tests/test_sg_caas.py
@@ -125,8 +125,8 @@ class TestBuildRecord:
         assert record["aircraft"]["manufacturer"] == "BOEING"
         assert record["aircraft"]["model"] == "B737-832"
         assert record["aircraft"]["serial_number"] == "27671"
-        assert record["powerplant"]["manufacturer"] == "CFM International"
-        assert record["powerplant"]["model"] == "CFM56-7B27"
+        assert record["aircraft"]["powerplant"]["manufacturer"] == "CFM International"
+        assert record["aircraft"]["powerplant"]["model"] == "CFM56-7B27"
         assert record["registrant"]["names"] == ["Singapore Airlines"]
 
     def test_empty_manufacturer_omitted(self):
@@ -147,12 +147,12 @@ class TestBuildRecord:
     def test_empty_engine_mfr_omitted(self):
         row = _make_row(engine_mfr="")
         record = _build_record(row, "76CE26", "9V-SKA")
-        assert "manufacturer" not in record.get("powerplant", {})
+        assert "manufacturer" not in record.get("aircraft", {}).get("powerplant", {})
 
     def test_empty_engine_model_omitted(self):
         row = _make_row(engine_model="")
         record = _build_record(row, "76CE26", "9V-SKA")
-        assert "model" not in record.get("powerplant", {})
+        assert "model" not in record.get("aircraft", {}).get("powerplant", {})
 
     def test_empty_operator_omits_registrant(self):
         row = _make_row(operator="")
@@ -163,7 +163,7 @@ class TestBuildRecord:
         row = _make_row(manufacturer="", model="", serial="", engine_mfr="", engine_model="")
         record = _build_record(row, "76CE26", "9V-SKA")
         assert "aircraft" not in record
-        assert "powerplant" not in record
+        assert "powerplant" not in record.get("aircraft", {})
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -183,7 +183,7 @@ def _build_record(details: dict) -> Optional[dict]:
     # aircraft sub-object
     max_pax = aircraft_details.get("MaximumPassengers")
     aircraft_class_raw = aircraft_details.get("AircraftClass", "")
-    aircraft_fields = {
+    aircraft_fields: dict = {
         "type": _decode_aircraft_class(aircraft_class_raw),
         "category": _decode_aircraft_category(aircraft_class_raw),
         "manufacturer": (aircraft_details.get("Manufacturer") or "").strip() or None,
@@ -193,7 +193,6 @@ def _build_record(details: dict) -> Optional[dict]:
         "manufactured_date": _parse_year_built(aircraft_details.get("YearBuild")),
         "seats": int(max_pax) + 1 if max_pax is not None else None,
     }
-    aircraft: Optional[dict] = {k: v for k, v in aircraft_fields.items() if v is not None} or None
 
     # powerplant sub-object — use first engine entry
     engines = aircraft_details.get("Engines") or []
@@ -208,6 +207,10 @@ def _build_record(details: dict) -> Optional[dict]:
         if name:
             pp_fields["model"] = name
         powerplant = pp_fields or None
+    if powerplant:
+        aircraft_fields["powerplant"] = powerplant
+
+    aircraft: Optional[dict] = {k: v for k, v in aircraft_fields.items() if v is not None} or None
 
     # registrant sub-object — use first registered owner
     owners = details.get("RegisteredAircraftOwners") or []
@@ -232,8 +235,6 @@ def _build_record(details: dict) -> Optional[dict]:
     record: dict = {"icao_hex": icao_hex, "registration": registration}
     if aircraft:
         record["aircraft"] = aircraft
-    if powerplant:
-        record["powerplant"] = powerplant
     if registrant:
         record["registrant"] = registrant
     return record

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -302,11 +302,11 @@ class TestBuildRecord:
 
     def test_powerplant_count(self):
         record = _build_record(_make_details(engine_count=2))
-        assert record["powerplant"]["count"] == 2
+        assert record["aircraft"]["powerplant"]["count"] == 2
 
     def test_powerplant_model(self):
         record = _build_record(_make_details(engine_name="ROLLS-ROYCE Trent 1000-K2"))
-        assert record["powerplant"]["model"] == "ROLLS-ROYCE Trent 1000-K2"
+        assert record["aircraft"]["powerplant"]["model"] == "ROLLS-ROYCE Trent 1000-K2"
 
     def test_registrant_name(self):
         record = _build_record(_make_details())
@@ -347,7 +347,7 @@ class TestBuildRecord:
         details = _make_details()
         details["AircraftDetails"]["Engines"] = []
         record = _build_record(details)
-        assert "powerplant" not in record
+        assert "powerplant" not in record.get("aircraft", {})
 
     def test_no_owners_omits_registrant(self):
         details = _make_details()

--- a/data-runners/us-faa/main.py
+++ b/data-runners/us-faa/main.py
@@ -413,12 +413,16 @@ def build_aircraft_record(
                 "power_value": power_value,
             }
 
+    if powerplant is not None:
+        if aircraft is None:
+            aircraft = {}
+        aircraft["powerplant"] = powerplant
+
     return {
         "icao_hex": reg_row["icao_hex"],
         "registration": reg_row["registration"],
         "registrant": registrant,
         "aircraft": aircraft,
-        "powerplant": powerplant,
     }
 
 

--- a/data-runners/us-faa/tests/test_us_faa.py
+++ b/data-runners/us-faa/tests/test_us_faa.py
@@ -501,7 +501,7 @@ class TestBuildAircraftRecord:
     def test_powerplant_turbofan(self):
         row, acft_row, eng_row = self._fetch_rows("A8AE7F")
         record = build_aircraft_record(row, acft_row, eng_row)
-        pp = record["powerplant"]
+        pp = record["aircraft"]["powerplant"]
         assert pp["count"] == 2
         assert pp["type"] == "Turbo-fan"
         assert pp["manufacturer"] == "PRATT & WHITNEY"
@@ -512,7 +512,7 @@ class TestBuildAircraftRecord:
     def test_powerplant_piston(self):
         row, acft_row, eng_row = self._fetch_rows("AA0001")
         record = build_aircraft_record(row, acft_row, eng_row)
-        pp = record["powerplant"]
+        pp = record["aircraft"]["powerplant"]
         assert pp["type"] == "Piston"
         assert pp["manufacturer"] == "LYCOMING"
         assert pp["model"] == "O-320-D2J"
@@ -523,7 +523,7 @@ class TestBuildAircraftRecord:
         row, _, _ = self._fetch_rows("AB1234")
         record = build_aircraft_record(row, None, None)
         assert record["aircraft"] is None
-        assert record["powerplant"] is None
+        assert "powerplant" not in (record.get("aircraft") or {})
 
     def test_manufactured_year_none_gives_null_date(self):
         row, acft_row, eng_row = self._fetch_rows("AB1234")

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -2671,243 +2671,243 @@ records:
                     "M/L": "Medium/Light"
                     "-": "Unknown/None"
 
-      powerplant:
-        type: object
-        description: "Engine and powerplant specification data"
-        persisted: true
-        properties:
-
-          count:
-            type: integer
-            description: "Number of engines installed"
+          powerplant:
+            type: object
+            description: "Engine and powerplant specification data"
             persisted: true
-            sources:
-              - source: us-faa
-                file: acftref.txt
-                field: NO-ENG
-                position: 7
-              - source: ca-tc
-                file: carscurr.txt
-                field: NUMBER_OF_ENGINES
-                position: 17
-              - source: nl-ilt
-                file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
-                field: Engines
-              - source: au-casa
-                file: acrftreg
-                field: engnum
-              - source: uk-caa
-                endpoint: details
-                field: "AircraftDetails.Engines[0].TotalNumberOfEngines"
-              - source: br-anac
-                file: dados_aeronaves.json
-                field: CDCLS
-                transform:
-                  type: decode_character
-                  position: 1
-                  description: "Position 2 (index 1) of CDCLS is the engine count digit; '0' or absent = omit; omitted for RPA (drone) records"
-              - source: es-aesa
-                file: aeronaves_inscritas.pdf
-                field: "Nº mot."
-                transform:
-                  type: parse_integer
-              - source: cz-caa
-                endpoint: detail
-                field: engine_count
-                skip_if_empty: true
-                skip_if_value: 0
+            properties:
 
-          type:
-            type: string
-            description: "Engine type (Reciprocating, Turbo-fan, etc.)"
-            persisted: true
-            sources:
-              - source: us-faa
-                file: acftref.txt
-                field: TYPE-ENG
-                position: 4
-                transform:
-                  type: decode_table
-                  values:
-                    "0": None
-                    "1": Piston
-                    "2": Turbo-prop
-                    "3": Turbo-shaft
-                    "4": Turbo-jet
-                    "5": Turbo-fan
-                    "6": Ramjet
-                    "7": 2 Cycle
-                    "8": 4 Cycle
-                    "9": Unknown
-                    "10": Electric
-                    "11": Rotary
-              - source: ca-tc
-                file: carscurr.txt
-                field: ENGINE_CATEGORY_E
-                position: 15
-                transform:
-                  type: decode_table
-                  values:
-                    "Piston": Piston
-                    "Turbo Fan": Turbo-fan
-                    "Turbo Prop": Turbo-prop
-                    "Turbo Shaft": Turbo-shaft
-                    "Turbo Jet": Turbo-jet
-                    "Electric": Electric
-                    "Other": Unknown
-              - source: nl-ilt
-                file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
-                field: EngKind
-                transform:
-                  type: decode_table_passthrough
-                  description: "Mapped to canonical type; 'Engine - not defined' and blank → omit; unknown values pass through unmodified"
-                  values:
-                    "Reciprocating piston-driven engine": Piston
-                    "Reciprocating piston radial engine": Piston
-                    "Piston-driven shaft (rotorcraft) engine": Piston
-                    "Reciprocating piston-driven Diesel engine": Diesel
-                    "Electrical engine": Electric
-                    "Turbofan engine": Turbo-fan
-                    "Turbine-driven shaft (rotorcraft) engine": Turbo-shaft
-                    "Turbine-driven propeller engine": Turbo-prop
-                    "Turbojet engine": Turbo-jet
-                    "Wankel engine": Rotary
-                    "Engine - not defined": ~~omit~~
-              - source: au-casa
-                file: acrftreg
-                field: Engtype
-                transform:
-                  type: decode_table_passthrough
-                  description: "Mapped to canonical type; 'Not Applicable' → omit; unknown values pass through unmodified"
-                  values:
-                    "Piston": Piston
-                    "Turbofan": Turbo-fan
-                    "Turboprop": Turbo-prop
-                    "Turboshaft": Turbo-shaft
-                    "Turbojet": Turbo-jet
-                    "Electric": Electric
-                    "Diesel Engine": Diesel
-                    "Rotary": Rotary
-                    "Not Applicable": ~~omit~~
-              - source: ch-bazl
-                endpoint: bulk
-                field: " Engine Category"
-                transform:
-                  type: decode_table_passthrough
-                  description: "Mapped to canonical type; comma-separated multi-engine entries take first value; unknown values pass through unmodified"
-                  values:
-                    "Piston Engine": Piston
-                    "Turboshaft Engine": Turbo-shaft
-                    "Turboprop Engine": Turbo-prop
-                    "Jet Engine": Turbo-jet
-                    "Electrical Engine": Electric
-                    "Hydrogen-Electric": Hydrogen-Electric
-              - source: br-anac
-                file: dados_aeronaves.json
-                field: CDCLS
-                transform:
-                  type: decode_character
-                  position: 2
-                  description: "Position 3 (index 2) of CDCLS is the propulsion code; T is context-sensitive: Turbo-shaft when CDCLS[0]='H' (helicopter), otherwise Turbo-prop; omitted for RPA (drone) records or when position is '0' or absent"
-                  values:
-                    "P": Piston
-                    "J": Turbo-jet
-                    "E": Electric
-                    "T": "Turbo-prop (or Turbo-shaft for helicopters — see description)"
-              - source: cz-caa
-                endpoint: detail
-                field: engine_type
-                skip_if_value: "NO_ENGINE"
-                transform:
-                  type: decode_table
-                  values:
-                    "PISTON": Piston
-                    "TURBINE": Turbine
-                    "TURBOSHAFT": Turboshaft
-                    "ELECTRIC": Electric
+              count:
+                type: integer
+                description: "Number of engines installed"
+                persisted: true
+                sources:
+                  - source: us-faa
+                    file: acftref.txt
+                    field: NO-ENG
+                    position: 7
+                  - source: ca-tc
+                    file: carscurr.txt
+                    field: NUMBER_OF_ENGINES
+                    position: 17
+                  - source: nl-ilt
+                    file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
+                    field: Engines
+                  - source: au-casa
+                    file: acrftreg
+                    field: engnum
+                  - source: uk-caa
+                    endpoint: details
+                    field: "AircraftDetails.Engines[0].TotalNumberOfEngines"
+                  - source: br-anac
+                    file: dados_aeronaves.json
+                    field: CDCLS
+                    transform:
+                      type: decode_character
+                      position: 1
+                      description: "Position 2 (index 1) of CDCLS is the engine count digit; '0' or absent = omit; omitted for RPA (drone) records"
+                  - source: es-aesa
+                    file: aeronaves_inscritas.pdf
+                    field: "Nº mot."
+                    transform:
+                      type: parse_integer
+                  - source: cz-caa
+                    endpoint: detail
+                    field: engine_count
+                    skip_if_empty: true
+                    skip_if_value: 0
 
-          model:
-            type: string
-            description: "Engine model designation (e.g. LEAP-1B28)"
-            persisted: true
-            sources:
-              - source: us-faa
-                file: engine.txt
-                field: MODEL
-                position: 2
-                join: "master.txt[3] → engine.txt[0]"
-              - source: nl-ilt
-                file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
-                field: EngModel
-                notes: "Values containing 'not further defined' are omitted"
-              - source: au-casa
-                file: acrftreg
-                field: Engmodel
-              - source: uk-caa
-                endpoint: details
-                field: "AircraftDetails.Engines[0].Name"
-              - source: ch-bazl
-                endpoint: bulk
-                field: " Engine"
-                transform:
-                  type: split_first
-                  delimiter: ", "
-                  description: "Comma-separated multi-engine entries take first value (e.g. 'CFM56-5B4/3, CFM56-5B4/P' → 'CFM56-5B4/3')"
-              - source: es-aesa
-                file: aeronaves_inscritas.pdf
-                field: "Modelo Motor"
-              - source: sg-caas
-                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
-                field: Engine Model
+              type:
+                type: string
+                description: "Engine type (Reciprocating, Turbo-fan, etc.)"
+                persisted: true
+                sources:
+                  - source: us-faa
+                    file: acftref.txt
+                    field: TYPE-ENG
+                    position: 4
+                    transform:
+                      type: decode_table
+                      values:
+                        "0": None
+                        "1": Piston
+                        "2": Turbo-prop
+                        "3": Turbo-shaft
+                        "4": Turbo-jet
+                        "5": Turbo-fan
+                        "6": Ramjet
+                        "7": 2 Cycle
+                        "8": 4 Cycle
+                        "9": Unknown
+                        "10": Electric
+                        "11": Rotary
+                  - source: ca-tc
+                    file: carscurr.txt
+                    field: ENGINE_CATEGORY_E
+                    position: 15
+                    transform:
+                      type: decode_table
+                      values:
+                        "Piston": Piston
+                        "Turbo Fan": Turbo-fan
+                        "Turbo Prop": Turbo-prop
+                        "Turbo Shaft": Turbo-shaft
+                        "Turbo Jet": Turbo-jet
+                        "Electric": Electric
+                        "Other": Unknown
+                  - source: nl-ilt
+                    file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
+                    field: EngKind
+                    transform:
+                      type: decode_table_passthrough
+                      description: "Mapped to canonical type; 'Engine - not defined' and blank → omit; unknown values pass through unmodified"
+                      values:
+                        "Reciprocating piston-driven engine": Piston
+                        "Reciprocating piston radial engine": Piston
+                        "Piston-driven shaft (rotorcraft) engine": Piston
+                        "Reciprocating piston-driven Diesel engine": Diesel
+                        "Electrical engine": Electric
+                        "Turbofan engine": Turbo-fan
+                        "Turbine-driven shaft (rotorcraft) engine": Turbo-shaft
+                        "Turbine-driven propeller engine": Turbo-prop
+                        "Turbojet engine": Turbo-jet
+                        "Wankel engine": Rotary
+                        "Engine - not defined": ~~omit~~
+                  - source: au-casa
+                    file: acrftreg
+                    field: Engtype
+                    transform:
+                      type: decode_table_passthrough
+                      description: "Mapped to canonical type; 'Not Applicable' → omit; unknown values pass through unmodified"
+                      values:
+                        "Piston": Piston
+                        "Turbofan": Turbo-fan
+                        "Turboprop": Turbo-prop
+                        "Turboshaft": Turbo-shaft
+                        "Turbojet": Turbo-jet
+                        "Electric": Electric
+                        "Diesel Engine": Diesel
+                        "Rotary": Rotary
+                        "Not Applicable": ~~omit~~
+                  - source: ch-bazl
+                    endpoint: bulk
+                    field: " Engine Category"
+                    transform:
+                      type: decode_table_passthrough
+                      description: "Mapped to canonical type; comma-separated multi-engine entries take first value; unknown values pass through unmodified"
+                      values:
+                        "Piston Engine": Piston
+                        "Turboshaft Engine": Turbo-shaft
+                        "Turboprop Engine": Turbo-prop
+                        "Jet Engine": Turbo-jet
+                        "Electrical Engine": Electric
+                        "Hydrogen-Electric": Hydrogen-Electric
+                  - source: br-anac
+                    file: dados_aeronaves.json
+                    field: CDCLS
+                    transform:
+                      type: decode_character
+                      position: 2
+                      description: "Position 3 (index 2) of CDCLS is the propulsion code; T is context-sensitive: Turbo-shaft when CDCLS[0]='H' (helicopter), otherwise Turbo-prop; omitted for RPA (drone) records or when position is '0' or absent"
+                      values:
+                        "P": Piston
+                        "J": Turbo-jet
+                        "E": Electric
+                        "T": "Turbo-prop (or Turbo-shaft for helicopters — see description)"
+                  - source: cz-caa
+                    endpoint: detail
+                    field: engine_type
+                    skip_if_value: "NO_ENGINE"
+                    transform:
+                      type: decode_table
+                      values:
+                        "PISTON": Piston
+                        "TURBINE": Turbine
+                        "TURBOSHAFT": Turboshaft
+                        "ELECTRIC": Electric
 
-          manufacturer:
-            type: string
-            description: "Engine manufacturer name"
-            persisted: true
-            sources:
-              - source: us-faa
-                file: engine.txt
-                field: MFR
-                position: 1
-                join: "master.txt[3] → engine.txt[0]"
-              - source: ca-tc
-                file: carscurr.txt
-                field: ENGINE_MANUF_E
-                position: 13
-              - source: nl-ilt
-                file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
-                field: EngManufacturer
-                notes: "Values of 'Unknown' are omitted"
-              - source: au-casa
-                file: acrftreg
-                field: Engmanu
-              - source: ch-bazl
-                endpoint: bulk
-                field: " Engine manufacturer"
-              - source: es-aesa
-                file: aeronaves_inscritas.pdf
-                field: "Marca Motor"
-              - source: sg-caas
-                file: Aircraft-Register-as-at-{MonYYYY}.xlsx
-                field: Engine Manufacturer
+              model:
+                type: string
+                description: "Engine model designation (e.g. LEAP-1B28)"
+                persisted: true
+                sources:
+                  - source: us-faa
+                    file: engine.txt
+                    field: MODEL
+                    position: 2
+                    join: "master.txt[3] → engine.txt[0]"
+                  - source: nl-ilt
+                    file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
+                    field: EngModel
+                    notes: "Values containing 'not further defined' are omitted"
+                  - source: au-casa
+                    file: acrftreg
+                    field: Engmodel
+                  - source: uk-caa
+                    endpoint: details
+                    field: "AircraftDetails.Engines[0].Name"
+                  - source: ch-bazl
+                    endpoint: bulk
+                    field: " Engine"
+                    transform:
+                      type: split_first
+                      delimiter: ", "
+                      description: "Comma-separated multi-engine entries take first value (e.g. 'CFM56-5B4/3, CFM56-5B4/P' → 'CFM56-5B4/3')"
+                  - source: es-aesa
+                    file: aeronaves_inscritas.pdf
+                    field: "Modelo Motor"
+                  - source: sg-caas
+                    file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                    field: Engine Model
 
-          power_type:
-            type: string
-            description: "Power rating unit — Horsepower (piston/turbo-prop) or Thrust (jet)"
-            persisted: true
-            sources:
-              - source: us-faa
-                file: engine.txt
-                description: "Derived from engine TYPE; piston/prop → Horsepower; jet → Thrust"
+              manufacturer:
+                type: string
+                description: "Engine manufacturer name"
+                persisted: true
+                sources:
+                  - source: us-faa
+                    file: engine.txt
+                    field: MFR
+                    position: 1
+                    join: "master.txt[3] → engine.txt[0]"
+                  - source: ca-tc
+                    file: carscurr.txt
+                    field: ENGINE_MANUF_E
+                    position: 13
+                  - source: nl-ilt
+                    file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
+                    field: EngManufacturer
+                    notes: "Values of 'Unknown' are omitted"
+                  - source: au-casa
+                    file: acrftreg
+                    field: Engmanu
+                  - source: ch-bazl
+                    endpoint: bulk
+                    field: " Engine manufacturer"
+                  - source: es-aesa
+                    file: aeronaves_inscritas.pdf
+                    field: "Marca Motor"
+                  - source: sg-caas
+                    file: Aircraft-Register-as-at-{MonYYYY}.xlsx
+                    field: Engine Manufacturer
 
-          power_value:
-            type: integer
-            description: "Rated power output in horsepower or pounds of thrust"
-            persisted: true
-            sources:
-              - source: us-faa
-                file: engine.txt
-                description: "HORSEPOWER or THRUST column depending on engine type"
+              power_type:
+                type: string
+                description: "Power rating unit — Horsepower (piston/turbo-prop) or Thrust (jet)"
+                persisted: true
+                sources:
+                  - source: us-faa
+                    file: engine.txt
+                    description: "Derived from engine TYPE; piston/prop → Horsepower; jet → Thrust"
+
+              power_value:
+                type: integer
+                description: "Rated power output in horsepower or pounds of thrust"
+                persisted: true
+                sources:
+                  - source: us-faa
+                    file: engine.txt
+                    description: "HORSEPOWER or THRUST column depending on engine type"
 
       military:
         type: boolean


### PR DESCRIPTION
Closes #185

## Summary
- Moved `powerplant` object from a top-level sibling of `aircraft` to a nested property inside `aircraft` in `specs/data-dictionary.yaml` (re-indented the entire block)
- Updated all 9 affected runner `main.py` files to write `aircraft["powerplant"]` instead of a top-level `record["powerplant"]`
- Updated all 6 runner test files to assert `record["aircraft"]["powerplant"][...]` accordingly

## Runners changed
us-faa, ca-tc, nl-ilt, au-casa, uk-caa, ch-bazl, br-anac, es-aesa, sg-caas

## Test plan
- [ ] All 6 affected test suites pass (61 + 86 + 86 + 90 + 32 + 47 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)