### PR TITLE
enhancement: rename Redis aircraft keys simple→mictronics, detail→registry

### DIFF
--- a/data-runners/at-austrocontrol/main.py
+++ b/data-runners/at-austrocontrol/main.py
@@ -5,7 +5,7 @@ SkyFollower Austria Austrocontrol Data Runner
 Downloads the Austrian aircraft register from Austrocontrol, looks up each
 OE- registration in the Redis simple search index to find the ICAO hex (provided
 by Mictronics), runs a type sanity check against the aircraft:simple record, then
-writes enrichment data to aircraft:detail:{icao_hex} and publishes MQTT completion
+writes enrichment data to aircraft:registry:{icao_hex} and publishes MQTT completion
 stats, then exits.
 
 Important: the Austrocontrol register does not publish ICAO hex (Mode S) addresses.
@@ -37,10 +37,10 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
-    aircraft_simple_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
+    aircraft_mictronics_key,
 )
 
 logger = logging.getLogger("at-austrocontrol")
@@ -266,16 +266,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -296,13 +296,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -382,13 +382,13 @@ def write_to_redis(items: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         item = reg_to_item[registration]
         baumuster = (item.get("baumuster") or "").strip()
 
-        simple_raw = r.json().get(aircraft_simple_key(icao_hex))
+        simple_raw = r.json().get(aircraft_mictronics_key(icao_hex))
         if not simple_raw or not _type_check_passes(simple_raw, baumuster):
             logger.debug("Type sanity check failed for %s, skipping", registration)
             continue
 
         record = _build_record(item, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         pipe_count += 1

--- a/data-runners/at-austrocontrol/tests/test_at_austrocontrol.py
+++ b/data-runners/at-austrocontrol/tests/test_at_austrocontrol.py
@@ -90,7 +90,7 @@ def _make_redis_with_search(icao_hex="440123", registration="OE-ARG", simple_rec
     """Redis mock that returns a search result and a simple aircraft record for the type check."""
     r = _make_redis()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -431,14 +431,14 @@ class TestWriteToRedis:
         r.json.return_value.mget.assert_not_called()
 
     def test_writes_to_detail_key(self):
-        """Records must be written to aircraft:detail:{icao_hex}, not icao_hex:{icao_hex}."""
+        """Records must be written to aircraft:registry:{icao_hex}, not icao_hex:{icao_hex}."""
         item = _make_item()
         r = _make_redis_with_search(icao_hex="440123", registration="OE-ARG")
         write_to_redis([item], r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call is not None
         key_used = set_call[0][0]
-        assert key_used == "aircraft:detail:440123"
+        assert key_used == "aircraft:registry:440123"
         assert "icao_hex:440123" not in key_used
 
     def test_source_field_in_written_record(self):
@@ -471,7 +471,7 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call is not None
         key_used, _, written = set_call[0]
-        assert key_used == "aircraft:detail:440123"
+        assert key_used == "aircraft:registry:440123"
         assert written.get("registration") == "OE-ARG"
 
     def test_numeric_kennzeichen_prefixed(self):
@@ -511,7 +511,7 @@ class TestWriteToRedis:
             docs = []
             for reg in ["OE-ARG", "OE-ARK"]:
                 doc = MagicMock()
-                doc.id = f"aircraft:simple:44012{call_count[0]}"
+                doc.id = f"aircraft:mictronics:44012{call_count[0]}"
                 doc.registration = reg
                 docs.append(doc)
             results.docs = docs

--- a/data-runners/au-casa/main.py
+++ b/data-runners/au-casa/main.py
@@ -5,7 +5,7 @@ SkyFollower Australia CASA Data Runner
 Downloads the Civil Aviation Safety Authority (CASA) aircraft register CSV,
 looks up each VH- registration in the Mictronics simple index to find the ICAO
 hex, performs a type sanity check to reject false cross-registry joins, writes
-full CASA enrichment records to aircraft:detail:{icao_hex} keys in Redis,
+full CASA enrichment records to aircraft:registry:{icao_hex} keys in Redis,
 publishes MQTT completion stats, then exits.
 
 Important: the CASA register does not publish ICAO hex (Mode S) addresses.
@@ -38,10 +38,10 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
-    aircraft_simple_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
+    aircraft_mictronics_key,
 )
 
 logger = logging.getLogger("au-casa")
@@ -272,16 +272,16 @@ def _build_record(row: dict, icao_hex: str, registration: str) -> dict:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -303,13 +303,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -386,7 +386,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         # Type sanity check: reject false joins where registries share a mark
         # for different aircraft.
         au_casa_model = row.get("Model", "").strip()
-        simple_raw = r.json().get(aircraft_simple_key(icao_hex))
+        simple_raw = r.json().get(aircraft_mictronics_key(icao_hex))
         if simple_raw is not None and not _type_check_passes(simple_raw, au_casa_model):
             logger.debug(
                 "Type sanity check failed for %s (icao_hex=%s, casa_model=%r); skipping.",
@@ -398,8 +398,8 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         record = _build_record(row, icao_hex, registration)
         record["source"] = "au-casa"
 
-        pipe.json().set(aircraft_detail_key(icao_hex), "$", record)
-        pipe.expire(aircraft_detail_key(icao_hex), ttl)
+        pipe.json().set(aircraft_registry_key(icao_hex), "$", record)
+        pipe.expire(aircraft_registry_key(icao_hex), ttl)
         pipe_size += 1
         count += 1
 

--- a/data-runners/bg-caa/main.py
+++ b/data-runners/bg-caa/main.py
@@ -5,7 +5,7 @@ SkyFollower Bulgaria CAA Data Runner
 Scrapes the Bulgaria CAA aircraft register page to discover the current
 date-encoded xlsx URL, downloads and parses it with openpyxl, filters to
 LZ-prefix rows, looks up ICAO hex via the Redis simple search index
-(Mictronics), writes enrichment data to aircraft:detail:{icao_hex} with
+(Mictronics), writes enrichment data to aircraft:registry:{icao_hex} with
 14-day TTL, publishes MQTT completion stats, then exits.
 
 Xlsx columns (0-based; row 0 = info text, row 1 = header, data from row 2):
@@ -41,8 +41,8 @@ from redis.commands.search.query import Query
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from shared.redis_keys import (
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("bg-caa")
@@ -205,11 +205,11 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         escaped = [_escape_tag(reg) for reg in batch]
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str).return_fields("registration").paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -251,7 +251,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/bg-caa/tests/test_bg_caa.py
+++ b/data-runners/bg-caa/tests/test_bg_caa.py
@@ -363,7 +363,7 @@ class TestBuildRegistrationMap:
         doc_mocks = []
         for icao_hex, registration in docs:
             doc = MagicMock()
-            doc.id = f"aircraft:simple:{icao_hex}"
+            doc.id = f"aircraft:mictronics:{icao_hex}"
             doc.registration = registration
             doc_mocks.append(doc)
         result = MagicMock()
@@ -433,7 +433,7 @@ class TestWriteToRedis:
             count = write_to_redis(rows, r, 1209600)
         assert count == 0
 
-    def test_uses_aircraft_detail_key(self):
+    def test_uses_aircraft_registry_key(self):
         rows = [_make_row(registration="LZ-ABC")]
         r = MagicMock()
         pipe = MagicMock()
@@ -441,7 +441,7 @@ class TestWriteToRedis:
         with patch.object(_mod, "_build_registration_map", return_value={"LZ-ABC": "42A001"}):
             write_to_redis(rows, r, 1209600)
         set_call = pipe.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:42A001"
+        assert set_call[0][0] == "aircraft:registry:42A001"
 
     def test_pipeline_error_logs_warning(self):
         rows = [_make_row(registration="LZ-ABC")]

--- a/data-runners/br-anac/main.py
+++ b/data-runners/br-anac/main.py
@@ -6,7 +6,7 @@ Downloads the Registro Aeronáutico Brasileiro (RAB) aircraft register JSON
 from ANAC, filters for active registrations, looks up each PP/PR/PT/PS/PU-
 prefix registration in the Redis simple-aircraft search index (populated by
 Mictronics) to find the ICAO hex, performs a type sanity check, then writes
-enrichment data to aircraft:detail:{icao_hex} (fire-and-forget).
+enrichment data to aircraft:registry:{icao_hex} (fire-and-forget).
 
 Important: the ANAC register does not publish ICAO hex (Mode S) addresses.
 This runner can only enrich records already present in Redis from Mictronics.
@@ -37,10 +37,10 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
-    aircraft_simple_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
+    aircraft_mictronics_key,
 )
 
 logger = logging.getLogger("br-anac")
@@ -198,7 +198,7 @@ def _parse_proprietarios(raw: Optional[str]) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 def _build_record(icao_hex: str, registration: str, row: dict) -> dict:
-    """Build the aircraft:detail:{hex} enrichment record from a RAB row."""
+    """Build the aircraft:registry:{hex} enrichment record from a RAB row."""
     aircraft_type, engine_count, engine_type = _decode_cdcls(row.get("CDCLS"))
 
     cdcls_raw = (row.get("CDCLS") or "").strip().upper()
@@ -256,16 +256,16 @@ def _build_record(icao_hex: str, registration: str, row: dict) -> dict:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -297,13 +297,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -371,7 +371,7 @@ def write_to_redis(records: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in icao_map.items():
         row = reg_map[registration]
 
-        simple_raw = r.json().get(aircraft_simple_key(icao_hex))
+        simple_raw = r.json().get(aircraft_mictronics_key(icao_hex))
         model_str = (row.get("DSMODELO") or "").strip()
         if simple_raw and not _type_check_passes(simple_raw, model_str):
             logger.debug(
@@ -386,7 +386,7 @@ def write_to_redis(records: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         try:
             record = _build_record(icao_hex, registration, row)
             record["source"] = "br-anac"
-            key = aircraft_detail_key(icao_hex)
+            key = aircraft_registry_key(icao_hex)
             r.json().set(key, "$", record)
             r.expire(key, ttl)
             count += 1

--- a/data-runners/br-anac/tests/test_br_anac.py
+++ b/data-runners/br-anac/tests/test_br_anac.py
@@ -458,7 +458,7 @@ class TestWriteToRedis:
         with self._patch_reg_map({"PP-AJH": "E491A0"}):
             write_to_redis(rows, r, REDIS_TTL)
         key_arg = r.json.return_value.set.call_args.args[0]
-        assert key_arg == "aircraft:detail:E491A0"
+        assert key_arg == "aircraft:registry:E491A0"
 
     def test_writes_source_field(self):
         r = self._make_redis()
@@ -519,7 +519,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         with self._patch_reg_map({"PP-AJH": "E491A0"}):
             write_to_redis(rows, r, REDIS_TTL)
-        r.expire.assert_called_once_with("aircraft:detail:E491A0", REDIS_TTL)
+        r.expire.assert_called_once_with("aircraft:registry:E491A0", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/bs-caa/main.py
+++ b/data-runners/bs-caa/main.py
@@ -3,7 +3,7 @@
 SkyFollower Bahamas CAA Data Runner
 
 Downloads the Civil Aviation Authority of the Bahamas (CAA) aircraft register PDF,
-parses aircraft data, and writes enrichment records to aircraft:detail:{icao_hex} keys
+parses aircraft data, and writes enrichment records to aircraft:registry:{icao_hex} keys
 in Redis. ICAO hex is resolved via a RediSearch lookup against the Mictronics
 aircraft:simple index (Mode S address is not published in this register).
 
@@ -42,10 +42,10 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
-    aircraft_simple_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
+    aircraft_mictronics_key,
 )
 
 logger = logging.getLogger("bs-caa")
@@ -223,16 +223,16 @@ def _type_check_passes(simple_record: dict, detail_model_str: str) -> bool:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -254,13 +254,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                hex_val = doc.id.replace("aircraft:simple:", "")
+                hex_val = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = hex_val
@@ -301,13 +301,13 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         row = reg_row_map[registration]
         make_model = row.get("AIRCRAFT TYPE - MAKE/MODEL", "").strip()
 
-        simple_raw = r.json().get(aircraft_simple_key(hex_val))
+        simple_raw = r.json().get(aircraft_mictronics_key(hex_val))
         if not simple_raw or not _type_check_passes(simple_raw, make_model):
             logger.debug("Type sanity check failed for %s, skipping", registration)
             continue
 
         record = _build_record(hex_val, registration, row)
-        key = aircraft_detail_key(hex_val)
+        key = aircraft_registry_key(hex_val)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/bz-bdca/main.py
+++ b/data-runners/bz-bdca/main.py
@@ -6,7 +6,7 @@ Fetches the Belize Department of Civil Aviation (BDCA) civil aircraft register
 from a single static HTML page, parses the table with BeautifulSoup, looks up
 each V3- registration in the Redis simple search index to find the ICAO hex
 (provided by Mictronics), then writes enrichment data to
-aircraft:detail:{icao_hex} and publishes MQTT completion stats, then exits.
+aircraft:registry:{icao_hex} and publishes MQTT completion stats, then exits.
 
 Important: the Belize register does not publish ICAO hex (Mode S) addresses.
 This runner can only enrich records that already exist in Redis from Mictronics.
@@ -37,9 +37,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("bz-bdca")
@@ -177,16 +177,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -204,13 +204,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -251,7 +251,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in reg_icao_map.items():
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/bz-bdca/tests/test_bz_bdca.py
+++ b/data-runners/bz-bdca/tests/test_bz_bdca.py
@@ -67,7 +67,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="0A0123", registration="V3-ABC"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -232,7 +232,7 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call is not None
         key_used = set_call[0][0]
-        assert key_used == "aircraft:detail:0A0123"
+        assert key_used == "aircraft:registry:0A0123"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -252,7 +252,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="0A0123", registration="V3-ABC")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:0A0123", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:0A0123", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/ca-transport-canada/main.py
+++ b/data-runners/ca-transport-canada/main.py
@@ -33,7 +33,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, aircraft_detail_key
+from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
 
 logger = logging.getLogger("ca-transport-canada")
 
@@ -422,16 +422,16 @@ def build_aircraft_record(acft_row: sqlite3.Row, owner_rows: list[sqlite3.Row]) 
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -471,7 +471,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
         owner_rows = owner_cur.fetchall()
         record = build_aircraft_record(acft_row, owner_rows)
         record["source"] = "ca-transport-canada"
-        key = aircraft_detail_key(record["icao_hex"])
+        key = aircraft_registry_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/ca-transport-canada/tests/test_ca_tc.py
+++ b/data-runners/ca-transport-canada/tests/test_ca_tc.py
@@ -638,7 +638,7 @@ class TestBuildAircraftRecord:
         acft = self._fetch_acft_row("C00001", conn)
         owners = self._fetch_owner_rows("C-GABC", conn)
         record = build_aircraft_record(acft, owners)
-        pp = record["powerplant"]
+        pp = record["aircraft"]["powerplant"]
         assert pp["count"] == 1
         assert pp["type"] == "Piston"
         assert pp["manufacturer"] == "LYCOMING"
@@ -652,7 +652,7 @@ class TestBuildAircraftRecord:
         acft = self._fetch_acft_row("C00002", conn)
         owners = self._fetch_owner_rows("C-XYZ", conn)
         record = build_aircraft_record(acft, owners)
-        pp = record["powerplant"]
+        pp = record["aircraft"]["powerplant"]
         assert pp["count"] == 2
         assert pp["type"] == "Turbo-fan"
         assert pp["manufacturer"] == "CFM INTERNATIONAL"
@@ -664,13 +664,13 @@ class TestBuildAircraftRecord:
 # ---------------------------------------------------------------------------
 
 class TestRedisKeys:
-    def test_aircraft_detail_key_format(self):
-        from shared.redis_keys import aircraft_detail_key
-        assert aircraft_detail_key("c00001") == "aircraft:detail:C00001"
+    def test_aircraft_registry_key_format(self):
+        from shared.redis_keys import aircraft_registry_key
+        assert aircraft_registry_key("c00001") == "aircraft:registry:C00001"
 
     def test_aircraft_detail_search_index_name(self):
-        from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX
-        assert AIRCRAFT_DETAIL_SEARCH_INDEX == "idx:aircraft:detail"
+        from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX
+        assert AIRCRAFT_REGISTRY_SEARCH_INDEX == "idx:aircraft:registry"
 
 
 # ---------------------------------------------------------------------------
@@ -703,8 +703,8 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "aircraft:detail:C00001" in keys
-        assert "aircraft:detail:C00002" in keys
+        assert "aircraft:registry:C00001" in keys
+        assert "aircraft:registry:C00002" in keys
         conn.close()
 
     def test_inactive_icao_hex_not_written(self):
@@ -712,7 +712,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "aircraft:detail:C00003" not in keys
+        assert "aircraft:registry:C00003" not in keys
         conn.close()
 
     def test_json_set_uses_root_path(self):
@@ -747,7 +747,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["aircraft:detail:C00001"]
+        record = calls["aircraft:registry:C00001"]
         assert isinstance(record, dict)
         assert record["source"] == "ca-transport-canada"
         assert record["registration"] == "C-GABC"

--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -30,7 +30,7 @@ import requests
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import aircraft_detail_key, AIRCRAFT_DETAIL_SEARCH_INDEX
+from shared.redis_keys import aircraft_registry_key, AIRCRAFT_REGISTRY_SEARCH_INDEX
 
 logger = logging.getLogger("ch-bazl")
 
@@ -279,7 +279,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
 
         record["source"] = "ch-bazl"
-        key = aircraft_detail_key(record["icao_hex"])
+        key = aircraft_registry_key(record["icao_hex"])
         try:
             r.json().set(key, "$", record)
             r.expire(key, ttl)
@@ -303,16 +303,16 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/ch-bazl/tests/test_ch_bazl.py
+++ b/data-runners/ch-bazl/tests/test_ch_bazl.py
@@ -426,7 +426,7 @@ class TestWriteToRedis:
         r = _make_redis()
         write_to_redis([_make_row(icao_hex="4B1916")], r, REDIS_TTL)
         key = r.json.return_value.set.call_args.args[0]
-        assert key == "aircraft:detail:4B1916"
+        assert key == "aircraft:registry:4B1916"
 
     def test_uses_root_json_path(self):
         r = _make_redis()
@@ -436,7 +436,7 @@ class TestWriteToRedis:
     def test_sets_ttl(self):
         r = _make_redis()
         write_to_redis([_make_row()], r, REDIS_TTL)
-        r.expire.assert_called_once_with("aircraft:detail:4B1916", REDIS_TTL)
+        r.expire.assert_called_once_with("aircraft:registry:4B1916", REDIS_TTL)
 
     def test_source_field_set(self):
         r = _make_redis()
@@ -463,7 +463,7 @@ class TestWriteToRedis:
         r = _make_redis()
         write_to_redis([_make_row(icao_hex="4b1916")], r, REDIS_TTL)
         key = r.json.return_value.set.call_args.args[0]
-        assert key == "aircraft:detail:4B1916"
+        assert key == "aircraft:registry:4B1916"
 
 
 # ---------------------------------------------------------------------------
@@ -473,7 +473,7 @@ class TestWriteToRedis:
 class TestEnsureSearchIndex:
     def test_skips_create_when_index_exists(self):
         r = MagicMock()
-        r.ft.return_value.info.return_value = {"index_name": "idx:aircraft:detail"}
+        r.ft.return_value.info.return_value = {"index_name": "idx:aircraft:registry"}
         _ensure_search_index(r)
         r.ft.return_value.create_index.assert_not_called()
 
@@ -489,7 +489,7 @@ class TestEnsureSearchIndex:
         _ensure_search_index(r)
         call_kwargs = r.ft.return_value.create_index.call_args.kwargs
         definition = call_kwargs["definition"]
-        assert "aircraft:detail:" in definition.args
+        assert "aircraft:registry:" in definition.args
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/cy-dca/main.py
+++ b/data-runners/cy-dca/main.py
@@ -6,7 +6,7 @@ Downloads the Cyprus Department of Civil Aviation aircraft register PDF from
 a stable URL, parses all pages using pdfplumber extract_table(), filters to
 5B-prefix rows, looks up each registration in the Redis simple search index
 to find the ICAO hex (provided by Mictronics), writes enrichment data to
-aircraft:detail:{icao_hex} with 14-day TTL, publishes MQTT completion stats,
+aircraft:registry:{icao_hex} with 14-day TTL, publishes MQTT completion stats,
 then exits.
 
 PDF columns (0-based):
@@ -44,8 +44,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("cy-dca")
@@ -184,11 +184,11 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str).return_fields("registration").paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -231,7 +231,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/cy-dca/tests/test_cy_dca.py
+++ b/data-runners/cy-dca/tests/test_cy_dca.py
@@ -359,7 +359,7 @@ class TestBuildRegistrationMap:
         doc_mocks = []
         for icao_hex, registration in docs:
             doc = MagicMock()
-            doc.id = f"aircraft:simple:{icao_hex}"
+            doc.id = f"aircraft:mictronics:{icao_hex}"
             doc.registration = registration
             doc_mocks.append(doc)
         result = MagicMock()
@@ -431,7 +431,7 @@ class TestWriteToRedis:
             count = write_to_redis(rows, r, 1209600)
         assert count == 0
 
-    def test_uses_aircraft_detail_key(self):
+    def test_uses_aircraft_registry_key(self):
         rows = [_make_row(registration="5B-ABC")]
         r = MagicMock()
         pipe = MagicMock()
@@ -439,7 +439,7 @@ class TestWriteToRedis:
         with patch.object(_mod, "_build_registration_map", return_value={"5B-ABC": "4B0001"}):
             write_to_redis(rows, r, 1209600)
         set_call = pipe.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4B0001"
+        assert set_call[0][0] == "aircraft:registry:4B0001"
 
     def test_pipeline_error_logs_warning(self):
         rows = [_make_row(registration="5B-ABC")]

--- a/data-runners/cz-caa/main.py
+++ b/data-runners/cz-caa/main.py
@@ -7,13 +7,13 @@ Two-step REST API:
   2. GET detail endpoint per record → extract ICAO hex from `transponder` field
 
 ICAO hex is available directly (no RediSearch needed). Writes enrichment
-data to aircraft:detail:{icao_hex} with 14-day TTL.
+data to aircraft:registry:{icao_hex} with 14-day TTL.
 
 List endpoint:   https://lr.caa.gov.cz/api/avreg/filtered?start=0&length=10000
 Detail endpoint: https://lr.caa.gov.cz/api/avreg/{id}
 
 Field mapping:
-  transponder       → aircraft:detail:{icao_hex} key (skip if null/empty)
+  transponder       → aircraft:registry:{icao_hex} key (skip if null/empty)
   manufacturer      → aircraft.manufacturer
   model             → aircraft.model
   serial_number     → aircraft.serial_number
@@ -38,7 +38,7 @@ import requests
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from shared.redis_keys import aircraft_detail_key
+from shared.redis_keys import aircraft_registry_key
 
 logger = logging.getLogger("cz-caa")
 
@@ -245,7 +245,7 @@ def write_to_redis(row: dict, r: redis_lib.Redis, ttl: int) -> bool:
     if not icao_hex:
         return False
     record = _build_record(row)
-    key = aircraft_detail_key(icao_hex)
+    key = aircraft_registry_key(icao_hex)
     try:
         r.json().set(key, "$", record)
         r.expire(key, ttl)

--- a/data-runners/cz-caa/tests/test_cz_caa.py
+++ b/data-runners/cz-caa/tests/test_cz_caa.py
@@ -559,7 +559,7 @@ class TestWriteToRedis:
         r = _make_redis()
         write_to_redis(_make_row(icao_hex="49B0AA"), r, REDIS_TTL)
         key = r.json.return_value.set.call_args[0][0]
-        assert key == "aircraft:detail:49B0AA"
+        assert key == "aircraft:registry:49B0AA"
 
     def test_source_field_in_record(self):
         r = _make_redis()
@@ -570,7 +570,7 @@ class TestWriteToRedis:
     def test_ttl_applied(self):
         r = _make_redis()
         write_to_redis(_make_row(icao_hex="49B0AA"), r, REDIS_TTL)
-        r.expire.assert_called_with("aircraft:detail:49B0AA", REDIS_TTL)
+        r.expire.assert_called_with("aircraft:registry:49B0AA", REDIS_TTL)
 
     def test_empty_icao_hex_returns_false(self):
         r = _make_redis()

--- a/data-runners/ee-transpordiamet/main.py
+++ b/data-runners/ee-transpordiamet/main.py
@@ -6,7 +6,7 @@ Fetches the Estonian Transport Administration civil aircraft register page,
 parses the single HTML table, normalizes ES- registration marks (removing
 internal whitespace), looks up each registration in the Redis simple search
 index to find the ICAO hex (provided by Mictronics), writes enrichment data
-to aircraft:detail:{icao_hex}, publishes MQTT completion stats, then exits.
+to aircraft:registry:{icao_hex}, publishes MQTT completion stats, then exits.
 
 Table columns (0-based, 9 columns total):
   0: blank
@@ -42,8 +42,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("ee-transpordiamet")
@@ -168,11 +168,11 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str).return_fields("registration").paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -215,7 +215,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/ee-transpordiamet/tests/test_ee_transpordiamet.py
+++ b/data-runners/ee-transpordiamet/tests/test_ee_transpordiamet.py
@@ -99,7 +99,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="4B1234", registration="ES-AAA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -289,7 +289,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4B1234", registration="ES-AAA")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4B1234"
+        assert set_call[0][0] == "aircraft:registry:4B1234"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -302,7 +302,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="4B1234", registration="ES-AAA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4B1234", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4B1234", REDIS_TTL)
 
     def test_empty_list_returns_zero(self):
         assert write_to_redis([], _make_redis_no_match(), REDIS_TTL) == 0

--- a/data-runners/es-aesa/main.py
+++ b/data-runners/es-aesa/main.py
@@ -5,7 +5,7 @@ SkyFollower Spain AESA Data Runner
 Downloads the AESA (Agencia Estatal de Seguridad Aérea) aircraft register PDF,
 extracts all EC- registration rows using pdfplumber, looks up each registration
 in the Redis simple search index to find the ICAO hex (provided by Mictronics),
-writes enrichment data to aircraft:detail:{icao_hex}, and publishes MQTT
+writes enrichment data to aircraft:registry:{icao_hex}, and publishes MQTT
 completion stats, then exits.
 
 No registrant data is available in this register.
@@ -38,9 +38,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("es-aesa")
@@ -215,16 +215,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -242,13 +242,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -293,7 +293,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in reg_icao_map.items():
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/es-aesa/tests/test_es_aesa.py
+++ b/data-runners/es-aesa/tests/test_es_aesa.py
@@ -79,7 +79,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="340123", registration="EC-ABC"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -301,7 +301,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="340123", registration="EC-ABC")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:340123"
+        assert set_call[0][0] == "aircraft:registry:340123"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -319,7 +319,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="340123", registration="EC-ABC")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:340123", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:340123", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/fr-dgac/main.py
+++ b/data-runners/fr-dgac/main.py
@@ -4,10 +4,10 @@ SkyFollower France DGAC Data Runner
 
 Downloads the Direction Générale de l'Aviation Civile (DGAC) aircraft register
 CSV, groups rows by registration to handle co-ownership, looks up each F-
