### PR TITLE
defect: replace ~~omit~~ with skip_if_value in powerplant.type decode tables

### DIFF
--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -2758,9 +2758,10 @@ records:
                   - source: nl-ilt
                     file: luchtvaartuigregister-ilt-datas2-{YYYY-MM-DD}.ods
                     field: EngKind
+                    skip_if_value: "Engine - not defined"
                     transform:
                       type: decode_table_passthrough
-                      description: "Mapped to canonical type; 'Engine - not defined' and blank → omit; unknown values pass through unmodified"
+                      description: "Mapped to canonical type; blank → omit; unknown values pass through unmodified"
                       values:
                         "Reciprocating piston-driven engine": Piston
                         "Reciprocating piston radial engine": Piston
@@ -2772,13 +2773,13 @@ records:
                         "Turbine-driven propeller engine": Turbo-prop
                         "Turbojet engine": Turbo-jet
                         "Wankel engine": Rotary
-                        "Engine - not defined": ~~omit~~
                   - source: au-casa
                     file: acrftreg
                     field: Engtype
+                    skip_if_value: "Not Applicable"
                     transform:
                       type: decode_table_passthrough
-                      description: "Mapped to canonical type; 'Not Applicable' → omit; unknown values pass through unmodified"
+                      description: "Mapped to canonical type; unknown values pass through unmodified"
                       values:
                         "Piston": Piston
                         "Turbofan": Turbo-fan
@@ -2788,7 +2789,6 @@ records:
                         "Electric": Electric
                         "Diesel Engine": Diesel
                         "Rotary": Rotary
-                        "Not Applicable": ~~omit~~
                   - source: ch-bazl
                     endpoint: bulk
                     field: " Engine Category"


### PR DESCRIPTION
Closes #284

## Summary
- `powerplant.type` nl-ilt source: removed `"Engine - not defined": ~~omit~~` from the decode table; added `skip_if_value: "Engine - not defined"` at the source entry level; updated description to remove the explicit mention
- `powerplant.type` au-casa source: removed `"Not Applicable": ~~omit~~` from the decode table; added `skip_if_value: "Not Applicable"` at the source entry level; updated description accordingly
- No runner code changes — runners already map these values to `None` and omit the field

## Test plan
- [ ] No runner tests affected (spec-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)