### PR TITLE
uk-caa: retry prefix searches that return 403

### DIFF
--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -362,34 +362,6 @@ def run_pipeline(
             r.expire(key, ttl)
             count += 1
 
-    if retry_queue:
-        logger.info("Retrying %d aircraft that returned 403 (500ms interval)...", len(retry_queue))
-        for aircraft_id in retry_queue:
-            time.sleep(0.5)
-            try:
-                details = _get_aircraft_details(session, aircraft_id)
-            except Exception as exc:
-                logger.warning("Retry failed for AircraftID=%d: %s", aircraft_id, exc)
-                errors += 1
-                continue
-
-            reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
-            if reg_status != "Registered":
-                skipped += 1
-                continue
-
-            record = _build_record(details)
-            if record is None:
-                logger.warning("Could not build record for AircraftID=%d.", aircraft_id)
-                errors += 1
-                continue
-
-            record["source"] = "uk-caa"
-            key = aircraft_registry_key(record["icao_hex"])
-            r.json().set(key, "$", record)
-            r.expire(key, ttl)
-            count += 1
-
     if prefix_retry_queue:
         logger.info("Retrying %d prefixes that returned 403 (500ms interval)...", len(prefix_retry_queue))
         for prefix in prefix_retry_queue:
@@ -440,6 +412,34 @@ def run_pipeline(
                 r.json().set(key, "$", record)
                 r.expire(key, ttl)
                 count += 1
+
+    if retry_queue:
+        logger.info("Retrying %d aircraft that returned 403 (500ms interval)...", len(retry_queue))
+        for aircraft_id in retry_queue:
+            time.sleep(0.5)
+            try:
+                details = _get_aircraft_details(session, aircraft_id)
+            except Exception as exc:
+                logger.warning("Retry failed for AircraftID=%d: %s", aircraft_id, exc)
+                errors += 1
+                continue
+
+            reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
+            if reg_status != "Registered":
+                skipped += 1
+                continue
+
+            record = _build_record(details)
+            if record is None:
+                logger.warning("Could not build record for AircraftID=%d.", aircraft_id)
+                errors += 1
+                continue
+
+            record["source"] = "uk-caa"
+            key = aircraft_registry_key(record["icao_hex"])
+            r.json().set(key, "$", record)
+            r.expire(key, ttl)
+            count += 1
 
     logger.info("Finished: %d written, %d skipped, %d errors.", count, skipped, errors)
     return count

--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -305,11 +305,18 @@ def run_pipeline(
     skipped = 0
     errors = 0
     retry_queue: list[int] = []
+    prefix_retry_queue: list[str] = []
 
     for c1, c2 in product(_LETTERS, _LETTERS):
         prefix = f"{c1}{c2}"
         try:
             results = _search_by_prefix(session, prefix)
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 403:
+                prefix_retry_queue.append(prefix)
+            else:
+                logger.warning("Search error for prefix %s: %s", prefix, exc)
+            continue
         except Exception as exc:
             logger.warning("Search error for prefix %s: %s", prefix, exc)
             continue
@@ -382,6 +389,57 @@ def run_pipeline(
             r.json().set(key, "$", record)
             r.expire(key, ttl)
             count += 1
+
+    if prefix_retry_queue:
+        logger.info("Retrying %d prefixes that returned 403 (500ms interval)...", len(prefix_retry_queue))
+        for prefix in prefix_retry_queue:
+            time.sleep(0.5)
+            try:
+                results = _search_by_prefix(session, prefix)
+            except Exception as exc:
+                logger.warning("Retry failed for prefix %s: %s", prefix, exc)
+                errors += 1
+                continue
+
+            aircraft_ids = [
+                item.get("AircraftID")
+                for item in results
+                if item.get("RegistrationStatus") == "R" and item.get("AircraftID") is not None
+            ]
+            logger.info("G-%s* (retry): %d registered.", prefix, len(aircraft_ids))
+
+            for aircraft_id in aircraft_ids:
+                try:
+                    time.sleep(request_interval)
+                    details = _get_aircraft_details(session, aircraft_id)
+                except requests.HTTPError as exc:
+                    if exc.response is not None and exc.response.status_code == 403:
+                        retry_queue.append(aircraft_id)
+                    else:
+                        logger.warning("Error fetching details for AircraftID=%d: %s", aircraft_id, exc)
+                        errors += 1
+                    continue
+                except Exception as exc:
+                    logger.warning("Error fetching details for AircraftID=%d: %s", aircraft_id, exc)
+                    errors += 1
+                    continue
+
+                reg_status = (details.get("RegistrationDetails") or {}).get("Status", "")
+                if reg_status != "Registered":
+                    skipped += 1
+                    continue
+
+                record = _build_record(details)
+                if record is None:
+                    logger.warning("Could not build record for AircraftID=%d.", aircraft_id)
+                    errors += 1
+                    continue
+
+                record["source"] = "uk-caa"
+                key = aircraft_registry_key(record["icao_hex"])
+                r.json().set(key, "$", record)
+                r.expire(key, ttl)
+                count += 1
 
     logger.info("Finished: %d written, %d skipped, %d errors.", count, skipped, errors)
     return count

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -551,6 +551,80 @@ class TestRunPipeline:
         assert session.post.call_count == 676
         assert count == 0
 
+    def test_prefix_403_queued_and_retried(self):
+        r = self._make_redis()
+        session = MagicMock()
+
+        error_resp = MagicMock()
+        error_resp.status_code = 403
+        bad_search = MagicMock()
+        bad_search.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
+
+        good_search = MagicMock()
+        good_search.json.return_value = _SEARCH_RESULT
+        good_search.raise_for_status.return_value = None
+
+        empty_search = MagicMock()
+        empty_search.json.return_value = []
+        empty_search.raise_for_status.return_value = None
+
+        # First prefix (AA) returns 403; remaining 675 return empty; retry returns a result
+        session.post.side_effect = [bad_search] + [empty_search] * 675 + [good_search]
+
+        details_resp = MagicMock()
+        details_resp.json.return_value = _make_details()
+        details_resp.raise_for_status.return_value = None
+        session.get.return_value = details_resp
+
+        with patch("time.sleep"):
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert count == 1
+        assert session.post.call_count == 677  # 676 main + 1 retry
+
+    def test_prefix_403_retry_uses_500ms_sleep(self):
+        r = self._make_redis()
+        session = MagicMock()
+
+        error_resp = MagicMock()
+        error_resp.status_code = 403
+        bad_search = MagicMock()
+        bad_search.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
+
+        empty_search = MagicMock()
+        empty_search.json.return_value = []
+        empty_search.raise_for_status.return_value = None
+
+        # First prefix returns 403; retry returns empty
+        session.post.side_effect = [bad_search] + [empty_search] * 675 + [empty_search]
+
+        sleep_calls = []
+        with patch("time.sleep", side_effect=lambda x: sleep_calls.append(x)):
+            run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert 0.5 in sleep_calls
+
+    def test_prefix_non_403_not_retried(self):
+        r = self._make_redis()
+        session = MagicMock()
+
+        error_resp = MagicMock()
+        error_resp.status_code = 503
+        bad_search = MagicMock()
+        bad_search.raise_for_status.side_effect = requests.HTTPError(response=error_resp)
+
+        empty_search = MagicMock()
+        empty_search.json.return_value = []
+        empty_search.raise_for_status.return_value = None
+
+        session.post.side_effect = [bad_search] + [empty_search] * 675
+
+        with patch("time.sleep"):
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert count == 0
+        assert session.post.call_count == 676  # no retry
+
     def test_details_error_skips_and_continues(self):
         r = self._make_redis()
         session = MagicMock()

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -625,6 +625,44 @@ class TestRunPipeline:
         assert count == 0
         assert session.post.call_count == 676  # no retry
 
+    def test_detail_403_during_prefix_retry_is_retried(self):
+        """Aircraft that 403 during a prefix retry must still be retried via retry_queue."""
+        r = self._make_redis()
+        session = MagicMock()
+
+        prefix_403_resp = MagicMock()
+        prefix_403_resp.status_code = 403
+        bad_search = MagicMock()
+        bad_search.raise_for_status.side_effect = requests.HTTPError(response=prefix_403_resp)
+
+        good_search = MagicMock()
+        good_search.json.return_value = _SEARCH_RESULT
+        good_search.raise_for_status.return_value = None
+
+        empty_search = MagicMock()
+        empty_search.json.return_value = []
+        empty_search.raise_for_status.return_value = None
+
+        # Main loop: first prefix 403, rest empty; prefix retry returns a result
+        session.post.side_effect = [bad_search] + [empty_search] * 675 + [good_search]
+
+        detail_403_resp = MagicMock()
+        detail_403_resp.status_code = 403
+        detail_403 = MagicMock()
+        detail_403.raise_for_status.side_effect = requests.HTTPError(response=detail_403_resp)
+
+        good_detail = MagicMock()
+        good_detail.json.return_value = _make_details()
+        good_detail.raise_for_status.return_value = None
+
+        # Detail 403 during prefix retry, then success in aircraft retry_queue pass
+        session.get.side_effect = [detail_403, good_detail]
+
+        with patch("time.sleep"):
+            count = run_pipeline(session, r, REDIS_TTL, 0.1)
+
+        assert count == 1
+
     def test_details_error_skips_and_continues(self):
         r = self._make_redis()
         session = MagicMock()


### PR DESCRIPTION
## Summary

- Adds `prefix_retry_queue` to collect prefix search requests that return 403, mirroring the existing `retry_queue` for detail fetches
- 403 responses on prefix search are queued and retried after the main loop at 500ms intervals
- Non-403 HTTP errors and other exceptions on prefix search continue to log and skip (unchanged)
- Adds three new tests: prefix 403 queued and retried, retry uses 500ms sleep, non-403 not retried

Observed in the wild: `G-BN*` registrations silently skipped due to 403 on prefix search.

Closes #293

## Test plan

- [ ] `python3 -m pytest data-runners/uk-caa/tests/ -q` — 89 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)