### PR TITLE
me-caa: fix sparse Redis overwrite and add detail page retry

### DIFF
--- a/data-runners/me-caa/main.py
+++ b/data-runners/me-caa/main.py
@@ -57,6 +57,8 @@ _DETAIL_BASE_URL = "https://www.caa.me/en/"
 REDIS_TTL = 14 * 86400
 MQTT_ROOT = "SkyFollower/runner/me-caa"
 BATCH_SIZE = 100
+_DETAIL_MAX_RETRIES = 2
+_RETRIABLE_HTTP = frozenset({403, 429})
 
 _BROWSER_UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -110,15 +112,52 @@ def _fetch_list_page(session: requests.Session, page: int) -> list[dict]:
     return rows
 
 
-def _fetch_detail_page(session: requests.Session, registration: str) -> dict:
-    """Fetch the detail page for one aircraft and return extracted fields."""
+def _fetch_detail_page(session: requests.Session, registration: str) -> dict | None:
+    """Fetch the detail page for one aircraft and return extracted fields.
+
+    Returns None if the page cannot be fetched after retries (caller should skip
+    the record entirely). Returns an empty dict if the page loaded but no fields
+    were parsed.
+    """
     slug = registration.lower()
     url = f"{_DETAIL_BASE_URL}{slug}"
     logger.debug("Fetching Montenegro CAA detail page from %s", url)
-    resp = session.get(url, timeout=30)
-    if not resp.ok:
-        logger.warning("Detail page for %s returned HTTP %s; skipping.", registration, resp.status_code)
-        return {}
+
+    for attempt in range(_DETAIL_MAX_RETRIES + 1):
+        try:
+            resp = session.get(url, timeout=30)
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+            if attempt < _DETAIL_MAX_RETRIES:
+                wait = 2 ** attempt
+                logger.warning(
+                    "Detail page for %s failed (%s); retrying in %ds (attempt %d/%d).",
+                    registration, exc, wait, attempt + 1, _DETAIL_MAX_RETRIES,
+                )
+                time.sleep(wait)
+                continue
+            logger.warning("Detail page for %s failed after %d attempts: %s", registration, _DETAIL_MAX_RETRIES + 1, exc)
+            return None
+
+        if resp.ok:
+            break
+
+        if resp.status_code in _RETRIABLE_HTTP or resp.status_code >= 500:
+            if attempt < _DETAIL_MAX_RETRIES:
+                wait = 2 ** attempt
+                logger.warning(
+                    "Detail page for %s returned HTTP %d; retrying in %ds (attempt %d/%d).",
+                    registration, resp.status_code, wait, attempt + 1, _DETAIL_MAX_RETRIES,
+                )
+                time.sleep(wait)
+                continue
+            logger.warning(
+                "Detail page for %s returned HTTP %d after %d attempts.",
+                registration, resp.status_code, _DETAIL_MAX_RETRIES + 1,
+            )
+            return None
+
+        logger.warning("Detail page for %s returned HTTP %d; skipping.", registration, resp.status_code)
+        return None
 
     soup = BeautifulSoup(resp.text, "lxml")
     fields: dict = {}
@@ -179,6 +218,8 @@ def download_and_parse(session: requests.Session) -> list[dict]:
             continue
 
         detail = _fetch_detail_page(session, registration)