-registration in the Redis simple-aircraft search index (idx:aircraft:simple,
-populated by Mictronics) to find the ICAO hex, performs a type sanity check
-against the simple record, then writes DGAC enrichment data to
-aircraft:detail:{icao_hex} (fire-and-forget, no read-before-write).
+registration in the Mictronics search index (idx:aircraft:mictronics)
+to find the ICAO hex, performs a type sanity check against the Mictronics
+record, then writes DGAC enrichment data to
+aircraft:registry:{icao_hex} (fire-and-forget, no read-before-write).
 Publishes MQTT completion stats then exits.
 
 Important: the DGAC register does not publish ICAO hex (Mode S) addresses.
@@ -41,10 +41,10 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    aircraft_detail_key,
-    aircraft_simple_key,
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
+    aircraft_registry_key,
+    aircraft_mictronics_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
 )
 
 logger = logging.getLogger("fr-dgac")
@@ -262,16 +262,16 @@ def _build_record(
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -292,13 +292,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -375,7 +375,7 @@ def _group_by_registration(rows: list[dict]) -> dict[str, dict]:
 # ---------------------------------------------------------------------------
 
 def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
-    """Write DGAC enrichment records to aircraft:detail:{icao_hex}. Returns count written."""
+    """Write DGAC enrichment records to aircraft:registry:{icao_hex}. Returns count written."""
     groups = _group_by_registration(rows)
     registrations = list(groups.keys())
     logger.info("Looking up %d registrations in Redis search index.", len(registrations))
@@ -401,7 +401,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         fr_dgac_model = group["first_row"].get("MODELE", "").strip()
 
         # Type sanity check: compare DGAC model against the simple record.
-        simple_raw = r.json().get(aircraft_simple_key(icao_hex))
+        simple_raw = r.json().get(aircraft_mictronics_key(icao_hex))
         if simple_raw is not None and not _type_check_passes(simple_raw, fr_dgac_model):
             logger.debug("Type sanity check failed for %s (%s), skipping.", registration, fr_dgac_model)
             continue
@@ -415,7 +415,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         )
         record["source"] = "fr-dgac"
 
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         pipe_size += 1

