### PR TITLE
Omit null-valued fields from Redis enrichment records

### DIFF
--- a/data-runners/at-austrocontrol/main.py
+++ b/data-runners/at-austrocontrol/main.py
@@ -42,6 +42,7 @@ from shared.redis_keys import (
     aircraft_registry_key,
     aircraft_mictronics_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("at-austrocontrol")
 
@@ -389,7 +390,7 @@ def write_to_redis(items: list[dict], r: redis_lib.Redis, ttl: int) -> int:
 
         record = _build_record(item, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         pipe_count += 1
         count += 1

--- a/data-runners/at-austrocontrol/tests/test_at_austrocontrol.py
+++ b/data-runners/at-austrocontrol/tests/test_at_austrocontrol.py
@@ -530,6 +530,17 @@ class TestWriteToRedis:
         count = write_to_redis(items, r, REDIS_TTL)
         assert count == 1
 
+    def test_null_fields_omitted_from_written_record(self):
+        """Optional fields with no source data must be absent from the written record, not None."""
+        item = _make_item(hersteller="", seriennummer="")
+        r = _make_redis_with_search(icao_hex="440123", registration="OE-ARG")
+        write_to_redis([item], r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call is not None
+        written = set_call[0][2]
+        assert "manufacturer" not in written["aircraft"]
+        assert "serial_number" not in written["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/au-casa/main.py
+++ b/data-runners/au-casa/main.py
@@ -43,6 +43,7 @@ from shared.redis_keys import (
     aircraft_registry_key,
     aircraft_mictronics_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("au-casa")
 
@@ -398,7 +399,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         record = _build_record(row, icao_hex, registration)
         record["source"] = "au-casa"
 
-        pipe.json().set(aircraft_registry_key(icao_hex), "$", record)
+        set_json(pipe, aircraft_registry_key(icao_hex), record)
         pipe.expire(aircraft_registry_key(icao_hex), ttl)
         pipe_size += 1
         count += 1

--- a/data-runners/bg-caa/main.py
+++ b/data-runners/bg-caa/main.py
@@ -44,6 +44,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("bg-caa")
 
@@ -252,7 +253,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/bg-caa/tests/test_bg_caa.py
+++ b/data-runners/bg-caa/tests/test_bg_caa.py
@@ -453,3 +453,16 @@ class TestWriteToRedis:
             with patch.object(_mod, "logger") as mock_logger:
                 write_to_redis(rows, r, 1209600)
         mock_logger.warning.assert_called()
+
+    def test_null_fields_omitted_from_written_record(self):
+        """Optional fields with no source data must be absent from the written record, not None."""
+        rows = [_make_row(registration="LZ-ABC", model="", category="")]
+        r = MagicMock()
+        pipe = MagicMock()
+        r.pipeline.return_value = pipe
+        with patch.object(_mod, "_build_registration_map", return_value={"LZ-ABC": "42A001"}):
+            write_to_redis(rows, r, 1209600)
+        set_call = pipe.json.return_value.set.call_args
+        written = set_call[0][2]
+        assert "model" not in written["aircraft"]
+        assert "type" not in written["aircraft"]

--- a/data-runners/br-anac/main.py
+++ b/data-runners/br-anac/main.py
@@ -42,6 +42,7 @@ from shared.redis_keys import (
     aircraft_registry_key,
     aircraft_mictronics_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("br-anac")
 
@@ -387,7 +388,7 @@ def write_to_redis(records: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             record = _build_record(icao_hex, registration, row)
             record["source"] = "br-anac"
             key = aircraft_registry_key(icao_hex)
-            r.json().set(key, "$", record)
+            set_json(r, key, record)
             r.expire(key, ttl)
             count += 1
         except Exception as exc:

--- a/data-runners/br-anac/tests/test_br_anac.py
+++ b/data-runners/br-anac/tests/test_br_anac.py
@@ -521,6 +521,15 @@ class TestWriteToRedis:
             write_to_redis(rows, r, REDIS_TTL)
         r.expire.assert_called_once_with("aircraft:registry:E491A0", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        """Optional fields with no source data must be absent from the written record, not None."""
+        r = self._make_redis()
+        rows = [_make_row(proprietariosjson=None)]
+        with self._patch_reg_map({"PP-AJH": "E491A0"}):
+            write_to_redis(rows, r, REDIS_TTL)
+        written = r.json.return_value.set.call_args.args[2]
+        assert "registrant" not in written
+
 
 # ---------------------------------------------------------------------------
 # Tests: MQTT completion stats (mocked)

--- a/data-runners/bs-caa/main.py
+++ b/data-runners/bs-caa/main.py
@@ -47,6 +47,7 @@ from shared.redis_keys import (
     aircraft_registry_key,
     aircraft_mictronics_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("bs-caa")
 
@@ -308,7 +309,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
 
         record = _build_record(hex_val, registration, row)
         key = aircraft_registry_key(hex_val)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/bz-bdca/main.py
+++ b/data-runners/bz-bdca/main.py
@@ -41,6 +41,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("bz-bdca")
 
@@ -252,7 +253,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/bz-bdca/tests/test_bz_bdca.py
+++ b/data-runners/bz-bdca/tests/test_bz_bdca.py
@@ -254,6 +254,18 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:0A0123", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        """Optional fields with no source data must be absent from the written record, not None."""
+        rows = [_make_row(serial="", address="")]
+        r = _make_redis_with_search(icao_hex="0A0123", registration="V3-ABC")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call is not None
+        written = set_call[0][2]
+        assert "serial_number" not in written["aircraft"]
+        assert "city" not in written["registrant"]
+        assert "street" not in written["registrant"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/ca-transport-canada/main.py
+++ b/data-runners/ca-transport-canada/main.py
@@ -34,6 +34,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("ca-transport-canada")
 
@@ -457,7 +458,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     def _flush():
         pipe = r.pipeline()
         for key, record in batch:
-            pipe.json().set(key, "$", record)
+            set_json(pipe, key, record)
             pipe.expire(key, ttl)
         pipe.execute()
 

--- a/data-runners/ca-transport-canada/tests/test_ca_tc.py
+++ b/data-runners/ca-transport-canada/tests/test_ca_tc.py
@@ -763,6 +763,17 @@ class TestWriteToRedis:
             assert record["source"] == "ca-transport-canada"
         conn.close()
 
+    def test_null_fields_omitted_from_written_record(self):
+        """C-XYZ has no active owner, so build_aircraft_record sets registrant=None;
+        the written record must omit the key entirely, not write it as None."""
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
+        record = calls["aircraft:registry:C00002"]
+        assert "registrant" not in record
+        conn.close()
+
 
 # ---------------------------------------------------------------------------
 # Tests: MQTT completion stats (mocked)

--- a/data-runners/ch-bazl/main.py
+++ b/data-runners/ch-bazl/main.py
@@ -31,6 +31,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import aircraft_registry_key, AIRCRAFT_REGISTRY_SEARCH_INDEX
+from shared.redis_json import set_json
 
 logger = logging.getLogger("ch-bazl")
 
@@ -281,7 +282,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         record["source"] = "ch-bazl"
         key = aircraft_registry_key(record["icao_hex"])
         try:
-            r.json().set(key, "$", record)
+            set_json(r, key, record)
             r.expire(key, ttl)
             count += 1
         except Exception as exc:

--- a/data-runners/ch-bazl/tests/test_ch_bazl.py
+++ b/data-runners/ch-bazl/tests/test_ch_bazl.py
@@ -465,6 +465,14 @@ class TestWriteToRedis:
         key = r.json.return_value.set.call_args.args[0]
         assert key == "aircraft:registry:4B1916"
 
+    def test_null_fields_omitted_from_written_record(self):
+        """Optional fields with no source data must be absent from the written record, not None."""
+        r = _make_redis()
+        write_to_redis([_make_row(manufacturer="", owner="")], r, REDIS_TTL)
+        written = r.json.return_value.set.call_args.args[2]
+        assert "manufacturer" not in written["aircraft"]
+        assert "registrant" not in written
+
 
 # ---------------------------------------------------------------------------
 # Tests: _ensure_search_index

--- a/data-runners/cy-dca/main.py
+++ b/data-runners/cy-dca/main.py
@@ -47,6 +47,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("cy-dca")
 
@@ -232,7 +233,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/cy-dca/tests/test_cy_dca.py
+++ b/data-runners/cy-dca/tests/test_cy_dca.py
@@ -464,3 +464,16 @@ class TestWriteToRedis:
             args and "%d / %d" in str(args[0]) and args[1] == 1 and args[2] == 1
             for args in (c.args for c in calls)
         )
+
+    def test_null_fields_omitted_from_written_record(self):
+        """Optional fields with no source data must be absent from the written record, not None."""
+        rows = [_make_row(registration="5B-ABC", serial="", owner="")]
+        r = MagicMock()
+        pipe = MagicMock()
+        r.pipeline.return_value = pipe
+        with patch.object(_mod, "_build_registration_map", return_value={"5B-ABC": "4B0001"}):
+            write_to_redis(rows, r, 1209600)
+        set_call = pipe.json.return_value.set.call_args
+        written = set_call[0][2]
+        assert "serial_number" not in written["aircraft"]
+        assert "registrant" not in written

--- a/data-runners/cz-caa/main.py
+++ b/data-runners/cz-caa/main.py
@@ -39,6 +39,7 @@ import requests
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from shared.redis_keys import aircraft_registry_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("cz-caa")
 
@@ -262,7 +263,7 @@ def write_to_redis(row: dict, r: redis_lib.Redis, ttl: int) -> bool:
     record = _build_record(row)
     key = aircraft_registry_key(icao_hex)
     try:
-        r.json().set(key, "$", record)
+        set_json(r, key, record)
         r.expire(key, ttl)
         return True
     except Exception as exc:

--- a/data-runners/cz-caa/tests/test_cz_caa.py
+++ b/data-runners/cz-caa/tests/test_cz_caa.py
@@ -630,6 +630,13 @@ class TestWriteToRedis:
         r.json.return_value.set.side_effect = Exception("connection refused")
         assert write_to_redis(_make_row(), r, REDIS_TTL) is False
 
+    def test_null_fields_omitted_from_written_record(self):
+        r = _make_redis()
+        write_to_redis(_make_row(model="", seats=None), r, REDIS_TTL)
+        written = r.json.return_value.set.call_args[0][2]
+        assert "model" not in written["aircraft"]
+        assert "seats" not in written["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/ee-transpordiamet/main.py
+++ b/data-runners/ee-transpordiamet/main.py
@@ -45,6 +45,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("ee-transpordiamet")
 
@@ -216,7 +217,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/ee-transpordiamet/tests/test_ee_transpordiamet.py
+++ b/data-runners/ee-transpordiamet/tests/test_ee_transpordiamet.py
@@ -307,6 +307,13 @@ class TestWriteToRedis:
     def test_empty_list_returns_zero(self):
         assert write_to_redis([], _make_redis_no_match(), REDIS_TTL) == 0
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(model="")]
+        r = _make_redis_with_search(icao_hex="4B1234", registration="ES-AAA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert "model" not in set_call[0][2]["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/es-aesa/main.py
+++ b/data-runners/es-aesa/main.py
@@ -42,6 +42,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("es-aesa")
 
@@ -294,7 +295,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/es-aesa/tests/test_es_aesa.py
+++ b/data-runners/es-aesa/tests/test_es_aesa.py
@@ -321,6 +321,13 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:340123", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(fabricante="")]
+        r = _make_redis_with_search(icao_hex="340123", registration="EC-ABC")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert "manufacturer" not in set_call[0][2]["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/fr-dgac/main.py
+++ b/data-runners/fr-dgac/main.py
@@ -46,6 +46,7 @@ from shared.redis_keys import (
     AIRCRAFT_REGISTRY_SEARCH_INDEX,
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("fr-dgac")
 
@@ -416,7 +417,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         record["source"] = "fr-dgac"
 
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         pipe_size += 1
         count += 1

--- a/data-runners/ge-gcaa/main.py
+++ b/data-runners/ge-gcaa/main.py
@@ -51,6 +51,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("ge-gcaa")
 
@@ -298,7 +299,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/ge-gcaa/tests/test_ge_gcaa.py
+++ b/data-runners/ge-gcaa/tests/test_ge_gcaa.py
@@ -379,6 +379,13 @@ class TestWriteToRedis:
     def test_empty_list_returns_zero(self):
         assert write_to_redis([], _make_redis_no_match(), REDIS_TTL) == 0
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_merged_row(serial="")]
+        r = _make_redis_with_search(icao_hex="4A1234", registration="4L-GAA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert "serial_number" not in set_call[0][2]["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/gg-2reg/main.py
+++ b/data-runners/gg-2reg/main.py
@@ -54,6 +54,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("gg-2reg")
 
@@ -294,7 +295,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/gg-2reg/tests/test_gg_2reg.py
+++ b/data-runners/gg-2reg/tests/test_gg_2reg.py
@@ -452,6 +452,13 @@ class TestWriteToRedis:
         count = write_to_redis([], _make_redis_no_match(), REDIS_TTL)
         assert count == 0
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(manufacturer="")]
+        r = _make_redis_with_search(icao_hex="4CA123", registration="2-ABCD")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert "manufacturer" not in set_call[0][2]["aircraft"]
+
     def test_multiple_records(self):
         rows = [_make_row(registration="2-ABCD"), _make_row(registration="2-EFGH")]
         r = MagicMock()

--- a/data-runners/hr-ccaa/main.py
+++ b/data-runners/hr-ccaa/main.py
@@ -45,6 +45,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("hr-ccaa")
 
@@ -250,7 +251,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/hr-ccaa/tests/test_hr_ccaa.py
+++ b/data-runners/hr-ccaa/tests/test_hr_ccaa.py
@@ -478,3 +478,13 @@ class TestWriteToRedis:
             with patch.object(_mod, "logger") as mock_logger:
                 write_to_redis(rows, r, 1209600)
         mock_logger.warning.assert_called()
+
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(registration="9A-ABC", manufacturer="")]
+        r = MagicMock()
+        pipe = MagicMock()
+        r.pipeline.return_value = pipe
+        with patch.object(_mod, "_build_registration_map", return_value={"9A-ABC": "501234"}):
+            write_to_redis(rows, r, 1209600)
+        set_call = pipe.json.return_value.set.call_args
+        assert "manufacturer" not in set_call[0][2]["aircraft"]

--- a/data-runners/hu-kozhaf/main.py
+++ b/data-runners/hu-kozhaf/main.py
@@ -52,6 +52,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("hu-kozhaf")
 
@@ -295,7 +296,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/hu-kozhaf/tests/test_hu_kozhaf.py
+++ b/data-runners/hu-kozhaf/tests/test_hu_kozhaf.py
@@ -339,6 +339,13 @@ class TestWriteToRedis:
         count = write_to_redis(rows, r, REDIS_TTL)
         assert count == 2
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(model="")]
+        r = _make_redis_with_search(icao_hex="4D1234", registration="HA-GZQ")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert "model" not in set_call[0][2]["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/im-ardis/main.py
+++ b/data-runners/im-ardis/main.py
@@ -30,6 +30,7 @@ from bs4 import BeautifulSoup
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from shared.redis_keys import aircraft_registry_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("im-ardis")
 
@@ -235,7 +236,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
 
         key = aircraft_registry_key(record["icao_hex"])
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/im-ardis/tests/test_im_ardis.py
+++ b/data-runners/im-ardis/tests/test_im_ardis.py
@@ -223,6 +223,15 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call[0][2]["source"] == "im-ardis"
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(mode_s="43E717", model="")]
+        r = _make_redis()
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call[0][1] == "$"
+        record = set_call[0][2]
+        assert "model" not in record["aircraft"]
+
     def test_mixed_active_and_deregistered(self):
         rows = [
             _make_row(registration="M-ABCD", mode_s="43E717", status="Active"),

--- a/data-runners/is-samgongustofa/main.py
+++ b/data-runners/is-samgongustofa/main.py
@@ -40,6 +40,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("is-samgongustofa")
 
@@ -277,7 +278,7 @@ def write_to_redis(aircrafts: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         aircraft = reg_to_aircraft[registration]
         record = _build_record(aircraft, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         pipe_count += 1
         count += 1

--- a/data-runners/is-samgongustofa/tests/test_is_samgongustofa.py
+++ b/data-runners/is-samgongustofa/tests/test_is_samgongustofa.py
@@ -290,6 +290,17 @@ class TestWriteToRedis:
         write_to_redis(aircraft, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4CA123", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        aircraft = [_make_aircraft(aircraft_type="", serial_number="")]
+        r = _make_redis_with_search(icao_hex="4CA123", registration="TF-ABC")
+        write_to_redis(aircraft, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call is not None
+        assert set_call[0][1] == "$"
+        written = set_call[0][2]
+        assert "model" not in written["aircraft"]
+        assert "serial_number" not in written["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/kg-caa/main.py
+++ b/data-runners/kg-caa/main.py
@@ -50,6 +50,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("kg-caa")
 
@@ -320,7 +321,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/kg-caa/tests/test_kg_caa.py
+++ b/data-runners/kg-caa/tests/test_kg_caa.py
@@ -472,6 +472,16 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:458100", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(model="", serial="")]
+        r = _make_redis_with_search(icao_hex="458100", registration="EX-001")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call[0][1] == "$"
+        record = set_call[0][2]
+        assert "model" not in record["aircraft"]
+        assert "serial_number" not in record["aircraft"]
+
     def test_multiple_records(self):
         rows = [_make_row(registration="EX-001"), _make_row(registration="EX-002")]
         r = MagicMock()

--- a/data-runners/kr-koca/main.py
+++ b/data-runners/kr-koca/main.py
@@ -41,6 +41,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("kr-koca")
 
@@ -253,7 +254,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/kr-koca/tests/test_kr_koca.py
+++ b/data-runners/kr-koca/tests/test_kr_koca.py
@@ -241,6 +241,16 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:710ABC", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(air_type="", build_no="")]
+        r = _make_redis_with_search(icao_hex="710ABC", registration="HL9301")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call[0][1] == "$"
+        record = set_call[0][2]
+        assert "model" not in record["aircraft"]
+        assert "serial_number" not in record["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/ky-caa/main.py
+++ b/data-runners/ky-caa/main.py
@@ -47,6 +47,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     AIRCRAFT_REGISTRY_SEARCH_INDEX,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("ky-caa")
 
@@ -359,7 +360,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
                 continue
             record = _build_record(hex_val, registration, row)
             key = aircraft_registry_key(hex_val)
-            pipe.json().set(key, "$", record)
+            set_json(pipe, key, record)
             pipe.expire(key, ttl)
             written += 1
 

--- a/data-runners/ky-caa/tests/test_ky_caa.py
+++ b/data-runners/ky-caa/tests/test_ky_caa.py
@@ -574,6 +574,18 @@ class TestWriteToRedis:
         count = write_to_redis(rows, r, REDIS_TTL)
         assert count == 2
 
+    def test_null_fields_omitted_from_written_record(self):
+        """Optional fields with no source data are absent from the written record, not None."""
+        row = _make_row(series_type="", serial="")
+        r = _make_redis_with_search(icao_hex="C00001", registration="VP-CAD")
+        write_to_redis([row], r, REDIS_TTL)
+        pipe = r.pipeline.return_value
+        set_call = pipe.json.return_value.set.call_args
+        assert set_call[0][1] == "$"
+        written_record = set_call[0][2]
+        assert "model" not in written_record.get("aircraft", {})
+        assert "serial_number" not in written_record.get("aircraft", {})
+
     def test_searches_simple_index(self):
         """Registration lookup queries the Mictronics simple search index."""
         row = _make_row()

--- a/data-runners/lu-dac/main.py
+++ b/data-runners/lu-dac/main.py
@@ -45,6 +45,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("lu-dac")
 
@@ -364,7 +365,7 @@ def write_to_redis(records: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         parsed = reg_record_map[registration]
         record = _build_record(parsed, icao_hex)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/lu-dac/tests/test_lu_dac.py
+++ b/data-runners/lu-dac/tests/test_lu_dac.py
@@ -347,6 +347,17 @@ class TestWriteToRedis:
         write_to_redis(records, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4A0123", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        records = [_make_parsed(manufacturer="", model="")]
+        r = _make_redis_with_search(icao_hex="4A0123", registration="LX-ABC")
+        write_to_redis(records, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call is not None
+        assert set_call[0][1] == "$"
+        written = set_call[0][2]
+        assert "manufacturer" not in written["aircraft"]
+        assert "model" not in written["aircraft"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: publish_completion_stats

--- a/data-runners/lv-caa/main.py
+++ b/data-runners/lv-caa/main.py
@@ -36,6 +36,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("lv-caa")
 
@@ -224,7 +225,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/lv-caa/tests/test_lv_caa.py
+++ b/data-runners/lv-caa/tests/test_lv_caa.py
@@ -341,6 +341,16 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:502100", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(model="", category="")]
+        r = _make_redis_with_search(icao_hex="502100", registration="YL-AAA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        assert set_call[0][1] == "$"
+        record = set_call[0][2]
+        assert "model" not in record["aircraft"]
+        assert "type" not in record["aircraft"]
+
     def test_multiple_records(self):
         rows = [_make_row(registration="YL-AAA"), _make_row(registration="YL-BBB")]
         r = MagicMock()

--- a/data-runners/md-caa/main.py
+++ b/data-runners/md-caa/main.py
@@ -44,6 +44,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("md-caa")
 
@@ -221,7 +222,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/md-caa/tests/test_md_caa.py
+++ b/data-runners/md-caa/tests/test_md_caa.py
@@ -309,6 +309,14 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4B4100", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(model="")]
+        r = _make_redis_with_search(icao_hex="4B4100", registration="ER-AXA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "model" not in record.get("aircraft", {})
+
     def test_multiple_records(self):
         rows = [_make_row(registration="ER-AXA"), _make_row(registration="ER-BBB")]
         r = MagicMock()

--- a/data-runners/me-caa/main.py
+++ b/data-runners/me-caa/main.py
@@ -48,6 +48,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("me-caa")
 
@@ -401,7 +402,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/me-caa/tests/test_me_caa.py
+++ b/data-runners/me-caa/tests/test_me_caa.py
@@ -615,6 +615,15 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4C0100", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(manufacturer="", operator_address="")]
+        r = _make_redis_with_search(icao_hex="4C0100", registration="4O-AOA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "manufacturer" not in record.get("aircraft", {})
+        assert "street" not in record.get("registrant", {})
+
     def test_multiple_records(self):
         rows = [_make_row(registration="4O-AOA"), _make_row(registration="4O-ABC")]
         r = MagicMock()

--- a/data-runners/mictronics/main.py
+++ b/data-runners/mictronics/main.py
@@ -32,6 +32,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import AIRCRAFT_MICTRONICS_SEARCH_INDEX, aircraft_mictronics_key, operator_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("mictronics")
 
@@ -321,7 +322,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
         pipe = r.pipeline()
         for (key, new_record), existing_raw in zip(batch, existing_list):
             merged = _deep_merge(existing_raw[0], new_record) if existing_raw else new_record
-            pipe.json().set(key, "$", merged)
+            set_json(pipe, key, merged)
             pipe.expire(key, ttl)
         pipe.execute()
 
@@ -357,7 +358,7 @@ def write_operators_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: 
     for row in rows:
         record = build_operator_record(row)
         key = operator_key(record["airline_designator"])
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         if count % 10000 == 0:

--- a/data-runners/mictronics/tests/test_mictronics.py
+++ b/data-runners/mictronics/tests/test_mictronics.py
@@ -470,6 +470,24 @@ class TestWriteOperatorsToRedis:
         assert all(ttl == REDIS_TTL for ttl in expire_ttls)
         conn.close()
 
+    def test_null_fields_omitted_from_written_record(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(_mod._SCHEMA)
+        conn.execute(
+            "INSERT INTO operators (airline_designator, name, country, callsign) "
+            "VALUES ('XYZ', NULL, NULL, NULL)"
+        )
+        conn.commit()
+        r, _, pipe_json = self._mock_redis()
+        write_operators_to_redis(conn, r, REDIS_TTL)
+        records = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
+        record = records["operator:XYZ"]
+        assert "name" not in record
+        assert "country" not in record
+        assert "callsign" not in record
+        conn.close()
+
     def test_empty_designator_skipped(self):
         conn = sqlite3.connect(":memory:")
         conn.row_factory = sqlite3.Row

--- a/data-runners/mk-caa/main.py
+++ b/data-runners/mk-caa/main.py
@@ -41,6 +41,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("mk-caa")
 
@@ -259,7 +260,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/mk-caa/tests/test_mk_caa.py
+++ b/data-runners/mk-caa/tests/test_mk_caa.py
@@ -292,6 +292,15 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:4C4000", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(manufacturer="", owner_address="")]
+        r = _make_redis_with_search(icao_hex="4C4000", registration="Z3-AAA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "manufacturer" not in record.get("aircraft", {})
+        assert "street" not in record.get("registrant", {})
+
     def test_multiple_records(self):
         rows = [_make_row(reg="Z3-AAA"), _make_row(reg="Z3-AAB")]
         r = MagicMock()

--- a/data-runners/mv-caa/main.py
+++ b/data-runners/mv-caa/main.py
@@ -55,6 +55,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("mv-caa")
 
@@ -296,7 +297,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/mv-caa/tests/test_mv_caa.py
+++ b/data-runners/mv-caa/tests/test_mv_caa.py
@@ -507,6 +507,15 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:900100", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(model="", year_built="")]
+        r = _make_redis_with_search(icao_hex="900100", registration="8Q-IAD")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "model" not in record.get("aircraft", {})
+        assert "manufactured_date" not in record.get("aircraft", {})
+
     def test_multiple_records(self):
         rows = [_make_row(registration="8Q-IAD"), _make_row(registration="8Q-MBD")]
         r = MagicMock()

--- a/data-runners/nl-ilt/main.py
+++ b/data-runners/nl-ilt/main.py
@@ -39,6 +39,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("nl-ilt")
 
@@ -280,7 +281,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     def _flush() -> None:
         pipe = r.pipeline()
         for key, record in batch:
-            pipe.json().set(key, "$", record)
+            set_json(pipe, key, record)
             pipe.expire(key, ttl)
         pipe.execute()
 

--- a/data-runners/no-caa/main.py
+++ b/data-runners/no-caa/main.py
@@ -28,6 +28,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("no-caa")
 
@@ -243,7 +244,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     def _flush() -> None:
         pipe = r.pipeline()
         for key, record in batch:
-            pipe.json().set(key, "$", record)
+            set_json(pipe, key, record)
             pipe.expire(key, ttl)
         pipe.execute()
 

--- a/data-runners/nz-caa/main.py
+++ b/data-runners/nz-caa/main.py
@@ -31,6 +31,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("nz-caa")
 
@@ -225,7 +226,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
     def _flush() -> None:
         pipe = r.pipeline()
         for key, record in batch:
-            pipe.json().set(key, "$", record)
+            set_json(pipe, key, record)
             pipe.expire(key, ttl)
         pipe.execute()
 

--- a/data-runners/ourairports/main.py
+++ b/data-runners/ourairports/main.py
@@ -31,6 +31,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import AIRPORT_SEARCH_INDEX, airport_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("ourairports")
 
@@ -275,7 +276,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     for row in rows:
         record = build_airport_record(row)
         key = airport_key(record["icao_code"])
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         if count % 10000 == 0:

--- a/data-runners/ourairports/tests/test_ourairports.py
+++ b/data-runners/ourairports/tests/test_ourairports.py
@@ -404,6 +404,32 @@ class TestWriteToRedis:
         assert kjfk["phonic"] == "Kennedy"
         conn.close()
 
+    def test_null_fields_omitted_from_written_record(self):
+        # city is nullable in the staging schema (e.g. no municipality in source data).
+        # The record dict actually handed to the mocked RedisJSON `.set(...)` call must
+        # omit the "city" key entirely rather than carry it with a None value.
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(_mod._SCHEMA)
+        conn.execute(
+            "INSERT INTO airports (icao_code, name, city, region, country, phonic) "
+            "VALUES ('KTST', 'Test Airport', NULL, 'US-NY', 'US', 'Test')"
+        )
+        conn.commit()
+
+        r = MagicMock()
+        pipe = MagicMock()
+        pipe_json = MagicMock()
+        r.pipeline.return_value = pipe
+        pipe.json.return_value = pipe_json
+        pipe.execute.return_value = []
+
+        write_to_redis(conn, r, REDIS_TTL)
+
+        records = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
+        assert "city" not in records["airport:KTST"]
+        conn.close()
+
 
 # ---------------------------------------------------------------------------
 # Tests: MQTT completion stats — single JSON payload pattern

--- a/data-runners/pg-casapng/main.py
+++ b/data-runners/pg-casapng/main.py
@@ -44,6 +44,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("pg-casapng")
 
@@ -270,7 +271,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/pg-casapng/tests/test_pg_casapng.py
+++ b/data-runners/pg-casapng/tests/test_pg_casapng.py
@@ -301,6 +301,16 @@ class TestWriteToRedis:
         write_to_redis(rows, r, REDIS_TTL)
         r.pipeline.return_value.expire.assert_called_with("aircraft:registry:898A00", REDIS_TTL)
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(manufacturer="", address="")]
+        r = _make_redis_with_search(icao_hex="898A00", registration="P2-ANG")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "manufacturer" not in record.get("aircraft", {})
+        assert "street" not in record.get("registrant", {})
+        assert "country" not in record.get("registrant", {})
+
     def test_multiple_records(self):
         rows = [_make_row(reg="P2-ANG"), _make_row(reg="P2-ANH")]
         r = MagicMock()

--- a/data-runners/rs-cad/main.py
+++ b/data-runners/rs-cad/main.py
@@ -37,6 +37,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("rs-cad")
 
@@ -229,7 +230,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/rs-cad/tests/test_rs_cad.py
+++ b/data-runners/rs-cad/tests/test_rs_cad.py
@@ -287,6 +287,14 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call[0][2]["source"] == "rs-cad"
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(operator="")]
+        r = _make_redis_with_search(icao_hex="4C0A3E", registration="YU-HRD")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "registrant" not in record
+
     def test_empty_list_returns_zero(self):
         r = _make_redis_no_match()
         count = write_to_redis([], r, REDIS_TTL)

--- a/data-runners/sg-caas/main.py
+++ b/data-runners/sg-caas/main.py
@@ -43,6 +43,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("sg-caas")
 
@@ -275,7 +276,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
             continue
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/sg-caas/tests/test_sg_caas.py
+++ b/data-runners/sg-caas/tests/test_sg_caas.py
@@ -219,6 +219,14 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call[0][2]["source"] == "sg-caas"
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(engine_mfr="", engine_model="")]
+        r = _make_redis_with_search(icao_hex="76CE26", registration="9V-SKA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "powerplant" not in record.get("aircraft", {})
+
     def test_empty_list_returns_zero(self):
         r = _make_redis_no_match()
         count = write_to_redis([], r, REDIS_TTL)

--- a/data-runners/sk-nsat/main.py
+++ b/data-runners/sk-nsat/main.py
@@ -49,6 +49,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("sk-nsat")
 
@@ -273,7 +274,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/sk-nsat/tests/test_sk_nsat.py
+++ b/data-runners/sk-nsat/tests/test_sk_nsat.py
@@ -237,6 +237,14 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call[0][2]["source"] == "sk-nsat"
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(type_="")]
+        r = _make_redis_with_search(icao_hex="710ABC", registration="OM-0101")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "model" not in record.get("aircraft", {})
+
     def test_empty_list_returns_zero(self):
         r = _make_redis_no_match()
         count = write_to_redis([], r, REDIS_TTL)

--- a/data-runners/tc-caa/main.py
+++ b/data-runners/tc-caa/main.py
@@ -40,6 +40,7 @@ from shared.redis_keys import (
     AIRCRAFT_MICTRONICS_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("tc-caa")
 
@@ -226,7 +227,7 @@ def write_to_redis(rows: list[dict], r: redis_lib.Redis, ttl: int) -> int:
         row = reg_row_map[registration]
         record = _build_record(row, icao_hex, registration)
         key = aircraft_registry_key(icao_hex)
-        pipe.json().set(key, "$", record)
+        set_json(pipe, key, record)
         pipe.expire(key, ttl)
         count += 1
         pipe_count += 1

--- a/data-runners/tc-caa/tests/test_tc_caa.py
+++ b/data-runners/tc-caa/tests/test_tc_caa.py
@@ -191,6 +191,14 @@ class TestWriteToRedis:
         set_call = r.pipeline.return_value.json.return_value.set.call_args
         assert set_call[0][2]["source"] == "tc-caa"
 
+    def test_null_fields_omitted_from_written_record(self):
+        rows = [_make_row(owner="")]
+        r = _make_redis_with_search(icao_hex="0C1234", registration="VQ-TCA")
+        write_to_redis(rows, r, REDIS_TTL)
+        set_call = r.pipeline.return_value.json.return_value.set.call_args
+        record = set_call[0][2]
+        assert "registrant" not in record
+
     def test_empty_list_returns_zero(self):
         r = _make_redis_no_match()
         count = write_to_redis([], r, REDIS_TTL)

--- a/data-runners/uk-caa/main.py
+++ b/data-runners/uk-caa/main.py
@@ -34,6 +34,7 @@ from shared.redis_keys import (
     AIRCRAFT_REGISTRY_SEARCH_INDEX,
     aircraft_registry_key,
 )
+from shared.redis_json import set_json
 
 logger = logging.getLogger("uk-caa")
 
@@ -358,7 +359,7 @@ def run_pipeline(
 
             record["source"] = "uk-caa"
             key = aircraft_registry_key(record["icao_hex"])
-            r.json().set(key, "$", record)
+            set_json(r, key, record)
             r.expire(key, ttl)
             count += 1
 
@@ -409,7 +410,7 @@ def run_pipeline(
 
                 record["source"] = "uk-caa"
                 key = aircraft_registry_key(record["icao_hex"])
-                r.json().set(key, "$", record)
+                set_json(r, key, record)
                 r.expire(key, ttl)
                 count += 1
 
@@ -437,7 +438,7 @@ def run_pipeline(
 
             record["source"] = "uk-caa"
             key = aircraft_registry_key(record["icao_hex"])
-            r.json().set(key, "$", record)
+            set_json(r, key, record)
             r.expire(key, ttl)
             count += 1
 

--- a/data-runners/uk-caa/tests/test_uk_caa.py
+++ b/data-runners/uk-caa/tests/test_uk_caa.py
@@ -510,6 +510,14 @@ class TestRunPipeline:
         written = r.json.return_value.set.call_args.args[2]
         assert written["source"] == "uk-caa"
 
+    def test_null_fields_omitted_from_written_record(self):
+        r = self._make_redis()
+        session = self._make_session(_SEARCH_RESULT, _make_details(county=None))
+        with patch("time.sleep"):
+            run_pipeline(session, r, REDIS_TTL, 0.1)
+        written = r.json.return_value.set.call_args.args[2]
+        assert "administrative_area" not in written.get("registrant", {})
+
     def test_no_foreign_key_in_record(self):
         r = self._make_redis()
         session = self._make_session(_SEARCH_RESULT, _make_details())

--- a/data-runners/us-faa/main.py
+++ b/data-runners/us-faa/main.py
@@ -33,6 +33,7 @@ from redis.commands.search.field import TagField
 from redis.commands.search.index_definition import IndexDefinition, IndexType
 
 from shared.redis_keys import AIRCRAFT_REGISTRY_SEARCH_INDEX, aircraft_registry_key
+from shared.redis_json import set_json
 
 logger = logging.getLogger("us-faa")
 
@@ -478,7 +479,7 @@ def write_to_redis(conn: sqlite3.Connection, r: redis_lib.Redis, ttl: int) -> in
     def _flush():
         pipe = r.pipeline()
         for key, record in batch:
-            pipe.json().set(key, "$", record)
+            set_json(pipe, key, record)
             pipe.expire(key, ttl)
         pipe.execute()
 

--- a/data-runners/us-faa/tests/test_us_faa.py
+++ b/data-runners/us-faa/tests/test_us_faa.py
@@ -627,6 +627,17 @@ class TestWriteToRedis:
         r.json().mget.assert_not_called()
         conn.close()
 
+    def test_null_fields_omitted_from_written_record(self):
+        """No matching aircraft ref (AB1234) yields aircraft=None from build_aircraft_record;
+        set_json must prune that key entirely from what actually reaches Redis."""
+        conn = self._make_db()
+        r, _, pipe_json = self._mock_redis()
+        write_to_redis(conn, r, REDIS_TTL)
+        calls = {c.args[0]: c.args[2] for c in pipe_json.set.call_args_list}
+        record = calls["aircraft:registry:AB1234"]
+        assert "aircraft" not in record
+        conn.close()
+
     def test_source_field_set_on_all_records(self):
         """Every record written to Redis must carry source='us-faa'."""
         conn = self._make_db()

--- a/shared/redis_json.py
+++ b/shared/redis_json.py
@@ -1,0 +1,34 @@
+"""
+Shared write path for RedisJSON documents.
+
+All data runners build an enrichment record as a plain dict, often leaving
+`None` in place for fields with no data (e.g. `row["model"] or None`). Writing
+that dict straight to Redis stores literal JSON `null` for those fields,
+which forces every consumer to distinguish "null" from "missing" (issue #289).
+
+`set_json()` is the single choke point every runner writes enrichment records
+through, so the "no null values in Redis" invariant is enforced once here
+rather than needing to be re-implemented in each runner's record-building
+logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def prune_none(value: Any) -> Any:
+    """Recursively drop dict keys whose value is None. Lists are walked
+    element-wise (so dicts nested inside lists are pruned too); their own
+    entries are otherwise left as-is, including empty lists."""
+    if isinstance(value, dict):
+        return {k: prune_none(v) for k, v in value.items() if v is not None}
+    if isinstance(value, list):
+        return [prune_none(v) for v in value]
+    return value
+
+
+def set_json(client: Any, key: str, obj: Any, path: str = "$") -> None:
+    """Write `obj` to Redis as a JSON document at `key`/`path`, omitting any
+    field whose value is None. `client` may be a redis client or a pipeline."""
+    client.json().set(key, path, prune_none(obj))

--- a/shared/tests/test_redis_json.py
+++ b/shared/tests/test_redis_json.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+from shared.redis_json import prune_none, set_json
+
+
+class TestPruneNone:
+    def test_drops_top_level_none(self):
+        assert prune_none({"a": 1, "b": None}) == {"a": 1}
+
+    def test_drops_nested_none(self):
+        assert prune_none({"a": {"b": 1, "c": None}}) == {"a": {"b": 1}}
+
+    def test_drops_dict_that_is_entirely_none_valued(self):
+        assert prune_none({"a": {"b": None, "c": None}}) == {"a": {}}
+
+    def test_top_level_none_field_removed_not_kept_as_null(self):
+        assert prune_none({"a": 1, "aircraft": None}) == {"a": 1}
+        assert "aircraft" not in prune_none({"a": 1, "aircraft": None})
+
+    def test_preserves_falsy_but_non_none_values(self):
+        record = {"count": 0, "enabled": False, "name": "", "items": []}
+        assert prune_none(record) == record
+
+    def test_walks_dicts_nested_in_lists(self):
+        record = {"items": [{"a": 1, "b": None}, {"c": None}]}
+        assert prune_none(record) == {"items": [{"a": 1}, {}]}
+
+    def test_leaves_scalars_and_none_itself_unchanged(self):
+        assert prune_none(5) == 5
+        assert prune_none("x") == "x"
+        assert prune_none(None) is None
+
+    def test_does_not_mutate_input(self):
+        record = {"a": 1, "b": None}
+        prune_none(record)
+        assert record == {"a": 1, "b": None}
+
+
+class TestSetJson:
+    def test_writes_pruned_object_to_json_set(self):
+        client = MagicMock()
+        set_json(client, "aircraft:registry:A8AE7F", {"a": 1, "b": None})
+        client.json.return_value.set.assert_called_once_with(
+            "aircraft:registry:A8AE7F", "$", {"a": 1}
+        )
+
+    def test_default_path_is_root(self):
+        client = MagicMock()
+        set_json(client, "key", {"a": 1})
+        args = client.json.return_value.set.call_args
+        assert args.args[1] == "$"
+
+    def test_custom_path_is_passed_through(self):
+        client = MagicMock()
+        set_json(client, "key", {"a": 1}, path="$.aircraft")
+        args = client.json.return_value.set.call_args
+        assert args.args[1] == "$.aircraft"
+
+    def test_works_with_a_pipeline_object(self):
+        pipe = MagicMock()
+        set_json(pipe, "key", {"a": 1, "b": None})
+        pipe.json.return_value.set.assert_called_once_with("key", "$", {"a": 1})


### PR DESCRIPTION
## Summary
- Runners were writing literal JSON `null` for optional fields with no data (e.g. FAA `powerplant.model`/`manufacturer`, TC `aircraft.seats`), forcing consumers to distinguish null from missing.
- Adds `shared/redis_json.py::set_json()`, a single write-path helper that recursively strips `None`-valued dict keys before every `JSON.SET` call.
- Routes all 40 data runners through `set_json()` instead of calling `pipe.json().set(...)` / `r.json().set(...)` directly, so the "no nulls" invariant is enforced once at the write boundary rather than needing a per-runner fix.

## Test plan
- [x] `shared/tests/test_redis_json.py` — unit tests for `prune_none()`/`set_json()` (12 tests)
- [x] One new `test_null_fields_omitted_from_written_record`-style regression test added to each of the 34 runners that already have a test suite, asserting the omitted key is absent from what's actually passed to the mocked `.set(...)` call (not `is None`)
- [x] Ran each runner's full test suite individually — all pass except 2 pre-existing unrelated failures in `at-austrocontrol` (glider-type wording) and 4 pre-existing unrelated failures in `ourairports` (stale test expectations for a `pipe.set`/`json.dumps` write path the code no longer uses) — both confirmed present on `main` before this change
- [x] 6 runners (`au-casa`, `bs-caa`, `fr-dgac`, `nl-ilt`, `no-caa`, `nz-caa`) have no test directory at all (pre-existing gap); `main.py` was still updated to use `set_json()` for them

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)