### PR TITLE
ofelia: add missing runner schedules (issue #298)

### DIFF
--- a/config/ofelia/config.ini.example
+++ b/config/ofelia/config.ini.example
@@ -2,6 +2,10 @@
 schedule = 10 5 * * 1
 container = skyfollower-runner-ourairports
 
+[job-run "runner-uk-caa"]
+schedule = 10 6 * * 1
+container = skyfollower-runner-uk-caa
+
 [job-run "runner-mictronics"]
 schedule = 10 5 * * 2
 container = skyfollower-runner-mictronics
@@ -37,6 +41,14 @@ container = skyfollower-runner-lu-dac
 [job-run "runner-bz-bdca"]
 schedule = 10 11 * * 3
 container = skyfollower-runner-bz-bdca
+
+[job-run "runner-at-austrocontrol"]
+schedule = 10 12 * * 3
+container = skyfollower-runner-at-austrocontrol
+
+[job-run "runner-ch-bazl"]
+schedule = 10 13 * * 3
+container = skyfollower-runner-ch-bazl
 
 [job-run "runner-au-casa"]
 schedule = 10 7 * * 2

--- a/config/ofelia/config.ini.example
+++ b/config/ofelia/config.ini.example
@@ -2,6 +2,8 @@
 schedule = 10 5 * * 1
 container = skyfollower-runner-ourairports
 
+# uk-caa makes 676 prefix search calls + per-aircraft detail fetches and takes several hours.
+# Schedule it as the last runner of the day.
 [job-run "runner-uk-caa"]
 schedule = 10 6 * * 1
 container = skyfollower-runner-uk-caa


### PR DESCRIPTION
## Summary

Audit of `config/ofelia/config.ini.example` against `docker-compose.server.yaml` found three runners with no schedule entry:

| Runner | Added schedule | Notes |
|--------|---------------|-------|
| uk-caa | Monday 06:10 | Last on Monday; after ourairports (fast); slow runner gets the day |
| at-austrocontrol | Wednesday 12:10 | Requires RediSearch — must run after mictronics (Tuesday 05:10) |
| ch-bazl | Wednesday 13:10 | Own ICAO hex from CSV; grouped with European runners |

All docker-compose runner services now have a corresponding ofelia job entry.

Closes #298

## Test plan

- [ ] `comm -23 <(grep "container_name: skyfollower-runner-" docker-compose.server.yaml | awk '{print $2}' | sort) <(grep "^container = " config/ofelia/config.ini.example | awk '{print $3}' | sort)` — no output (no gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)