### PR TITLE
Stamp spec version placeholders at release time

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -77,9 +77,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # TODO(#306): substitute the 9999.99.99 placeholder in
-      # specs/data-dictionary.yaml and specs/asyncapi.yaml with
-      # ${{ github.ref_name }} before building any image that bundles them.
+      # No image currently bundles specs/*.yaml, so there's nothing to stamp
+      # here. release.yaml stamps version-substituted copies once and
+      # attaches them to the GitHub Release directly (see #306) instead of
+      # repeating that work in every one of this job's matrix entries.
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,11 +33,30 @@ jobs:
           git tag ${{ inputs.version }}
           git push origin ${{ inputs.version }}
 
+      - name: Stamp spec versions
+        # specs/*.yaml carry a checked-in 9999.99.99 placeholder (see #305)
+        # so main never has a stale or manually-bumped version string. This
+        # never edits the checked-out files in place or commits anything —
+        # it writes stamped copies to dist/specs/ that are only attached to
+        # the GitHub Release below. Any spec file with the placeholder is
+        # picked up automatically; no workflow change needed to add one.
+        run: |
+          set -euo pipefail
+          mkdir -p dist/specs
+          for spec in specs/*.yaml; do
+            if grep -q '9999\.99\.99' "$spec"; then
+              out="dist/specs/$(basename "$spec")"
+              sed 's/9999\.99\.99/${{ inputs.version }}/g' "$spec" > "$out"
+              echo "Stamped $spec -> $out"
+            fi
+          done
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.version }}
           generate_release_notes: true
+          files: dist/specs/*
 
       - name: Build and publish images
         run: gh workflow run build-images.yaml --ref ${{ inputs.version }}

--- a/shared/tests/test_spec_version_placeholders.py
+++ b/shared/tests/test_spec_version_placeholders.py
@@ -1,0 +1,39 @@
+"""
+Guards the convention from issue #305/#306: every spec file's version field
+is a checked-in 9999.99.99 placeholder on main, substituted with the real
+release version only in build/release output (see .github/workflows/release.yaml),
+never committed back to main.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+_SPECS_DIR = Path(__file__).resolve().parents[2] / "specs"
+
+_PLACEHOLDER = "9999.99.99"
+
+
+class TestSpecVersionPlaceholders:
+    def test_data_dictionary_version_is_placeholder(self):
+        data = yaml.safe_load((_SPECS_DIR / "data-dictionary.yaml").read_text())
+        assert data["version"] == _PLACEHOLDER
+
+    def test_asyncapi_version_is_placeholder(self):
+        data = yaml.safe_load((_SPECS_DIR / "asyncapi.yaml").read_text())
+        assert data["info"]["version"] == _PLACEHOLDER
+
+    def test_no_spec_file_has_a_real_version_checked_in(self):
+        """Catches any spec file (including future ones, e.g. openapi.yaml)
+        that carries a version-shaped string other than the placeholder."""
+        version_line = re.compile(r'^\s*version:\s*[\'"]?([0-9]{4}\.[0-9]{2}\.[0-9]{2})[\'"]?\s*$')
+        offenders = []
+        for spec in _SPECS_DIR.glob("*.yaml"):
+            for line in spec.read_text().splitlines():
+                match = version_line.match(line)
+                if match and match.group(1) != _PLACEHOLDER:
+                    offenders.append(f"{spec.name}: {line.strip()}")
+        assert offenders == []


### PR DESCRIPTION
## Summary
- `release.yaml` now stamps every `specs/*.yaml` file that carries the `9999.99.99` placeholder (currently `data-dictionary.yaml` and `asyncapi.yaml`) with the real release version, and attaches the stamped copies to the GitHub Release as downloadable assets.
- The mechanism is generic (`grep`s for the placeholder, not hardcoded filenames), so `openapi.yaml` will be picked up automatically once it exists — no workflow change needed.
- Nothing is ever edited in place or committed back to `main`: the stamped copies are written to `dist/specs/`, a build-only directory, and only referenced by the release-asset upload step.
- Did this once in `release.yaml` rather than per-image in `build-images.yaml`'s matrix — confirmed no Docker image currently bundles `specs/*.yaml`, so repeating it 43 times there would be pure waste. Replaced the `TODO(#306)` left in `build-images.yaml` with a note explaining why.
- Added `shared/tests/test_spec_version_placeholders.py` as the acceptance criterion's "never accidentally committed" guard — asserts every `specs/*.yaml` version field on `main` is still the placeholder (and generically catches any other real-version-shaped string, not just the two known files).

## Test plan
- [x] `shared/tests/test_spec_version_placeholders.py` — 3 new tests, all passing
- [x] Full `shared/` suite — 63 passed
- [x] Both workflow YAML files still parse
- [x] Ran the stamping shell logic locally against a fake `2026.07.01` version — confirmed stamped copies get the real version and the original checked-out files are untouched

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)