### PR TITLE
Use 9999.99.99 placeholder for data-dictionary.yaml version

### DIFF
--- a/specs/data-dictionary.yaml
+++ b/specs/data-dictionary.yaml
@@ -17,7 +17,7 @@
 # \uXXXX escaping of non-ASCII characters). Every runner writes JSON via
 # shared.redis_json.set_json(), which serializes with ensure_ascii=False.
 
-version: "1.0"
+version: "9999.99.99"
 description: >
   Field-level data dictionary for SkyFollower record types. Defines sources,
   column positions, transforms, merge priority, and persistence rules for each


### PR DESCRIPTION
## Summary
- `specs/data-dictionary.yaml` hand-pinned `version: "1.0"`, which would drift over time.
- Switches it to the `9999.99.99` placeholder, matching the convention `specs/asyncapi.yaml` already follows on `main`.
- The actual build-time substitution mechanism is tracked separately in #306 (shared across all spec files); this PR is just the placeholder value.

## Test plan
- [x] YAML still parses (`yaml.safe_load`)
- [x] Confirmed no other code reads/depends on this field's value (only doc-comment references to the file itself, unrelated to `version:`)

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)