--- a/data-runners/ge-gcaa/main.py
+++ b/data-runners/ge-gcaa/main.py
@@ -6,7 +6,7 @@ Fetches the Georgia Civil Aviation Agency aircraft register page, parses two
 pre-rendered HTML tables (table_1: operator data; table_2: owner data), merges
 them by registration mark, looks up each 4L- registration in the Redis simple
 search index to find the ICAO hex (provided by Mictronics), writes enrichment
-data to aircraft:detail:{icao_hex}, publishes MQTT completion stats, then exits.
+data to aircraft:registry:{icao_hex}, publishes MQTT completion stats, then exits.
 
 Table columns (0-based; identical layout in both tables):
   0: Operator / Owner (Georgian + English text; stored differently per table)
@@ -47,9 +47,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("ge-gcaa")
@@ -223,16 +223,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -250,11 +250,11 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str).return_fields("registration").paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -297,7 +297,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/ge-gcaa/tests/test_ge_gcaa.py
+++ b/data-runners/ge-gcaa/tests/test_ge_gcaa.py
@@ -105,7 +105,7 @@ def _make_merged_row(
 def _make_redis_with_search(icao_hex="4A1234", registration="4L-GAA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -361,7 +361,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4A1234", registration="4L-GAA")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4A1234"
+        assert set_call[0][0] == "aircraft:registry:4A1234"
 
     def test_source_field_in_written_record(self):
         rows = [_make_merged_row()]
@@ -374,7 +374,7 @@ class TestWriteToRedis:
         rows = [_make_merged_row()]
         r = _make_redis_with_search(icao_hex="4A1234", registration="4L-GAA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4A1234", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4A1234", REDIS_TTL)
 
     def test_empty_list_returns_zero(self):
         assert write_to_redis([], _make_redis_no_match(), REDIS_TTL) == 0

--- a/data-runners/gg-2reg/main.py
+++ b/data-runners/gg-2reg/main.py
@@ -5,7 +5,7 @@ SkyFollower Guernsey (2-reg) Data Runner
 Discovers the current aircraft register PDF from the 2-reg index page, parses
 main-register pages (skipping the special sections at the end), looks up each
 2-prefix registration in the Redis simple search index to find the ICAO hex
-(provided by Mictronics), writes enrichment data to aircraft:detail:{icao_hex},
+(provided by Mictronics), writes enrichment data to aircraft:registry:{icao_hex},
 publishes MQTT completion stats, then exits.
 
 PDF column layout (all pages; determined from word x-positions):
@@ -50,9 +50,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("gg-2reg")
@@ -219,16 +219,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -246,11 +246,11 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str).return_fields("registration").paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -293,7 +293,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/gg-2reg/tests/test_gg_2reg.py
+++ b/data-runners/gg-2reg/tests/test_gg_2reg.py
@@ -89,7 +89,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="4CA123", registration="2-ABCD"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -433,7 +433,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4CA123", registration="2-ABCD")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4CA123"
+        assert set_call[0][0] == "aircraft:registry:4CA123"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -446,7 +446,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="4CA123", registration="2-ABCD")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4CA123", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4CA123", REDIS_TTL)
 
     def test_empty_list_returns_zero(self):
         count = write_to_redis([], _make_redis_no_match(), REDIS_TTL)
@@ -456,10 +456,10 @@ class TestWriteToRedis:
         rows = [_make_row(registration="2-ABCD"), _make_row(registration="2-EFGH")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:4CA123"
+        doc_a.id = "aircraft:mictronics:4CA123"
         doc_a.registration = "2-ABCD"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:4CA456"
+        doc_b.id = "aircraft:mictronics:4CA456"
         doc_b.registration = "2-EFGH"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/hr-ccaa/main.py
+++ b/data-runners/hr-ccaa/main.py
@@ -6,7 +6,7 @@ Scrapes the Croatia Civil Aviation Agency aircraft register page to discover
 the current PDF URL, downloads and parses all pages with pdfplumber, prepends
 the 9A- prefix to each registration suffix, looks up ICAO hex via the Redis
 simple search index (Mictronics), writes enrichment data to
-aircraft:detail:{icao_hex} with 14-day TTL, publishes MQTT completion stats,
+aircraft:registry:{icao_hex} with 14-day TTL, publishes MQTT completion stats,
 then exits.
 
 PDF columns (0-based):
@@ -42,8 +42,8 @@ from redis.commands.search.query import Query
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from shared.redis_keys import (
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("hr-ccaa")
@@ -203,11 +203,11 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         escaped = [_escape_tag(reg) for reg in batch]
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str).return_fields("registration").paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -249,7 +249,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/hr-ccaa/tests/test_hr_ccaa.py
+++ b/data-runners/hr-ccaa/tests/test_hr_ccaa.py
@@ -388,7 +388,7 @@ class TestBuildRegistrationMap:
         doc_mocks = []
         for icao_hex, registration in docs:
             doc = MagicMock()
-            doc.id = f"aircraft:simple:{icao_hex}"
+            doc.id = f"aircraft:mictronics:{icao_hex}"
             doc.registration = registration
             doc_mocks.append(doc)
         result = MagicMock()
@@ -458,7 +458,7 @@ class TestWriteToRedis:
             count = write_to_redis(rows, r, 1209600)
         assert count == 0
 
-    def test_uses_aircraft_detail_key(self):
+    def test_uses_aircraft_registry_key(self):
         rows = [_make_row(registration="9A-ABC")]
         r = MagicMock()
         pipe = MagicMock()
@@ -466,7 +466,7 @@ class TestWriteToRedis:
         with patch.object(_mod, "_build_registration_map", return_value={"9A-ABC": "501234"}):
             write_to_redis(rows, r, 1209600)
         set_call = pipe.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:501234"
+        assert set_call[0][0] == "aircraft:registry:501234"
 
     def test_pipeline_error_logs_warning(self):
         rows = [_make_row(registration="9A-ABC")]

--- a/data-runners/hu-kozhaf/main.py
+++ b/data-runners/hu-kozhaf/main.py
@@ -5,7 +5,7 @@ SkyFollower Hungary KoZHAF Data Runner
 Fetches the Hungary KoZHAF (National Transport Authority) aircraft register
 from a date-stamped PDF discovered by scraping the index page, looks up each
 HA- registration in the Redis simple search index to find the ICAO hex
-(provided by Mictronics), writes enrichment data to aircraft:detail:{icao_hex},
+(provided by Mictronics), writes enrichment data to aircraft:registry:{icao_hex},
 publishes MQTT completion stats, then exits.
 
 The index page requires a browser User-Agent. The PDF URL is embedded in the
@@ -48,9 +48,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("hu-kozhaf")
@@ -218,16 +218,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -245,13 +245,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -294,7 +294,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/hu-kozhaf/tests/test_hu_kozhaf.py
+++ b/data-runners/hu-kozhaf/tests/test_hu_kozhaf.py
@@ -71,7 +71,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="4D1234", registration="HA-GZQ"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -304,7 +304,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4D1234", registration="HA-GZQ")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4D1234"
+        assert set_call[0][0] == "aircraft:registry:4D1234"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -322,16 +322,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="4D1234", registration="HA-GZQ")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4D1234", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4D1234", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(registration="HA-GZQ"), _make_row(registration="HA-ABC")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:4D1234"
+        doc_a.id = "aircraft:mictronics:4D1234"
         doc_a.registration = "HA-GZQ"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:4D1235"
+        doc_b.id = "aircraft:mictronics:4D1235"
         doc_b.registration = "HA-ABC"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/im-ardis/main.py
+++ b/data-runners/im-ardis/main.py
@@ -5,7 +5,7 @@ SkyFollower Isle of Man ARDIS Data Runner
 Fetches the Isle of Man Aircraft Registry (ARDIS) from the search form at
 ardis.iomaircraftregistry.com, parses the HTML results table, filters out
 deregistered aircraft, and writes enrichment data to
