### PR TITLE
cz-caa: retry detail fetches on 403, 429, and 5xx

### DIFF
--- a/data-runners/cz-caa/main.py
+++ b/data-runners/cz-caa/main.py
@@ -49,6 +49,7 @@ REDIS_TTL = 14 * 86400
 MQTT_ROOT = "SkyFollower/runner/cz-caa"
 REQUEST_DELAY = 0.25  # seconds between detail requests
 _DETAIL_MAX_RETRIES = 3
+_RETRIABLE_HTTP = frozenset({403, 429})
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
@@ -91,17 +92,31 @@ def _fetch_active_ids(session: requests.Session) -> list[int]:
 
 
 def _fetch_detail(session: requests.Session, record_id: int) -> dict | None:
-    """Fetch a single aircraft detail record with retry on connection errors."""
+    """Fetch a single aircraft detail record with retry on connection errors and retriable HTTP errors."""
     url = _DETAIL_URL.format(id=record_id)
     logger.debug("Downloading Czech CAA detail from %s", url)
 
     for attempt in range(_DETAIL_MAX_RETRIES + 1):
         try:
             resp = session.get(url, timeout=30)
-            if not resp.ok:
-                logger.warning("Detail request for id=%d failed with HTTP %d.", record_id, resp.status_code)
+            if resp.ok:
+                return resp.json()
+            if resp.status_code in _RETRIABLE_HTTP or resp.status_code >= 500:
+                if attempt < _DETAIL_MAX_RETRIES:
+                    wait = 2 ** attempt
+                    logger.warning(
+                        "Detail request for id=%d returned HTTP %d; retrying in %ds (attempt %d/%d).",
+                        record_id, resp.status_code, wait, attempt + 1, _DETAIL_MAX_RETRIES,
+                    )
+                    time.sleep(wait)
+                    continue
+                logger.warning(
+                    "Detail request for id=%d returned HTTP %d after %d attempts.",
+                    record_id, resp.status_code, _DETAIL_MAX_RETRIES + 1,
+                )
                 return None
-            return resp.json()
+            logger.warning("Detail request for id=%d failed with HTTP %d.", record_id, resp.status_code)
+            return None
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
             if attempt < _DETAIL_MAX_RETRIES:
                 wait = 2 ** attempt

--- a/data-runners/cz-caa/tests/test_cz_caa.py
+++ b/data-runners/cz-caa/tests/test_cz_caa.py
@@ -249,6 +249,55 @@ class TestFetchDetail:
             _DETAIL_URL.format(id=99), timeout=30
         )
 
+    def test_retries_on_403(self):
+        session = MagicMock()
+        session.get.side_effect = [_make_response(status_code=403), _detail_response()]
+        with patch("cz_caa_main.time.sleep"):
+            result = _fetch_detail(session, 1)
+        assert result is not None
+        assert session.get.call_count == 2
+
+    def test_retries_on_429(self):
+        session = MagicMock()
+        session.get.side_effect = [_make_response(status_code=429), _detail_response()]
+        with patch("cz_caa_main.time.sleep"):
+            result = _fetch_detail(session, 1)
+        assert result is not None
+        assert session.get.call_count == 2
+
+    def test_retries_on_503(self):
+        session = MagicMock()
+        session.get.side_effect = [_make_response(status_code=503), _detail_response()]
+        with patch("cz_caa_main.time.sleep"):
+            result = _fetch_detail(session, 1)
+        assert result is not None
+        assert session.get.call_count == 2
+
+    def test_returns_none_after_all_http_retries_exhausted(self):
+        session = MagicMock()
+        session.get.return_value = _make_response(status_code=403)
+        with patch("cz_caa_main.time.sleep"):
+            assert _fetch_detail(session, 1) is None
+        assert session.get.call_count == 4  # initial + 3 retries
+
+    def test_non_retriable_http_not_retried(self):
+        session = MagicMock()
+        session.get.return_value = _make_response(status_code=404)
+        assert _fetch_detail(session, 1) is None
+        assert session.get.call_count == 1
+
+    def test_retriable_http_uses_exponential_backoff(self):
+        session = MagicMock()
+        session.get.side_effect = [
+            _make_response(status_code=429),
+            _make_response(status_code=429),
+            _detail_response(),
+        ]
+        with patch("cz_caa_main.time.sleep") as mock_sleep:
+            _fetch_detail(session, 1)
+        assert mock_sleep.call_args_list[0] == call(1)
+        assert mock_sleep.call_args_list[1] == call(2)
+
 
 # ---------------------------------------------------------------------------
 # Tests: _first_display_name
@@ -397,7 +446,7 @@ class TestDownloadAndParse:
         session = MagicMock()
         session.get.side_effect = [
             _list_response([_list_record(id=1), _list_record(id=2)]),
-            _make_response(status_code=500),
+            _make_response(status_code=404),
             _detail_response(transponder="AAAAAA"),
         ]
         records = self._collect(session)


### PR DESCRIPTION
## Summary

- Adds `_RETRIABLE_HTTP = frozenset({403, 429})` constant
- Extends `_fetch_detail` to retry on 403, 429, and any 5xx response using the same exponential backoff already in place for connection errors (up to `_DETAIL_MAX_RETRIES = 3` attempts)
- Non-retriable errors (404, 400, etc.) still return `None` immediately
- Updates `test_continues_on_detail_error` to use 404 (non-retriable) instead of 500
- Adds six new tests covering 403/429/5xx retry, exhausted retries, non-retriable skipping, and exponential backoff

Closes #296

## Test plan

- [ ] `python3 -m pytest data-runners/cz-caa/tests/ -q` — 74 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)