### PR TITLE
mictronics: add source field to aircraft records

### DIFF
--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -256,6 +256,7 @@ def build_aircraft_record(row: sqlite3.Row, types_row: Optional[sqlite3.Row]) ->
         "icao_hex": icao_hex,
         "registration": registration,
         "military": military,
+        "source": "mictronics",
     }
     if aircraft_fields:
         record["aircraft"] = aircraft_fields

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -323,16 +323,16 @@ class TestBuildAircraftRecord:
         assert record["icao_hex"] == "A8AE7F"
         assert record["registration"] == "N659DL"
         assert record["military"] is False
-        assert "source" not in record
+        assert record["source"] == "mictronics"
         ac = record["aircraft"]
         assert ac["type_designator"] == "B763"
         assert ac["manufacturer"] == "Boeing"
         assert ac["manufacturer_model"] == "Boeing 767-332ER"
 
-    def test_no_source_field(self):
+    def test_source_field(self):
         row = self._row("A8AE7F", "N659DL", "B763", False)
         record = build_aircraft_record(row, None)
-        assert "source" not in record
+        assert record["source"] == "mictronics"
 
     def test_no_unowned_fields(self):
         """Non-data-dictionary fields must be absent from the record."""


### PR DESCRIPTION
## Summary

- Adds `"source": "mictronics"` to every record written to `aircraft:mictronics:{icao_hex}`, consistent with all country registry runners
- Updates `test_full_record_shape` and renames `test_no_source_field` → `test_source_field` to assert the field is present and correct

Closes #290

## Test plan

- [ ] `python3 -m pytest data-runners/mictronics/tests/ -q` — 54 passed
- [ ] Run mictronics container and confirm `source` field present in Redis records via Lua merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)