-aircraft:detail:{icao_hex} using the Mode S Number column directly.
+aircraft:registry:{icao_hex} using the Mode S Number column directly.
 No RediSearch reverse-lookup is needed — ICAO hex is supplied in the register.
 Publishes MQTT completion stats, then exits.
 
@@ -29,7 +29,7 @@ from bs4 import BeautifulSoup
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from shared.redis_keys import aircraft_detail_key
+from shared.redis_keys import aircraft_registry_key
 
 logger = logging.getLogger("im-ardis")
 
@@ -234,7 +234,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if record is None:
             continue
 
-        key = aircraft_detail_key(record["icao_hex"])
+        key = aircraft_registry_key(record["icao_hex"])
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/im-ardis/tests/test_im_ardis.py
+++ b/data-runners/im-ardis/tests/test_im_ardis.py
@@ -208,13 +208,13 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call is not None
-        assert set_call[0][0] == "aircraft:detail:43E717"
+        assert set_call[0][0] == "aircraft:registry:43E717"
 
     def test_ttl_applied(self):
         rows = [_make_row(mode_s="43E717")]
         r = _make_redis()
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:43E717", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:43E717", REDIS_TTL)
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]

--- a/data-runners/is-samgongustofa/main.py
+++ b/data-runners/is-samgongustofa/main.py
@@ -5,7 +5,7 @@ SkyFollower Iceland Samgöngustofa Data Runner
 Fetches the Icelandic aircraft register from the Transport Authority
 (Samgöngustofa) via Apollo Persisted Query, looks up each TF- registration
 in the Redis simple search index to find the ICAO hex (provided by Mictronics),
-then writes enrichment data to aircraft:detail:{icao_hex} and publishes MQTT
+then writes enrichment data to aircraft:registry:{icao_hex} and publishes MQTT
 completion stats, then exits.
 
 Important: the Samgöngustofa register does not publish ICAO hex (Mode S)
