### PR TITLE
defect: Lua merge script — return nil only when both mictronics and registry absent

### DIFF
--- a/shared/lua/merge_aircraft.lua
+++ b/shared/lua/merge_aircraft.lua
@@ -5,7 +5,7 @@
 --
 -- ARGV[1] : icao_hex (e.g. "A8AE7F")
 --
--- Returns nil if no mictronics record exists for the given icao_hex.
+-- Returns nil only if both keys are absent for the given icao_hex.
 -- Registry fields win over mictronics fields on any overlap (same semantics as the
 -- old deep-merge-on-write pattern, but performed server-side at read time).
 --
@@ -23,16 +23,16 @@ local function deep_merge(base, update)
     end
 end
 
-local simple_raw = redis.call('JSON.GET', 'aircraft:mictronics:' .. icao_hex)
-if not simple_raw then
+local mictronics_raw = redis.call('JSON.GET', 'aircraft:mictronics:' .. icao_hex)
+local registry_raw   = redis.call('JSON.GET', 'aircraft:registry:'   .. icao_hex)
+
+if not mictronics_raw and not registry_raw then
     return nil
 end
 
-local result = cjson.decode(simple_raw)
-
-local detail_raw = redis.call('JSON.GET', 'aircraft:registry:' .. icao_hex)
-if detail_raw then
-    deep_merge(result, cjson.decode(detail_raw))
+local result = mictronics_raw and cjson.decode(mictronics_raw) or {}
+if registry_raw then
+    deep_merge(result, cjson.decode(registry_raw))
 end
 
 return cjson.encode(result)


### PR DESCRIPTION
Closes #286

## Summary
- Both `aircraft:mictronics:{icao_hex}` and `aircraft:registry:{icao_hex}` are fetched unconditionally
- Returns `nil` only when **both** are absent (previously returned `nil` if mictronics was missing even with a valid registry record)
- If only registry exists, result starts from an empty table and registry fields are merged in
- Registry fields continue to win over mictronics fields on overlap — merge semantics unchanged

## Test plan
- [ ] `shared/tests`: 45 passed (processor tests mock `evalsha` return value directly and are unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)