### PR TITLE
Add emoji prefixes to release workflow names

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,4 +1,4 @@
-name: Build Images
+name: 🛠️ Build Images
 run-name: "Build images ${{ github.ref_name }}"
 
 # Two ways in:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: 🚀 Release
 run-name: Release ${{ inputs.version }}
 
 on:


### PR DESCRIPTION
## Summary
- `release.yaml`'s `name:` → `🚀 Release`
- `build-images.yaml`'s `name:` → `🛠️ Build Images`
- Matches `BrentIO/FireFly-Controller`'s convention for its equivalent workflows. No functional change.

## Test plan
- [x] Both workflow files still parse as valid YAML with the new names

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)