@@ -36,9 +36,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("is-samgongustofa")
@@ -165,16 +165,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -195,13 +195,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -276,7 +276,7 @@ def write_to_redis(aircrafts: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in reg_icao_map.items():
         aircraft = reg_to_aircraft[registration]
         record = _build_record(aircraft, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         pipe_count += 1

--- a/data-runners/is-samgongustofa/tests/test_is_samgongustofa.py
+++ b/data-runners/is-samgongustofa/tests/test_is_samgongustofa.py
@@ -77,7 +77,7 @@ def _make_aircraft(
 def _make_redis_with_search(icao_hex="4CA123", registration="TF-ABC"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -243,7 +243,7 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call is not None
         key_used = set_call[0][0]
-        assert key_used == "aircraft:detail:4CA123"
+        assert key_used == "aircraft:registry:4CA123"
 
     def test_source_field_in_written_record(self):
         aircraft = [_make_aircraft()]
@@ -274,7 +274,7 @@ class TestWriteToRedis:
             docs = []
             for reg in ["TF-ABC", "TF-XYZ"]:
                 doc = MagicMock()
-                doc.id = f"aircraft:simple:4CA12{call_count[0]}"
+                doc.id = f"aircraft:mictronics:4CA12{call_count[0]}"
                 doc.registration = reg
                 docs.append(doc)
             results.docs = docs
@@ -288,7 +288,7 @@ class TestWriteToRedis:
         aircraft = [_make_aircraft()]
         r = _make_redis_with_search(icao_hex="4CA123", registration="TF-ABC")
         write_to_redis(aircraft, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4CA123", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4CA123", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/kg-caa/main.py
+++ b/data-runners/kg-caa/main.py
@@ -5,7 +5,7 @@ SkyFollower Kyrgyzstan CAA Data Runner
 Fetches the Kyrgyzstan CAA aircraft register from a static HTML page, handles
 rowspan-merged operator cells, looks up each EX- registration in the Redis
 simple search index to find the ICAO hex (provided by Mictronics), writes
-enrichment data to aircraft:detail:{icao_hex}, publishes MQTT completion
+enrichment data to aircraft:registry:{icao_hex}, publishes MQTT completion
 stats, then exits.
 
 Table columns (0-based, after rowspan expansion):
@@ -46,9 +46,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("kg-caa")
@@ -243,16 +243,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -270,13 +270,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -319,7 +319,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/kg-caa/tests/test_kg_caa.py
+++ b/data-runners/kg-caa/tests/test_kg_caa.py
@@ -159,7 +159,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="458100", registration="EX-001"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -452,7 +452,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="458100", registration="EX-001")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:458100"
+        assert set_call[0][0] == "aircraft:registry:458100"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -470,16 +470,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="458100", registration="EX-001")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:458100", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:458100", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(registration="EX-001"), _make_row(registration="EX-002")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:458100"
+        doc_a.id = "aircraft:mictronics:458100"
         doc_a.registration = "EX-001"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:458101"
+        doc_b.id = "aircraft:mictronics:458101"
         doc_b.registration = "EX-002"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/kr-koca/main.py
+++ b/data-runners/kr-koca/main.py
@@ -5,7 +5,7 @@ SkyFollower South Korea KOCA Data Runner
 Fetches the Korea Office of Civil Aviation (KOCA) aircraft register from the
 ATIS JSON API, looks up each HL- registration in the Redis simple search index
 to find the ICAO hex (provided by Mictronics), writes enrichment data to
-aircraft:detail:{icao_hex}, and publishes MQTT completion stats, then exits.
+aircraft:registry:{icao_hex}, and publishes MQTT completion stats, then exits.
 
 Important: the KOCA register does not publish ICAO hex (Mode S) addresses.
 This runner can only enrich records that already exist in Redis from Mictronics.
@@ -37,9 +37,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("kr-koca")
@@ -178,16 +178,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -205,13 +205,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -252,7 +252,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in reg_icao_map.items():
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/kr-koca/tests/test_kr_koca.py
+++ b/data-runners/kr-koca/tests/test_kr_koca.py
@@ -69,7 +69,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="710ABC", registration="HL9301"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -221,7 +221,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="710ABC", registration="HL9301")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:710ABC"
+        assert set_call[0][0] == "aircraft:registry:710ABC"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -239,7 +239,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="710ABC", registration="HL9301")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:710ABC", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:710ABC", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/ky-caa/main.py
+++ b/data-runners/ky-caa/main.py
@@ -4,7 +4,7 @@ SkyFollower Cayman Islands CAA Data Runner
 
 Downloads the Cayman Islands Civil Aviation Authority (CAA) aircraft register
 PDF, parses aircraft data, and writes enrichment records to Redis using
-the ICAO hex resolved via RediSearch against the Mictronics simple-key data.
+the ICAO hex resolved via RediSearch against the Mictronics data.
 
 The register contains owner name, registration, combined make/model ("Series
 Type"), and serial number. No manufacturer column, type designator, or
@@ -42,10 +42,10 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    aircraft_detail_key,
-    aircraft_simple_key,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
+    aircraft_registry_key,
+    aircraft_mictronics_key,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
 )
 
 logger = logging.getLogger("ky-caa")
@@ -100,7 +100,7 @@ def _type_tokens(model_str: str) -> set:
 
 
 def _type_check_passes(simple_record: dict, detail_model_str: str) -> bool:
-    """Return True if the ky-caa model string is consistent with the Mictronics simple record.
+    """Return True if the ky-caa model string is consistent with the Mictronics record.
 
     Returns True when detail_model_str is empty, when neither record contains
     recognisable type tokens, or when the token sets overlap.
@@ -261,27 +261,27 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
 # Registration → icao_hex lookup
 # ---------------------------------------------------------------------------
 
-_SIMPLE_KEY_PREFIX = "aircraft:simple:"
+_MICTRONICS_KEY_PREFIX = "aircraft:mictronics:"
 
 
 def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dict[str, str]:
-    """Batch-query the Mictronics simple search index for icao_hex by registration mark.
+    """Batch-query the Mictronics search index for icao_hex by registration mark.
 
     Returns {registration → icao_hex} for registrations already in Redis.
     Registrations not found (aircraft not yet in Mictronics) are omitted.
@@ -295,13 +295,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                hex_val = doc.id[len(_SIMPLE_KEY_PREFIX):]
+                hex_val = doc.id[len(_MICTRONICS_KEY_PREFIX):]
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = hex_val
@@ -318,9 +318,9 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
 def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     """Write Cayman Islands CAA data to aircraft detail keys. Returns count written.
 
-    Looks up each registration in the Mictronics simple search index, runs a
+    Looks up each registration in the Mictronics search index, runs a
     type sanity check against the simple record, then writes to
-    aircraft:detail:{icao_hex} without reading the existing detail record
+    aircraft:registry:{icao_hex} without reading the existing detail record
     (fire-and-forget).
     """
     reg_row_map: dict[str, dict] = {}
@@ -345,7 +345,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
 
     def _flush_pending() -> None:
         nonlocal count
-        simple_keys = [aircraft_simple_key(hex_val) for _, hex_val in pending]
+        simple_keys = [aircraft_mictronics_key(hex_val) for _, hex_val in pending]
         simple_records = r.json().mget(simple_keys, "$")
 
         pipe = r.pipeline()
@@ -358,7 +358,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
                 logger.debug("Type sanity check failed for %s, skipping", registration)
                 continue
             record = _build_record(hex_val, registration, row)
-            key = aircraft_detail_key(hex_val)
+            key = aircraft_registry_key(hex_val)
             pipe.json().set(key, "$", record)
             pipe.expire(key, ttl)
             written += 1

--- a/data-runners/ky-caa/tests/test_ky_caa.py
+++ b/data-runners/ky-caa/tests/test_ky_caa.py
@@ -55,7 +55,7 @@ COL_NATIONALITY = _mod.COL_NATIONALITY
 COL_SERIES_TYPE = _mod.COL_SERIES_TYPE
 COL_SERIAL = _mod.COL_SERIAL
 
-from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, AIRCRAFT_SIMPLE_SEARCH_INDEX
+from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, AIRCRAFT_MICTRONICS_SEARCH_INDEX
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +94,7 @@ def _make_redis_with_search(icao_hex="C00001", registration="VP-CAD", simple_rec
     """
     r = _make_redis()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -418,7 +418,7 @@ class TestEnsureSearchIndex:
         r = MagicMock()
         r.ft.return_value.info.side_effect = Exception("Index does not exist")
         _ensure_search_index(r)
-        r.ft.assert_called_with(AIRCRAFT_DETAIL_SEARCH_INDEX)
+        r.ft.assert_called_with(AIRCRAFT_REGISTRY_SEARCH_INDEX)
         r.ft.return_value.create_index.assert_called_once()
 
     def test_skips_creation_when_index_exists(self):
@@ -434,7 +434,7 @@ class TestEnsureSearchIndex:
             _ensure_search_index(r)
         mock_def.assert_called_once()
         call_kwargs = mock_def.call_args.kwargs
-        assert call_kwargs.get("prefix") == ["aircraft:detail:"]
+        assert call_kwargs.get("prefix") == ["aircraft:registry:"]
 
 
 # ---------------------------------------------------------------------------
@@ -511,17 +511,17 @@ class TestWriteToRedis:
         r.json.return_value.mget.assert_called_once()
         call_args = r.json.return_value.mget.call_args
         keys_arg = call_args[0][0]
-        assert all("aircraft:simple:" in k for k in keys_arg)
-        assert not any("aircraft:detail:" in k for k in keys_arg)
+        assert all("aircraft:mictronics:" in k for k in keys_arg)
+        assert not any("aircraft:registry:" in k for k in keys_arg)
 
     def test_writes_to_detail_key(self):
-        """Verified key written is aircraft:detail:{icao_hex}."""
+        """Verified key written is aircraft:registry:{icao_hex}."""
         row = _make_row()
         r = _make_redis_with_search(icao_hex="C00001", registration="VP-CAD")
         write_to_redis([row], r, REDIS_TTL)
         pipe = r.pipeline.return_value
         set_call = pipe.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:C00001"
+        assert set_call[0][0] == "aircraft:registry:C00001"
 
     def test_source_field_in_written_record(self):
         """Written records contain source='ky-caa'."""
@@ -562,7 +562,7 @@ class TestWriteToRedis:
             docs = []
             for reg in ["VP-CAD", "VP-CAF"]:
                 doc = MagicMock()
-                doc.id = f"aircraft:simple:C0000{call_count[0]}"
+                doc.id = f"aircraft:mictronics:C0000{call_count[0]}"
                 doc.registration = reg
                 docs.append(doc)
             results.docs = docs
@@ -579,7 +579,7 @@ class TestWriteToRedis:
         row = _make_row()
         r = _make_redis_with_search(icao_hex="C00001", registration="VP-CAD")
         write_to_redis([row], r, REDIS_TTL)
-        r.ft.assert_called_with(AIRCRAFT_SIMPLE_SEARCH_INDEX)
+        r.ft.assert_called_with(AIRCRAFT_MICTRONICS_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/lu-dac/main.py
+++ b/data-runners/lu-dac/main.py
@@ -6,7 +6,7 @@ Downloads the Luxembourg Directorate of Civil Aviation (DAC) aircraft register
 PDF, parses it using pdfplumber word-position extraction (pdfplumber.extract_table()
 does not correctly detect all columns in this PDF), looks up each LX- registration
 in the Redis simple search index to find the ICAO hex (provided by Mictronics),
-then writes enrichment data to aircraft:detail:{icao_hex} and publishes MQTT
+then writes enrichment data to aircraft:registry:{icao_hex} and publishes MQTT
 completion stats, then exits.
 
 Important: the Luxembourg DAC register does not publish ICAO hex (Mode S)
@@ -41,9 +41,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("lu-dac")
@@ -289,16 +289,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -316,13 +316,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -363,7 +363,7 @@ def write_to_redis(records: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in reg_icao_map.items():
         parsed = reg_record_map[registration]
         record = _build_record(parsed, icao_hex)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/lu-dac/tests/test_lu_dac.py
+++ b/data-runners/lu-dac/tests/test_lu_dac.py
@@ -76,7 +76,7 @@ def _make_word(text: str, x0: float, top: float) -> dict:
 def _make_redis_with_search(icao_hex="4A0123", registration="LX-ABC"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -325,7 +325,7 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call is not None
         key_used = set_call[0][0]
-        assert key_used == "aircraft:detail:4A0123"
+        assert key_used == "aircraft:registry:4A0123"
 
     def test_source_field_in_written_record(self):
         records = [_make_parsed()]
@@ -345,7 +345,7 @@ class TestWriteToRedis:
         records = [_make_parsed()]
         r = _make_redis_with_search(icao_hex="4A0123", registration="LX-ABC")
         write_to_redis(records, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4A0123", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4A0123", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/lv-caa/main.py
+++ b/data-runners/lv-caa/main.py
@@ -5,7 +5,7 @@ SkyFollower Latvia CAA Data Runner
 Fetches the Latvia aircraft register from the data.gov.lv CKAN datastore API,
 looks up each YL- registration in the Redis simple search index to find the
 ICAO hex (provided by Mictronics), writes enrichment data to
-aircraft:detail:{icao_hex}, publishes MQTT completion stats, then exits.
+aircraft:registry:{icao_hex}, publishes MQTT completion stats, then exits.
 
 Data source: https://data.gov.lv/dati/lv/api/action/datastore_search
   resource_id: dbde00e6-8616-449a-8cac-ef748c6793f3
@@ -32,9 +32,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("lv-caa")
@@ -147,16 +147,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -174,13 +174,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -223,7 +223,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/lv-caa/tests/test_lv_caa.py
+++ b/data-runners/lv-caa/tests/test_lv_caa.py
@@ -94,7 +94,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="502100", registration="YL-AAA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -321,7 +321,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="502100", registration="YL-AAA")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:502100"
+        assert set_call[0][0] == "aircraft:registry:502100"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -339,16 +339,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="502100", registration="YL-AAA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:502100", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:502100", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(registration="YL-AAA"), _make_row(registration="YL-BBB")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:502100"
+        doc_a.id = "aircraft:mictronics:502100"
         doc_a.registration = "YL-AAA"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:502101"
+        doc_b.id = "aircraft:mictronics:502101"
         doc_b.registration = "YL-BBB"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/md-caa/main.py
+++ b/data-runners/md-caa/main.py
@@ -5,7 +5,7 @@ SkyFollower Moldova CAA Data Runner
 Fetches the Moldova Civil Aviation Authority aircraft register from a static
 PDF URL, looks up each ER- registration in the Redis simple search index to
 find the ICAO hex (provided by Mictronics), writes enrichment data to
-aircraft:detail:{icao_hex}, publishes MQTT completion stats, then exits.
+aircraft:registry:{icao_hex}, publishes MQTT completion stats, then exits.
 
 PDF columns (no header row; positions are 0-based):
   0: Nr.              (sequence number; not stored)
@@ -40,9 +40,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("md-caa")
@@ -144,16 +144,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -171,13 +171,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -220,7 +220,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/md-caa/tests/test_md_caa.py
+++ b/data-runners/md-caa/tests/test_md_caa.py
@@ -78,7 +78,7 @@ def _make_pdf(pages):
 def _make_redis_with_search(icao_hex="4B4100", registration="ER-AXA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -289,7 +289,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4B4100", registration="ER-AXA")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4B4100"
+        assert set_call[0][0] == "aircraft:registry:4B4100"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -307,16 +307,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="4B4100", registration="ER-AXA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4B4100", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4B4100", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(registration="ER-AXA"), _make_row(registration="ER-BBB")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:4B4100"
+        doc_a.id = "aircraft:mictronics:4B4100"
         doc_a.registration = "ER-AXA"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:4B4101"
+        doc_b.id = "aircraft:mictronics:4B4101"
         doc_b.registration = "ER-BBB"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/me-caa/main.py
+++ b/data-runners/me-caa/main.py
@@ -6,7 +6,7 @@ Fetches the Montenegro CAA aircraft register from a pre-filtered paginated HTML
 list that returns only active registrations, fetches each aircraft's detail page
 to collect enrichment fields, looks up each 4O- registration in the Redis simple
 search index to find the ICAO hex (provided by Mictronics), writes enrichment
-data to aircraft:detail:{icao_hex}, publishes MQTT completion stats, then exits.
+data to aircraft:registry:{icao_hex}, publishes MQTT completion stats, then exits.
 
 The list URL includes field_ispisan_iz_registra_tid=157 which restricts results
 to active registrations only — no deregistration filtering is needed in code.
@@ -44,9 +44,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("me-caa")
@@ -283,16 +283,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -310,13 +310,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -359,7 +359,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/me-caa/tests/test_me_caa.py
+++ b/data-runners/me-caa/tests/test_me_caa.py
@@ -134,7 +134,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="4C0100", registration="4O-AOA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -528,7 +528,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4C0100", registration="4O-AOA")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4C0100"
+        assert set_call[0][0] == "aircraft:registry:4C0100"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -546,16 +546,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="4C0100", registration="4O-AOA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4C0100", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4C0100", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(registration="4O-AOA"), _make_row(registration="4O-ABC")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:4C0100"
+        doc_a.id = "aircraft:mictronics:4C0100"
         doc_a.registration = "4O-AOA"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:4C0101"
+        doc_b.id = "aircraft:mictronics:4C0101"
         doc_b.registration = "4O-ABC"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -31,7 +31,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_SIMPLE_SEARCH_INDEX, aircraft_simple_key, operator_key
+from shared.redis_keys import AIRCRAFT_MICTRONICS_SEARCH_INDEX, aircraft_mictronics_key, operator_key
 
 logger = logging.getLogger("mictronics")
 
@@ -281,16 +281,16 @@ def build_operator_record(row: sqlite3.Row) -> dict:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft simple JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:simple:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:mictronics:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_SIMPLE_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_MICTRONICS_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +327,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     for row in rows:
         types_row = row if row["manufacturer_model"] is not None else None
         record = build_aircraft_record(row, types_row)
-        key = aircraft_simple_key(record["icao_hex"])
+        key = aircraft_mictronics_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -491,17 +491,17 @@ class TestWriteOperatorsToRedis:
 # ---------------------------------------------------------------------------
 
 class TestRedisKeys:
-    def test_aircraft_simple_key_format(self):
-        from shared.redis_keys import aircraft_simple_key
-        assert aircraft_simple_key("a8ae7f") == "aircraft:simple:A8AE7F"
+    def test_aircraft_mictronics_key_format(self):
+        from shared.redis_keys import aircraft_mictronics_key
+        assert aircraft_mictronics_key("a8ae7f") == "aircraft:mictronics:A8AE7F"
 
-    def test_aircraft_simple_key_already_upper(self):
-        from shared.redis_keys import aircraft_simple_key
-        assert aircraft_simple_key("A8AE7F") == "aircraft:simple:A8AE7F"
+    def test_aircraft_mictronics_key_already_upper(self):
+        from shared.redis_keys import aircraft_mictronics_key
+        assert aircraft_mictronics_key("A8AE7F") == "aircraft:mictronics:A8AE7F"
 
     def test_aircraft_simple_search_index_name(self):
-        from shared.redis_keys import AIRCRAFT_SIMPLE_SEARCH_INDEX
-        assert AIRCRAFT_SIMPLE_SEARCH_INDEX == "idx:aircraft:simple"
+        from shared.redis_keys import AIRCRAFT_MICTRONICS_SEARCH_INDEX
+        assert AIRCRAFT_MICTRONICS_SEARCH_INDEX == "idx:aircraft:mictronics"
 
 
 # ---------------------------------------------------------------------------
@@ -533,7 +533,7 @@ class TestWriteToRedis:
         r_json = MagicMock()
         r.json.return_value = r_json
         r_json.mget.side_effect = lambda keys, path: [
-            [existing] if existing and k == f"aircraft:simple:{existing['icao_hex']}" else None
+            [existing] if existing and k == f"aircraft:mictronics:{existing['icao_hex']}" else None
             for k in keys
         ]
 
@@ -555,7 +555,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "aircraft:simple:A8AE7F" in keys
+        assert "aircraft:mictronics:A8AE7F" in keys
         conn.close()
 
     def test_json_set_uses_root_path(self):
@@ -597,7 +597,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis(existing=existing)
         write_to_redis(conn, r, REDIS_TTL)
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["aircraft:simple:A8AE7F"]
+        record = calls["aircraft:mictronics:A8AE7F"]
         # mictronics owns military — its value (False) overwrites the existing True
         assert record["military"] is False
         # registrant is not owned by mictronics — must be preserved

--- a/data-runners/mk-caa/main.py
+++ b/data-runners/mk-caa/main.py
@@ -5,7 +5,7 @@ SkyFollower North Macedonia CAA Data Runner
 Fetches the North Macedonia CAA (Civil Aviation Agency) aircraft register
 from a date-stamped PDF discovered by scraping the index page, looks up each
 Z3- registration in the Redis simple search index to find the ICAO hex
-(provided by Mictronics), writes enrichment data to aircraft:detail:{icao_hex},
+(provided by Mictronics), writes enrichment data to aircraft:registry:{icao_hex},
 publishes MQTT completion stats, then exits.
 
 No table header row is present; columns are identified by position.
@@ -37,9 +37,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("mk-caa")
@@ -182,16 +182,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -209,13 +209,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -258,7 +258,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/mk-caa/tests/test_mk_caa.py
+++ b/data-runners/mk-caa/tests/test_mk_caa.py
@@ -68,7 +68,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="4C4000", registration="Z3-AAA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -272,7 +272,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4C4000", registration="Z3-AAA")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4C4000"
+        assert set_call[0][0] == "aircraft:registry:4C4000"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -290,16 +290,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="4C4000", registration="Z3-AAA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4C4000", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4C4000", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(reg="Z3-AAA"), _make_row(reg="Z3-AAB")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:4C4000"
+        doc_a.id = "aircraft:mictronics:4C4000"
         doc_a.registration = "Z3-AAA"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:4C4001"
+        doc_b.id = "aircraft:mictronics:4C4001"
         doc_b.registration = "Z3-AAB"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/mv-caa/main.py
+++ b/data-runners/mv-caa/main.py
@@ -6,7 +6,7 @@ Fetches the Maldives Civil Aviation Authority aircraft register by scraping the
 index page to discover the current PDF URL (filename is an opaque hash), parses
 all pages with pdfplumber, looks up each 8Q- registration in the Redis simple
 search index to find the ICAO hex (provided by Mictronics), writes enrichment
-data to aircraft:detail:{icao_hex}, publishes MQTT completion stats, then exits.
+data to aircraft:registry:{icao_hex}, publishes MQTT completion stats, then exits.
 
 PDF columns (0-based):
   0:  N/S (sequence; not stored)
@@ -51,9 +51,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("mv-caa")
@@ -219,16 +219,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -246,13 +246,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -295,7 +295,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/mv-caa/tests/test_mv_caa.py
+++ b/data-runners/mv-caa/tests/test_mv_caa.py
@@ -129,7 +129,7 @@ def _make_pdf_response():
 def _make_redis_with_search(icao_hex="900100", registration="8Q-IAD"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -487,7 +487,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="900100", registration="8Q-IAD")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:900100"
+        assert set_call[0][0] == "aircraft:registry:900100"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -505,16 +505,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="900100", registration="8Q-IAD")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:900100", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:900100", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(registration="8Q-IAD"), _make_row(registration="8Q-MBD")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:900100"
+        doc_a.id = "aircraft:mictronics:900100"
         doc_a.registration = "8Q-IAD"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:900101"
+        doc_b.id = "aircraft:mictronics:900101"
         doc_b.registration = "8Q-MBD"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/nl-ilt/main.py
+++ b/data-runners/nl-ilt/main.py
@@ -38,7 +38,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, aircraft_detail_key
+from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
 
 logger = logging.getLogger("nl-ilt")
 
@@ -256,16 +256,16 @@ def _build_record(row: dict) -> Optional[dict]:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +289,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if record is None:
             continue
         record["source"] = "nl-ilt"
-        batch.append((aircraft_detail_key(record["icao_hex"]), record))
+        batch.append((aircraft_registry_key(record["icao_hex"]), record))
         count += 1
         if len(batch) == WRITE_BATCH_SIZE:
             _flush()

--- a/data-runners/no-caa/main.py
+++ b/data-runners/no-caa/main.py
@@ -3,7 +3,7 @@
 SkyFollower Norway CAA Data Runner
 
 Downloads the Norwegian Civil Aviation Authority aircraft register JSON,
-normalises fields into the aircraft:detail:{hex} enrichment shape, writes
+normalises fields into the aircraft:registry:{hex} enrichment shape, writes
 to Redis with a 14-day TTL, publishes MQTT completion stats, then exits.
 
 Data source: https://data.caa.no/nlr/norgesluftfartoyregister.json
@@ -27,7 +27,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, aircraft_detail_key
+from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
 
 logger = logging.getLogger("no-caa")
 
@@ -129,7 +129,7 @@ def _parse_manufactured_date(byggeaar: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 def _build_record(row: dict) -> Optional[dict]:
-    """Build the aircraft:detail:{hex} JSON record from a registry entry. Returns None if no ICAO hex."""
+    """Build the aircraft:registry:{hex} JSON record from a registry entry. Returns None if no ICAO hex."""
     icao_hex = _extract_icao_hex(row.get("ICAO 24-bits adresse") or [])
     if not icao_hex:
         return None
@@ -202,16 +202,16 @@ def _build_record(row: dict) -> Optional[dict]:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -252,7 +252,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if record is None:
             continue
         record["source"] = "no-caa"
-        key = aircraft_detail_key(record["icao_hex"])
+        key = aircraft_registry_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/nz-caa/main.py
+++ b/data-runners/nz-caa/main.py
@@ -3,7 +3,7 @@
 SkyFollower New Zealand CAA Data Runner
 
 Downloads the NZ CAA aircraft register CSV, normalises fields into the
-aircraft:detail:{hex} enrichment shape, writes to Redis with a 14-day TTL,
+aircraft:registry:{hex} enrichment shape, writes to Redis with a 14-day TTL,
 publishes MQTT completion stats, then exits.
 
 Data source: https://www.aviation.govt.nz/assets/aircraft/aircraft-register/Aircraft-Register-for-website-.csv
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, aircraft_detail_key
+from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
 
 logger = logging.getLogger("nz-caa")
 
@@ -135,7 +135,7 @@ def _parse_address(raw: str) -> dict:
 # ---------------------------------------------------------------------------
 
 def _build_record(row: dict) -> Optional[dict]:
-    """Build the aircraft:detail:{hex} JSON record from a CSV row. Returns None if no ICAO hex."""
+    """Build the aircraft:registry:{hex} JSON record from a CSV row. Returns None if no ICAO hex."""
     icao_hex = row.get("Mode S Code HEX", "").strip().upper()
     if not icao_hex:
         return None
@@ -185,16 +185,16 @@ def _build_record(row: dict) -> Optional[dict]:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +234,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if record is None:
             continue
         record["source"] = "nz-caa"
-        key = aircraft_detail_key(record["icao_hex"])
+        key = aircraft_registry_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/pg-casapng/main.py
+++ b/data-runners/pg-casapng/main.py
@@ -5,7 +5,7 @@ SkyFollower Papua New Guinea CASA PNG Data Runner
 Fetches the Papua New Guinea CASA PNG (Civil Aviation Safety Authority)
 aircraft register from a monthly-updated PDF, looks up each P2- registration
 in the Redis simple search index to find the ICAO hex (provided by Mictronics),
-writes enrichment data to aircraft:detail:{icao_hex}, publishes MQTT completion
+writes enrichment data to aircraft:registry:{icao_hex}, publishes MQTT completion
 stats, then exits.
 
 The PDF URL is date-stamped and discovered fresh each run by scraping the
@@ -40,9 +40,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("pg-casapng")
@@ -193,16 +193,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -220,13 +220,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -269,7 +269,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/pg-casapng/tests/test_pg_casapng.py
+++ b/data-runners/pg-casapng/tests/test_pg_casapng.py
@@ -67,7 +67,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="898A00", registration="P2-ANG"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -281,7 +281,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="898A00", registration="P2-ANG")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:898A00"
+        assert set_call[0][0] == "aircraft:registry:898A00"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -299,16 +299,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="898A00", registration="P2-ANG")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:898A00", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:898A00", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(reg="P2-ANG"), _make_row(reg="P2-ANH")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:898A00"
+        doc_a.id = "aircraft:mictronics:898A00"
         doc_a.registration = "P2-ANG"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:898A01"
+        doc_b.id = "aircraft:mictronics:898A01"
         doc_b.registration = "P2-ANH"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/rs-cad/main.py
+++ b/data-runners/rs-cad/main.py
@@ -5,7 +5,7 @@ SkyFollower Serbia CAD Data Runner
 Fetches the Serbia CAD (Civil Aviation Directorate) aircraft register from a
 REST JSON API, looks up each YU- registration in the Redis simple search index
 to find the ICAO hex (provided by Mictronics), writes enrichment data to
-aircraft:detail:{icao_hex}, publishes MQTT completion stats, then exits.
+aircraft:registry:{icao_hex}, publishes MQTT completion stats, then exits.
 
 Data source: https://apps.cad.gov.rs/ords/dcvws/regvaz/site/listAircraft
 """
@@ -33,9 +33,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("rs-cad")
@@ -152,16 +152,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -179,13 +179,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -228,7 +228,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/rs-cad/tests/test_rs_cad.py
+++ b/data-runners/rs-cad/tests/test_rs_cad.py
@@ -83,7 +83,7 @@ def _make_api_response(items: list[dict], status_code: int = 200):
 def _make_redis_with_search(icao_hex="4C0A3E", registration="YU-HRD"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -278,7 +278,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="4C0A3E", registration="YU-HRD")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:4C0A3E"
+        assert set_call[0][0] == "aircraft:registry:4C0A3E"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -296,16 +296,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="4C0A3E", registration="YU-HRD")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:4C0A3E", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4C0A3E", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(reg="YU-HRD"), _make_row(reg="YU-ANA")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:4C0A3E"
+        doc_a.id = "aircraft:mictronics:4C0A3E"
         doc_a.registration = "YU-HRD"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:4C0A3F"
+        doc_b.id = "aircraft:mictronics:4C0A3F"
         doc_b.registration = "YU-ANA"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/sg-caas/main.py
+++ b/data-runners/sg-caas/main.py
@@ -5,7 +5,7 @@ SkyFollower Singapore CAAS Data Runner
 Fetches the Singapore CAAS (Civil Aviation Authority of Singapore) aircraft
 register from a monthly-updated xlsx file, looks up each 9V- registration in
 the Redis simple search index to find the ICAO hex (provided by Mictronics),
-writes enrichment data to aircraft:detail:{icao_hex}, publishes MQTT completion
+writes enrichment data to aircraft:registry:{icao_hex}, publishes MQTT completion
 stats, then exits.
 
 The xlsx URL changes monthly (UUID component) and is discovered fresh each run
@@ -39,9 +39,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("sg-caas")
@@ -198,16 +198,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -225,13 +225,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration.strip()] = icao_hex
@@ -274,7 +274,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         if row is None:
             continue
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/sg-caas/tests/test_sg_caas.py
+++ b/data-runners/sg-caas/tests/test_sg_caas.py
@@ -79,7 +79,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="76CE26", registration="9V-SKA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -210,7 +210,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="76CE26", registration="9V-SKA")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:76CE26"
+        assert set_call[0][0] == "aircraft:registry:76CE26"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -228,16 +228,16 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="76CE26", registration="9V-SKA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:76CE26", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:76CE26", REDIS_TTL)
 
     def test_multiple_records(self):
         rows = [_make_row(reg="9V-SKA"), _make_row(reg="9V-SKB")]
         r = MagicMock()
         doc_a = MagicMock()
