### PR TITLE
Preserve UTF-8 characters when writing Redis JSON records

### DIFF
--- a/shared/redis_json.py
+++ b/shared/redis_json.py
@@ -6,15 +6,23 @@ All data runners build an enrichment record as a plain dict, often leaving
 that dict straight to Redis stores literal JSON `null` for those fields,
 which forces every consumer to distinguish "null" from "missing" (issue #289).
 
+redis-py's JSON client also serializes with `json.dumps(..., ensure_ascii=True)`
+by default, which escapes every non-ASCII character (e.g. accented Latin,
+Cyrillic, Georgian script) as a `\\uXXXX` sequence. That's valid JSON but
+unreadable in Redis Insight and other tooling (issue #291).
+
 `set_json()` is the single choke point every runner writes enrichment records
-through, so the "no null values in Redis" invariant is enforced once here
-rather than needing to be re-implemented in each runner's record-building
-logic.
+through, so both invariants — no null values, UTF-8 stored as-is — are
+enforced once here rather than needing to be re-implemented in each runner's
+record-building logic.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
+
+_ENCODER = json.JSONEncoder(ensure_ascii=False)
 
 
 def prune_none(value: Any) -> Any:
@@ -30,5 +38,6 @@ def prune_none(value: Any) -> Any:
 
 def set_json(client: Any, key: str, obj: Any, path: str = "$") -> None:
     """Write `obj` to Redis as a JSON document at `key`/`path`, omitting any
-    field whose value is None. `client` may be a redis client or a pipeline."""
-    client.json().set(key, path, prune_none(obj))
+    field whose value is None and preserving non-ASCII characters as-is.
+    `client` may be a redis client or a pipeline."""
+    client.json(encoder=_ENCODER).set(key, path, prune_none(obj))

--- a/shared/tests/test_redis_json.py
+++ b/shared/tests/test_redis_json.py
@@ -1,4 +1,7 @@
+import json
 from unittest.mock import MagicMock
+
+from redis.commands.json import JSON
 
 from shared.redis_json import prune_none, set_json
 
@@ -60,3 +63,37 @@ class TestSetJson:
         pipe = MagicMock()
         set_json(pipe, "key", {"a": 1, "b": None})
         pipe.json.return_value.set.assert_called_once_with("key", "$", {"a": 1})
+
+    def test_uses_an_ascii_preserving_encoder(self):
+        client = MagicMock()
+        set_json(client, "key", {"a": 1})
+        _, kwargs = client.json.call_args
+        assert kwargs["encoder"].ensure_ascii is False
+
+
+class TestSetJsonUtf8OnTheWire:
+    """Exercises the real redis-py JSON client's encoder to prove non-ASCII
+    characters reach the wire as-is, not as \\uXXXX escapes (issue #291)."""
+
+    def _json_client(self):
+        conn = MagicMock()
+        return conn, JSON(client=conn, encoder=json.JSONEncoder(ensure_ascii=False))
+
+    def test_accented_latin_characters_are_not_escaped(self):
+        conn, json_ns = self._json_client()
+        client = MagicMock()
+        client.json.return_value = json_ns
+        set_json(client, "aircraft:registry:C038AA", {"street": ["7373 de la Côte-Vertu Blvd."]})
+        encoded = conn.execute_command.call_args.args[3]
+        assert "Côte-Vertu" in encoded
+        assert "\\u00" not in encoded
+
+    def test_cyrillic_and_georgian_scripts_are_not_escaped(self):
+        conn, json_ns = self._json_client()
+        client = MagicMock()
+        client.json.return_value = json_ns
+        set_json(client, "operator:XYZ", {"name": "Авиакомпания", "owner": "ავიაკომპანია"})
+        encoded = conn.execute_command.call_args.args[3]
+        assert "Авиакомпания" in encoded
+        assert "ავიაკომპანია" in encoded
+        assert "\\u" not in encoded

--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -12,6 +12,10 @@
 #
 # persist_as — overrides the persisted shape for object fields that collapse
 # to a scalar on write (e.g. origin/destination objects → ICAO code string).
+#
+# Encoding: all string values stored in Redis are UTF-8 encoded as-is (no
+# \uXXXX escaping of non-ASCII characters). Every runner writes JSON via
+# shared.redis_json.set_json(), which serializes with ensure_ascii=False.
 
 version: "1.0"
 description: >


### PR DESCRIPTION
## Summary
- redis-py's JSON client serializes with `json.dumps(ensure_ascii=True)` by default, escaping every non-ASCII character (accented Latin, Cyrillic, Georgian script, etc.) as `\uXXXX` — valid JSON, but unreadable in Redis Insight and other tooling.
- `shared/redis_json.py::set_json()` — the single write path every runner already goes through, added in #289 — now passes `encoder=json.JSONEncoder(ensure_ascii=False)` to `client.json(...)`, fixing every runner at once with no per-runner changes.
- Documents the UTF-8 storage guarantee in `specs/data-dictionary.yaml`.

**Stacked on #289**: this branch is based on `issue-289-runners-omit-null-fields` since it depends on the `set_json()` helper introduced there. Base is set to that branch for now — please switch the base to `main` (or I'll rebase) once #289 merges.

## Test plan
- [x] `shared/tests/test_redis_json.py` — asserts `set_json()` passes an `ensure_ascii=False` encoder, plus two tests that exercise the real `redis.commands.json.JSON` client encoder end-to-end with accented Latin, Cyrillic, and Georgian script to confirm no `\uXXXX` escapes reach the wire
- [x] Ran every runner's test suite — no regressions (same pre-existing unrelated failures as on `main`: 2 in `at-austrocontrol`, 4 in `ourairports`)

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)