+        if detail is None:
+            continue
 
         records.append({
             "registration": registration,

--- a/data-runners/me-caa/tests/test_me_caa.py
+++ b/data-runners/me-caa/tests/test_me_caa.py
@@ -9,6 +9,7 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 # ---------------------------------------------------------------------------
 # Module import
@@ -283,11 +284,60 @@ class TestFetchDetailPage:
         detail = _fetch_detail_page(session, "4O-AOA")
         assert detail["Country"] == "Montenegro"
 
-    def test_returns_empty_dict_on_http_error(self):
+    def test_returns_none_on_non_retriable_http_error(self):
         session = MagicMock()
         session.get.return_value = _make_response("", 404)
         detail = _fetch_detail_page(session, "4O-AOA")
-        assert detail == {}
+        assert detail is None
+
+    def test_retries_on_403(self):
+        session = MagicMock()
+        session.get.side_effect = [_make_response("", 403), _make_response(_detail_html())]
+        with patch("me_caa_main.time.sleep"):
+            detail = _fetch_detail_page(session, "4O-AOA")
+        assert detail is not None
+        assert session.get.call_count == 2
+
+    def test_retries_on_429(self):
+        session = MagicMock()
+        session.get.side_effect = [_make_response("", 429), _make_response(_detail_html())]
+        with patch("me_caa_main.time.sleep"):
+            detail = _fetch_detail_page(session, "4O-AOA")
+        assert detail is not None
+        assert session.get.call_count == 2
+
+    def test_retries_on_503(self):
+        session = MagicMock()
+        session.get.side_effect = [_make_response("", 503), _make_response(_detail_html())]
+        with patch("me_caa_main.time.sleep"):
+            detail = _fetch_detail_page(session, "4O-AOA")
+        assert detail is not None
+        assert session.get.call_count == 2
+
+    def test_returns_none_after_retries_exhausted(self):
+        session = MagicMock()
+        session.get.return_value = _make_response("", 403)
+        with patch("me_caa_main.time.sleep"):
+            detail = _fetch_detail_page(session, "4O-AOA")
+        assert detail is None
+        assert session.get.call_count == 3  # initial + 2 retries
+
+    def test_retries_on_connection_error(self):
+        session = MagicMock()
+        session.get.side_effect = [
+            requests.exceptions.ConnectionError("dropped"),
+            _make_response(_detail_html()),
+        ]
+        with patch("me_caa_main.time.sleep"):
+            detail = _fetch_detail_page(session, "4O-AOA")
+        assert detail is not None
+
+    def test_returns_none_after_connection_error_retries_exhausted(self):
+        session = MagicMock()
+        session.get.side_effect = requests.exceptions.ConnectionError("dropped")
+        with patch("me_caa_main.time.sleep"):
+            detail = _fetch_detail_page(session, "4O-AOA")
+        assert detail is None
 
     def test_url_uses_lowercase_registration(self):
         session = MagicMock()
@@ -352,6 +402,23 @@ class TestDownloadAndParse:
         )
         records = download_and_parse(session)
         assert records[0]["model"] == "ERJ 190-200 LR"
+
+    def test_skips_record_when_detail_fetch_fails(self):
+        """A None detail response must not produce a sparse Redis write."""
+        session = MagicMock()
+        responses = [
+            _make_response(_list_html([
+                {"Registarska oznaka": "4O-AAA", "Ime": "Owner A", "Tip": "C172"},
+                {"Registarska oznaka": "4O-BBB", "Ime": "Owner B", "Tip": "PA28"},
+            ])),
+            _make_response(_list_html([])),
+            _make_response("", 404),         # 4O-AAA detail fails
+            _make_response(_detail_html()),  # 4O-BBB detail succeeds
+        ]
+        session.get.side_effect = responses
+        records = download_and_parse(session)
+        assert len(records) == 1
+        assert records[0]["registration"] == "4O-BBB"
 
     def test_maps_all_fields(self):
         session = self._make_session(


### PR DESCRIPTION
## Summary

Two bugs fixed:

**1. Sparse overwrite (primary issue)**
`_fetch_detail_page` previously returned `{}` on HTTP failure. `download_and_parse` always appended the result regardless, writing a sparse record (registration + list-page `Tip` only) to Redis — potentially overwriting a richer existing entry. Now `_fetch_detail_page` returns `None` on failure and `download_and_parse` skips the record entirely.

**2. No retry (secondary issue)**
`_fetch_detail_page` had no retry logic. Now retries 403, 429, 5xx, and connection errors up to `_DETAIL_MAX_RETRIES = 2` times with exponential backoff. Non-retriable errors (404, 400, etc.) return `None` immediately.

## Test plan

- [ ] `python3 -m pytest data-runners/me-caa/tests/ -q` — 70 passed

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)