-        doc_a.id = "aircraft:simple:76CE26"
+        doc_a.id = "aircraft:mictronics:76CE26"
         doc_a.registration = "9V-SKA"
         doc_b = MagicMock()
-        doc_b.id = "aircraft:simple:76CE27"
+        doc_b.id = "aircraft:mictronics:76CE27"
         doc_b.registration = "9V-SKB"
         results = MagicMock()
         results.docs = [doc_a, doc_b]

--- a/data-runners/sk-nsat/main.py
+++ b/data-runners/sk-nsat/main.py
@@ -5,7 +5,7 @@ SkyFollower Slovakia NSAT Data Runner
 Fetches the Slovakia NSAT (Národný bezpečnostný úrad pre letectvo) aircraft
 register PDF, parses all OM- registration rows using pdfplumber, looks up each
 registration in the Redis simple search index to find the ICAO hex (provided by
-Mictronics), writes enrichment data to aircraft:detail:{icao_hex}, and
+Mictronics), writes enrichment data to aircraft:registry:{icao_hex}, and
 publishes MQTT completion stats, then exits.
 
 The PDF URL is date-stamped and discovered fresh each run by scraping the index
@@ -45,9 +45,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("sk-nsat")
@@ -197,16 +197,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -224,13 +224,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[_normalize_registration(registration)] = icao_hex
@@ -272,7 +272,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in reg_icao_map.items():
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/sk-nsat/tests/test_sk_nsat.py
+++ b/data-runners/sk-nsat/tests/test_sk_nsat.py
@@ -74,7 +74,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="710ABC", registration="OM-0101"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -228,7 +228,7 @@ class TestWriteToRedis:
         r = _make_redis_with_search(icao_hex="710ABC", registration="OM-0101")
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
-        assert set_call[0][0] == "aircraft:detail:710ABC"
+        assert set_call[0][0] == "aircraft:registry:710ABC"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -246,7 +246,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="710ABC", registration="OM-0101")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:710ABC", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:710ABC", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/tc-caa/main.py
+++ b/data-runners/tc-caa/main.py
@@ -6,7 +6,7 @@ Fetches the Turks & Caicos Islands Civil Aviation Authority (CAA) aircraft
 register from a single static HTML page, parses the table with BeautifulSoup,
 looks up each VQ- registration in the Redis simple search index to find the
 ICAO hex (provided by Mictronics), then writes enrichment data to
-aircraft:detail:{icao_hex} and publishes MQTT completion stats, then exits.
+aircraft:registry:{icao_hex} and publishes MQTT completion stats, then exits.
 
 Important: the Turks & Caicos register does not publish ICAO hex (Mode S)
 addresses. This runner can only enrich records that already exist in Redis
@@ -36,9 +36,9 @@ from redis.commands.search.index_definition import IndexDefinition, IndexType
 from redis.commands.search.query import Query
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("tc-caa")
@@ -151,16 +151,16 @@ def _escape_tag(value: str) -> str:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -178,13 +178,13 @@ def _build_registration_map(registrations: list[str], r: redis_lib.Redis) -> dic
         query_str = f"@registration:{{{'|'.join(escaped)}}}"
 
         try:
