### PR TITLE
Add GitHub Actions release workflow

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,106 @@
+name: Build Images
+run-name: "Build images ${{ github.ref_name }}"
+
+# Two ways in:
+#   1. workflow_dispatch, --ref <tag> — how release.yaml triggers this. A tag
+#      pushed with GITHUB_TOKEN does not itself fire the `push: tags:` trigger
+#      below (GitHub suppresses that to avoid workflow recursion), so
+#      release.yaml calls `gh workflow run build-images.yaml --ref <version>`
+#      explicitly once the tag exists.
+#   2. push: tags — fallback for a tag pushed some other way (e.g. a human
+#      pushing with their own credentials).
+on:
+  push:
+    tags:
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  validate-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag format
+        run: |
+          if [[ ! "${{ github.ref_name }}" =~ ^[0-9]{4}\.(0[1-9]|1[0-2])\.(0[1-9]|[1-9][0-9])$ ]]; then
+            echo "❌ Invalid version format: ${{ github.ref_name }}. Expected YYYY.MM.BB"
+            exit 1
+          fi
+          echo "✅ Version format is valid: ${{ github.ref_name }}"
+
+  discover-images:
+    needs: validate-version
+    # Every component with a Dockerfile is built and published — the matrix
+    # below is generated from the repo tree, not hardcoded, so adding a new
+    # data runner (or, eventually, ui/) never requires a workflow change.
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Discover images to build
+        id: discover
+        run: |
+          set -euo pipefail
+          matrix="[]"
+          while IFS= read -r -d '' dockerfile; do
+            dockerfile="${dockerfile#./}"
+            dir="$(dirname "$dockerfile")"
+            case "$dir" in
+              receiver) name="receiver" ;;
+              processor) name="processor" ;;
+              archive-processor) name="archive" ;;
+              ui) name="ui" ;;
+              data-runners/*) name="runner-$(basename "$dir")" ;;
+              *) echo "Skipping unrecognized Dockerfile: $dockerfile" >&2; continue ;;
+            esac
+            image="ghcr.io/brentio/skyfollower-${name}"
+            matrix=$(jq -c --arg name "$name" --arg dockerfile "$dockerfile" --arg image "$image" \
+              '. + [{"name": $name, "dockerfile": $dockerfile, "image": $image}]' <<<"$matrix")
+          done < <(find . -mindepth 2 -maxdepth 3 -name Dockerfile -print0 | sort -z)
+
+          echo "Discovered $(jq 'length' <<<"$matrix") image(s):" >&2
+          jq -c '.[] | .name' <<<"$matrix" >&2
+
+          echo "matrix=$(jq -c -n --argjson entries "$matrix" '{include: $entries}')" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: discover-images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-images.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      # TODO(#306): substitute the 9999.99.99 placeholder in
+      # specs/data-dictionary.yaml and specs/asyncapi.yaml with
+      # ${{ github.ref_name }} before building any image that bundles them.
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.name }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: |
+            ${{ matrix.image }}:${{ github.ref_name }}
+            ${{ matrix.image }}:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Release
+run-name: Release ${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (YYYY.MM.BB)'
+        required: true
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Validate version format
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]{4}\.(0[1-9]|1[0-2])\.(0[1-9]|[1-9][0-9])$ ]]; then
+            echo "❌ Invalid version format: ${{ inputs.version }}. Expected YYYY.MM.BB"
+            exit 1
+          fi
+          echo "✅ Version format is valid: ${{ inputs.version }}"
+
+      - name: Tag and push
+        run: |
+          git tag ${{ inputs.version }}
+          git push origin ${{ inputs.version }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.version }}
+          generate_release_notes: true
+
+      - name: Build and publish images
+        run: gh workflow run build-images.yaml --ref ${{ inputs.version }}
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yaml` (entry point) and `.github/workflows/build-images.yaml` (build/publish), mirroring the two-stage release pattern from `BrentIO/FireFly-Controller`.
- `release.yaml`: `workflow_dispatch` with a `version` input, validated against `^[0-9]{4}\.(0[1-9]|1[0-2])\.(0[1-9]|[1-9][0-9])$` *before* tagging anything (blocks bad version numbers at the source, not after the fact), then tags, pushes, creates a GitHub Release, and triggers `build-images.yaml` explicitly (a `GITHUB_TOKEN` tag push doesn't fire another workflow's `push:` trigger — GitHub suppresses that to avoid recursive runs).
- `build-images.yaml`: re-validates the tag (defense-in-depth, since this job is what actually runs on a raw tag push), then a `discover-images` job globs the repo for every `Dockerfile` and emits a JSON matrix — currently 43 images (receiver, processor, archive-processor, 40 data-runners). Dynamic, not hardcoded, so adding a new data runner or `ui/` (once it exists) needs zero workflow changes. The `build` job then builds + pushes each for `linux/arm64,linux/amd64`, tagged `<image>:<version>` and `<image>:latest`.
- Left a `TODO(#306)` in `build-images.yaml`'s `build` job for the spec-version-placeholder substitution — that's a separate tracked issue, not part of this PR.

## Test plan
- [x] Both workflow files parse as valid YAML
- [x] Verified the version regex against valid/invalid inputs locally (`2026.07.01` ✅, `2026.13.01`/`2026.00.01`/`2026.07.00`/`9999.99.99`/`26.07.01` all correctly rejected)
- [x] Ran the `discover-images` matrix-generation logic locally against the current repo tree — correctly finds 43 Dockerfiles and names them (e.g. `data-runners/bg-caa/Dockerfile` → `skyfollower-runner-bg-caa`, `archive-processor/Dockerfile` → `skyfollower-archive`)
- [x] Confirmed build `context` must be repo root (`.`) for every existing Dockerfile, since they all `COPY shared/...` and `COPY data-runners/<name>/...` relative to repo root
- [ ] Not yet run for real (no GHCR push, no actual release cut) — first real run will be the first live release

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)