-            results = r.ft(AIRCRAFT_SIMPLE_SEARCH_INDEX).search(
+            results = r.ft(AIRCRAFT_MICTRONICS_SEARCH_INDEX).search(
                 Query(query_str)
                 .return_fields("registration")
                 .paging(0, BATCH_SIZE)
             )
             for doc in results.docs:
-                icao_hex = doc.id.replace("aircraft:simple:", "")
+                icao_hex = doc.id.replace("aircraft:mictronics:", "")
                 registration = getattr(doc, "registration", None)
                 if registration:
                     reg_map[registration] = icao_hex
@@ -225,7 +225,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     for registration, icao_hex in reg_icao_map.items():
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
-        key = aircraft_detail_key(icao_hex)
+        key = aircraft_registry_key(icao_hex)
         pipe.json().set(key, "$", record)
         pipe.expire(key, ttl)
         count += 1

--- a/data-runners/tc-caa/tests/test_tc_caa.py
+++ b/data-runners/tc-caa/tests/test_tc_caa.py
@@ -68,7 +68,7 @@ def _make_row(
 def _make_redis_with_search(icao_hex="0C1234", registration="VQ-TCA"):
     r = MagicMock()
     doc = MagicMock()
-    doc.id = f"aircraft:simple:{icao_hex}"
+    doc.id = f"aircraft:mictronics:{icao_hex}"
     doc.registration = registration
     results = MagicMock()
     results.docs = [doc]
@@ -182,7 +182,7 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call is not None
-        assert set_call[0][0] == "aircraft:detail:0C1234"
+        assert set_call[0][0] == "aircraft:registry:0C1234"
 
     def test_source_field_in_written_record(self):
         rows = [_make_row()]
@@ -200,7 +200,7 @@ class TestWriteToRedis:
         rows = [_make_row()]
         r = _make_redis_with_search(icao_hex="0C1234", registration="VQ-TCA")
         write_to_redis(rows, r, REDIS_TTL)
-        r.pipeline.return_value.expire.assert_called_with("aircraft:detail:0C1234", REDIS_TTL)
+        r.pipeline.return_value.expire.assert_called_with("aircraft:registry:0C1234", REDIS_TTL)
 
 
 # ---------------------------------------------------------------------------

--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -31,8 +31,8 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    aircraft_detail_key,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
+    aircraft_registry_key,
 )
 
 logger = logging.getLogger("uk-caa")
@@ -167,7 +167,7 @@ def _parse_year_built(year: Optional[int]) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 def _build_record(details: dict) -> Optional[dict]:
-    """Build the aircraft:detail:{hex} enrichment record from a G-INFO details payload."""
+    """Build the aircraft:registry:{hex} enrichment record from a G-INFO details payload."""
     aircraft_details = details.get("AircraftDetails", {})
 
     icao_addr = aircraft_details.get("ICAO24BitAircraftAddress") or {}
@@ -247,16 +247,16 @@ def _build_record(details: dict) -> Optional[dict]:
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft:detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -350,7 +350,7 @@ def run_pipeline(
                 continue
 
             record["source"] = "uk-caa"
-            key = aircraft_detail_key(record["icao_hex"])
+            key = aircraft_registry_key(record["icao_hex"])
             r.json().set(key, "$", record)
             r.expire(key, ttl)
             count += 1
@@ -378,7 +378,7 @@ def run_pipeline(
                 continue
 
             record["source"] = "uk-caa"
-            key = aircraft_detail_key(record["icao_hex"])
+            key = aircraft_registry_key(record["icao_hex"])
             r.json().set(key, "$", record)
             r.expire(key, ttl)
             count += 1

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -493,7 +493,7 @@ class TestRunPipeline:
         with patch("time.sleep"):
             run_pipeline(session, r, REDIS_TTL, 0.1)
         key_arg = r.json.return_value.set.call_args.args[0]
-        assert key_arg == "aircraft:detail:406B48"
+        assert key_arg == "aircraft:registry:406B48"
 
     def test_writes_at_root_path(self):
         r = self._make_redis()
@@ -530,7 +530,7 @@ class TestRunPipeline:
         session = self._make_session(_SEARCH_RESULT, _make_details())
         with patch("time.sleep"):
             run_pipeline(session, r, REDIS_TTL, 0.1)
-        r.expire.assert_called_with("aircraft:detail:406B48", REDIS_TTL)
+        r.expire.assert_called_with("aircraft:registry:406B48", REDIS_TTL)
 
     def test_search_error_skips_prefix_continues(self):
         r = self._make_redis()

--- a/data-runners/us-faa/main.py
+++ b/data-runners/us-faa/main.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
-from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX, aircraft_detail_key
+from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
 
 logger = logging.getLogger("us-faa")
 
@@ -433,16 +433,16 @@ def build_aircraft_record(
 def _ensure_search_index(r: redis_lib.Redis) -> None:
     """Create the aircraft detail JSON search index if it does not already exist."""
     try:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).info()
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).info()
     except Exception:
-        r.ft(AIRCRAFT_DETAIL_SEARCH_INDEX).create_index(
+        r.ft(AIRCRAFT_REGISTRY_SEARCH_INDEX).create_index(
             fields=[
                 TagField("$.icao_hex", as_name="icao_hex"),
                 TagField("$.registration", as_name="registration"),
             ],
-            definition=IndexDefinition(prefix=["aircraft:detail:"], index_type=IndexType.JSON),
+            definition=IndexDefinition(prefix=["aircraft:registry:"], index_type=IndexType.JSON),
         )
-        logger.info("Created search index %r.", AIRCRAFT_DETAIL_SEARCH_INDEX)
+        logger.info("Created search index %r.", AIRCRAFT_REGISTRY_SEARCH_INDEX)
 
 
 # ---------------------------------------------------------------------------
@@ -487,7 +487,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
         eng_row = engines_by_code.get(row["code_engine"]) if row["code_engine"] else None
         record = build_aircraft_record(row, acft_row, eng_row)
         record["source"] = "us-faa"
-        key = aircraft_detail_key(record["icao_hex"])
+        key = aircraft_registry_key(record["icao_hex"])
         batch.append((key, record))
         count += 1
         if len(batch) == 10000:

--- a/data-runners/us-faa/tests/test_us_faa.py
+++ b/data-runners/us-faa/tests/test_us_faa.py
@@ -537,13 +537,13 @@ class TestBuildAircraftRecord:
 # ---------------------------------------------------------------------------
 
 class TestRedisKeys:
-    def test_aircraft_detail_key_format(self):
-        from shared.redis_keys import aircraft_detail_key
-        assert aircraft_detail_key("a8ae7f") == "aircraft:detail:A8AE7F"
+    def test_aircraft_registry_key_format(self):
+        from shared.redis_keys import aircraft_registry_key
+        assert aircraft_registry_key("a8ae7f") == "aircraft:registry:A8AE7F"
 
     def test_aircraft_detail_search_index_name(self):
-        from shared.redis_keys import AIRCRAFT_DETAIL_SEARCH_INDEX
-        assert AIRCRAFT_DETAIL_SEARCH_INDEX == "idx:aircraft:detail"
+        from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX
+        assert AIRCRAFT_REGISTRY_SEARCH_INDEX == "idx:aircraft:registry"
 
 
 # ---------------------------------------------------------------------------
@@ -573,12 +573,12 @@ class TestWriteToRedis:
         assert write_to_redis(conn, r, REDIS_TTL) == 3
         conn.close()
 
-    def test_aircraft_detail_key_written(self):
+    def test_aircraft_registry_key_written(self):
         conn = self._make_db()
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         keys = [c.args[0] for c in pipe_json.set.call_args_list]
-        assert "aircraft:detail:A8AE7F" in keys
+        assert "aircraft:registry:A8AE7F" in keys
         conn.close()
 
     def test_json_set_uses_root_path(self):
@@ -613,7 +613,7 @@ class TestWriteToRedis:
         r, _, pipe_json = self._mock_redis()
         write_to_redis(conn, r, REDIS_TTL)
         calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
-        record = calls["aircraft:detail:A8AE7F"]
+        record = calls["aircraft:registry:A8AE7F"]
         assert isinstance(record, dict)
         assert record["source"] == "us-faa"
         assert record["registration"] == "N659DL"

--- a/shared/lua/merge_aircraft.lua
+++ b/shared/lua/merge_aircraft.lua
@@ -6,7 +6,7 @@
 -- ARGV[1] : icao_hex (e.g. "A8AE7F")
 --
 -- Returns nil if no mictronics record exists for the given icao_hex.
--- Detail fields win over simple fields on any overlap (same semantics as the
+-- Registry fields win over mictronics fields on any overlap (same semantics as the
 -- old deep-merge-on-write pattern, but performed server-side at read time).
 --
 -- Called by the processor via EVALSHA so the merge is a single round-trip.

--- a/shared/lua/merge_aircraft.lua
+++ b/shared/lua/merge_aircraft.lua
@@ -1,11 +1,11 @@
 -- merge_aircraft.lua
 --
--- Merges aircraft:simple:{icao_hex} and aircraft:detail:{icao_hex} into a
+-- Merges aircraft:mictronics:{icao_hex} and aircraft:registry:{icao_hex} into a
 -- single JSON document and returns it as a string.
 --
 -- ARGV[1] : icao_hex (e.g. "A8AE7F")
 --
--- Returns nil if no simple record exists for the given icao_hex.
+-- Returns nil if no mictronics record exists for the given icao_hex.
 -- Detail fields win over simple fields on any overlap (same semantics as the
 -- old deep-merge-on-write pattern, but performed server-side at read time).
 --
@@ -23,14 +23,14 @@ local function deep_merge(base, update)
     end
 end
 
-local simple_raw = redis.call('JSON.GET', 'aircraft:simple:' .. icao_hex)
+local simple_raw = redis.call('JSON.GET', 'aircraft:mictronics:' .. icao_hex)
 if not simple_raw then
     return nil
 end
 
 local result = cjson.decode(simple_raw)
 
-local detail_raw = redis.call('JSON.GET', 'aircraft:detail:' .. icao_hex)
+local detail_raw = redis.call('JSON.GET', 'aircraft:registry:' .. icao_hex)
 if detail_raw then
     deep_merge(result, cjson.decode(detail_raw))
 end

--- a/shared/redis_keys.py
+++ b/shared/redis_keys.py
@@ -9,27 +9,27 @@ are always explicit and typos in key names are caught by the type checker.
 _VALID_PERIODS = frozenset({"hour", "today", "lifetime"})
 _VALID_ARCHIVE_PERIODS = frozenset({"hour", "today"})
 
-# RediSearch index over all aircraft:simple:{hex} JSON documents (Mictronics).
+# RediSearch index over all aircraft:mictronics:{hex} JSON documents (Mictronics).
 # Indexed fields: $.icao_hex, $.registration
-AIRCRAFT_SIMPLE_SEARCH_INDEX = "idx:aircraft:simple"
+AIRCRAFT_MICTRONICS_SEARCH_INDEX = "idx:aircraft:mictronics"
 
-# RediSearch index over all aircraft:detail:{hex} JSON documents (country runners).
+# RediSearch index over all aircraft:registry:{hex} JSON documents (country runners).
 # Indexed fields: $.icao_hex, $.registration
-AIRCRAFT_DETAIL_SEARCH_INDEX = "idx:aircraft:detail"
+AIRCRAFT_REGISTRY_SEARCH_INDEX = "idx:aircraft:registry"
 
 # RediSearch index over all airport:{icao_code} JSON documents.
 # Supports lookup by ICAO code or IATA code.
 AIRPORT_SEARCH_INDEX = "idx:airport"
 
 
-def aircraft_simple_key(icao_hex: str) -> str:
-    """Mictronics aircraft enrichment record. aircraft:simple:{icao_hex}"""
-    return f"aircraft:simple:{icao_hex.upper()}"
+def aircraft_mictronics_key(icao_hex: str) -> str:
+    """Mictronics aircraft enrichment record. aircraft:mictronics:{icao_hex}"""
+    return f"aircraft:mictronics:{icao_hex.upper()}"
 
 
-def aircraft_detail_key(icao_hex: str) -> str:
-    """Country-runner aircraft enrichment record. aircraft:detail:{icao_hex}"""
-    return f"aircraft:detail:{icao_hex.upper()}"
+def aircraft_registry_key(icao_hex: str) -> str:
+    """Country-runner aircraft enrichment record. aircraft:registry:{icao_hex}"""
+    return f"aircraft:registry:{icao_hex.upper()}"
 
 
 def operator_key(designator: str) -> str:

--- a/shared/tests/test_redis_keys.py
+++ b/shared/tests/test_redis_keys.py
@@ -1,11 +1,11 @@
 import pytest
 
 from shared.redis_keys import (
-    AIRCRAFT_DETAIL_SEARCH_INDEX,
-    AIRCRAFT_SIMPLE_SEARCH_INDEX,
+    AIRCRAFT_MICTRONICS_SEARCH_INDEX,
+    AIRCRAFT_REGISTRY_SEARCH_INDEX,
     airport_key,
-    aircraft_detail_key,
-    aircraft_simple_key,
+    aircraft_mictronics_key,
+    aircraft_registry_key,
     config_areas_key,
     config_areas_version_key,
     config_rules_key,
@@ -20,19 +20,19 @@ from shared.redis_keys import (
 
 
 class TestEnrichmentKeys:
-    def test_aircraft_simple_key(self):
-        assert aircraft_simple_key("a8ae7f") == "aircraft:simple:A8AE7F"
-        assert aircraft_simple_key("A8AE7F") == "aircraft:simple:A8AE7F"
+    def test_aircraft_mictronics_key(self):
+        assert aircraft_mictronics_key("a8ae7f") == "aircraft:mictronics:A8AE7F"
+        assert aircraft_mictronics_key("A8AE7F") == "aircraft:mictronics:A8AE7F"
 
-    def test_aircraft_detail_key(self):
-        assert aircraft_detail_key("a8ae7f") == "aircraft:detail:A8AE7F"
-        assert aircraft_detail_key("A8AE7F") == "aircraft:detail:A8AE7F"
+    def test_aircraft_registry_key(self):
+        assert aircraft_registry_key("a8ae7f") == "aircraft:registry:A8AE7F"
+        assert aircraft_registry_key("A8AE7F") == "aircraft:registry:A8AE7F"
 
-    def test_aircraft_simple_search_index_name(self):
-        assert AIRCRAFT_SIMPLE_SEARCH_INDEX == "idx:aircraft:simple"
+    def test_aircraft_mictronics_search_index_name(self):
+        assert AIRCRAFT_MICTRONICS_SEARCH_INDEX == "idx:aircraft:mictronics"
 
-    def test_aircraft_detail_search_index_name(self):
-        assert AIRCRAFT_DETAIL_SEARCH_INDEX == "idx:aircraft:detail"
+    def test_aircraft_registry_search_index_name(self):
+        assert AIRCRAFT_REGISTRY_SEARCH_INDEX == "idx:aircraft:registry"
 
     def test_operator_key(self):
         assert operator_key("dal") == "operator:DAL"

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -476,7 +476,7 @@ sources:
     url: "https://www.caa.bg/bg/category/300/17238"
     format: xlsx
     cadence: weekly_tuesday
-    notes: "xlsx URL is date-encoded (Aircraft_Register_YYYYMMDD.xlsx) and discovered by scraping the index page; rows 0 (info) and 1 (header) skipped; column 4 holds LZ-prefix registration; no manufacturer, owner, or date stored; no ICAO hex — RediSearch lookup via Mictronics simple index; must run after Mictronics"
+    notes: "xlsx URL is date-encoded (Aircraft_Register_YYYYMMDD.xlsx) and discovered by scraping the index page; rows 0 (info) and 1 (header) skipped; column 4 holds LZ-prefix registration; no manufacturer, owner, or date stored; no ICAO hex — RediSearch lookup via Mictronics index; must run after Mictronics"
     fields:
       "Рег. № (col 0)": "Sequence number; not stored"
       "Дата (col 1)": "Date (Excel serial date format); not stored"
@@ -491,7 +491,7 @@ sources:
     url: "https://www.ccaa.hr/en/list-of-registered-aircraft-94674"
     format: pdf
     cadence: weekly_tuesday
-    notes: "PDF URL is hash-based and discovered by scraping the index page for the first /file/ link; PDF contains registration suffix only (e.g. ABC) — 9A- prefix must be prepended; no ICAO hex — RediSearch lookup via Mictronics simple index; newlines in cells collapsed to spaces; must run after Mictronics"
+    notes: "PDF URL is hash-based and discovered by scraping the index page for the first /file/ link; PDF contains registration suffix only (e.g. ABC) — 9A- prefix must be prepended; no ICAO hex — RediSearch lookup via Mictronics index; newlines in cells collapsed to spaces; must run after Mictronics"
     fields:
       "REG. OZNAKA": "Registration suffix (e.g. ABC); 9A- prefix must be prepended for full mark"
       "REDNI BROJ U REGISTRU": "Sequence number; not stored"
@@ -506,7 +506,7 @@ sources:
     url: "https://www.mcw.gov.cy/mcw/dca/dca.nsf/All/46E79D3B8B2B752AC2258D8D00384715/$file/Aircraft_Register_Extract.pdf"
     format: pdf
     cadence: weekly_tuesday
-    notes: "Stable PDF URL; all pages parsed with pdfplumber extract_table(); no ICAO hex in source — RediSearch lookup by registration against Mictronics simple index; OWNER/OPERATOR column split by / to produce multiple registrant names; MTOW KGS not stored; must run after Mictronics"
+    notes: "Stable PDF URL; all pages parsed with pdfplumber extract_table(); no ICAO hex in source — RediSearch lookup by registration against Mictronics index; OWNER/OPERATOR column split by / to produce multiple registrant names; MTOW KGS not stored; must run after Mictronics"
     fields:
       "REGISTRATION MARK": "Registration mark (5B-prefix; lookup key)"
       "MANUFACTURER": "Aircraft manufacturer name"
@@ -964,7 +964,7 @@ records:
             description: "Cayman Islands CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft @registration:{VP\\-CXXX} against Mictronics records; enriches existing records only"
           - source: br-anac
             file: dados_aeronaves.json
-            description: "ANAC does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{PP\\-XXX} against Mictronics records; enriches existing records only"
+            description: "ANAC does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{PP\\-XXX} against Mictronics records; enriches existing records only"
           - source: uk-caa
             endpoint: details
             field: AircraftDetails.ICAO24BitAircraftAddress.Hex
@@ -991,62 +991,62 @@ records:
               description: "6-character hex string normalised to uppercase"
           - source: me-caa
             page: detail
-            description: "Montenegro CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{4O\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Montenegro CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{4O\\-XXX} against Mictronics records; enriches existing records only"
           - source: is-samgongustofa
             endpoint: bulk
-            description: "Iceland Samgöngustofa does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{TF\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Iceland Samgöngustofa does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{TF\\-XXX} against Mictronics records; enriches existing records only"
           - source: kr-koca
             file: statListEn01.do (JSON datatable)
-            description: "Korea KOCA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{HL\\-XXXX} against Mictronics records; enriches existing records only"
+            description: "Korea KOCA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{HL\\-XXXX} against Mictronics records; enriches existing records only"
           - source: hu-kozhaf
             file: "Aircraft register PDF (date-stamped, discovered via index page)"
-            description: "Hungary KoZHAF does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{HA\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Hungary KoZHAF does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{HA\\-XXX} against Mictronics records; enriches existing records only"
           - source: ge-gcaa
-            description: "Georgia GCAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{4L\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Georgia GCAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{4L\\-XXX} against Mictronics records; enriches existing records only"
           - source: gg-2reg
             file: "PDF (date-encoded, discovered via index page)"
-            description: "Guernsey 2-reg does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{2\\-XXXX} against Mictronics records; enriches existing records only"
+            description: "Guernsey 2-reg does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{2\\-XXXX} against Mictronics records; enriches existing records only"
           - source: kg-caa
-            description: "Kyrgyzstan CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{EX\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Kyrgyzstan CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{EX\\-XXX} against Mictronics records; enriches existing records only"
           - source: bg-caa
             file: "Aircraft_Register_{YYYYMMDD}.xlsx"
-            description: "Bulgaria CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{LZ\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Bulgaria CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{LZ\\-XXX} against Mictronics records; enriches existing records only"
           - source: hr-ccaa
             file: "PDF (hash-based, discovered via index page)"
-            description: "Croatia CCAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{9A\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Croatia CCAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{9A\\-XXX} against Mictronics records; enriches existing records only"
           - source: cy-dca
             file: Aircraft_Register_Extract.pdf
-            description: "Cyprus DCA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{5B\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Cyprus DCA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{5B\\-XXX} against Mictronics records; enriches existing records only"
           - source: ee-transpordiamet
-            description: "Estonia Transpordiamet does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{ES\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Estonia Transpordiamet does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{ES\\-XXX} against Mictronics records; enriches existing records only"
           - source: lv-caa
-            description: "Latvia CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{YL\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Latvia CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{YL\\-XXX} against Mictronics records; enriches existing records only"
           - source: mv-caa
             file: "Aircraft register PDF (opaque hash filename; discovered via index page)"
-            description: "Maldives CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{8Q\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Maldives CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{8Q\\-XXX} against Mictronics records; enriches existing records only"
           - source: md-caa
             file: Registrul_Aerian_al_Republicii_Moldova.pdf
-            description: "Moldova CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{ER\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Moldova CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{ER\\-XXX} against Mictronics records; enriches existing records only"
           - source: mk-caa
             file: "AIRCRAFT-REGISTER-DD.MM.YYYY.pdf (date-stamped, discovered via index page)"
-            description: "North Macedonia CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{Z3\\-XXX} against Mictronics records; enriches existing records only"
+            description: "North Macedonia CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{Z3\\-XXX} against Mictronics records; enriches existing records only"
           - source: pg-casapng
             file: "PNG-civil-aircraft-register-website{date}.pdf (date-stamped, discovered via index page)"
-            description: "Papua New Guinea CASA PNG does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{P2\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Papua New Guinea CASA PNG does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{P2\\-XXX} against Mictronics records; enriches existing records only"
           - source: rs-cad
-            description: "Serbia CAD does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{YU\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Serbia CAD does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{YU\\-XXX} against Mictronics records; enriches existing records only"
           - source: sk-nsat
             file: WEB-DD.MM.YYYY.pdf (date-stamped, discovered via index page)
-            description: "Slovakia NSAT does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{OM\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Slovakia NSAT does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{OM\\-XXX} against Mictronics records; enriches existing records only"
           - source: tc-caa
             file: aircraft-register (HTML page)
-            description: "Turks & Caicos CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{VQ\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Turks & Caicos CAA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{VQ\\-XXX} against Mictronics records; enriches existing records only"
           - source: lu-dac
             file: "relev-aronefs-{DD}-{MM}-{YYYY}.pdf"
-            description: "Luxembourg DAC does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{LX\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Luxembourg DAC does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{LX\\-XXX} against Mictronics records; enriches existing records only"
           - source: bz-bdca
             file: bdca-civil-aircraft-register (HTML page)
-            description: "Belize BDCA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:simple @registration:{V3\\-XXX} against Mictronics records; enriches existing records only"
+            description: "Belize BDCA does not publish ICAO hex; resolved via FT.SEARCH idx:aircraft:mictronics @registration:{V3\\-XXX} against Mictronics records; enriches existing records only"
 
       registration:
         type: string


### PR DESCRIPTION
Closes #186

## Summary
- `shared/redis_keys.py`: `aircraft_simple_key()` → `aircraft_mictronics_key()`, `aircraft_detail_key()` → `aircraft_registry_key()`, `AIRCRAFT_SIMPLE_SEARCH_INDEX` → `AIRCRAFT_MICTRONICS_SEARCH_INDEX`, `AIRCRAFT_DETAIL_SEARCH_INDEX` → `AIRCRAFT_REGISTRY_SEARCH_INDEX`
- `shared/lua/merge_aircraft.lua`: updated both hardcoded `aircraft:simple:` and `aircraft:detail:` key prefixes
- `shared/tests/test_redis_keys.py`: updated imports and expected values
- All 38 data-runner `main.py` files and their test files: mechanical rename of symbols, string literals, `IndexDefinition` prefixes, and doc.id strip patterns
- `specs/data-dictionary.yaml`: updated `idx:aircraft:simple` → `idx:aircraft:mictronics` and "Mictronics simple index" prose across all source notes

Also fixed two regressions from #185 found while running the full suite: ca-tc and ca-transport-canada tests that still referenced `record["powerplant"]` instead of `record["aircraft"]["powerplant"]`.

## Test plan
- [ ] `shared/tests`: 45 passed
- [ ] `mictronics/tests`: 54 passed
- [ ] All 37 remaining runner suites pass (pre-existing failures in at-austrocontrol and ourairports are unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)