### PR TITLE
Fix traffic-recorder crash on clean shutdown

### DIFF
--- a/tools/traffic-recorder/main.py
+++ b/tools/traffic-recorder/main.py
@@ -122,7 +122,10 @@ class SourceCapture(threading.Thread):
         self.source_tag = source_tag
         self._output_lock = output_lock
         self._output_file = output_file
-        self._stop = stop_event
+        # Not named `self._stop` — threading.Thread already defines a private
+        # `_stop()` method it calls internally during join(); overwriting it
+        # with our Event caused `TypeError: 'Event' object is not callable`.
+        self._stop_event = stop_event
         self.count = 0
         self.error: Exception | None = None
         self.connected_event = threading.Event()
@@ -131,13 +134,13 @@ class SourceCapture(threading.Thread):
         try:
             self._connect_and_capture()
         except Exception as exc:
-            if not self._stop.is_set():
+            if not self._stop_event.is_set():
                 self.error = exc
                 print(
                     f"Error on {self.host}:{self.port} (source={self.source_tag}): {exc}",
                     flush=True,
                 )
-                self._stop.set()
+                self._stop_event.set()
         finally:
             self.connected_event.set()
 
@@ -153,7 +156,7 @@ class SourceCapture(threading.Thread):
 
     def _capture_1090(self, sock: socket.socket) -> None:
         buf = bytearray()
-        while not self._stop.is_set():
+        while not self._stop_event.is_set():
             try:
                 data = sock.recv(4096)
             except socket.timeout:
@@ -172,7 +175,7 @@ class SourceCapture(threading.Thread):
 
     def _capture_978(self, sock: socket.socket) -> None:
         line_buf = b""
-        while not self._stop.is_set():
+        while not self._stop_event.is_set():
             try:
                 data = sock.recv(4096)
             except socket.timeout:

--- a/tools/traffic-recorder/tests/test_source_capture.py
+++ b/tools/traffic-recorder/tests/test_source_capture.py
@@ -1,0 +1,102 @@
+"""
+Regression test for issue #312: SourceCapture used to assign its stop
+Event to `self._stop`, which shadows threading.Thread's own private
+`_stop()` method. Thread.join() calls that method internally once the
+thread has finished, so joining a completed SourceCapture always raised
+`TypeError: 'Event' object is not callable`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import socket
+import sys
+import threading
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_TOOL_DIR = os.path.dirname(_HERE)
+
+
+def _load_main():
+    spec = importlib.util.spec_from_file_location(
+        "traffic_recorder_main",
+        os.path.join(_TOOL_DIR, "main.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["traffic_recorder_main"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_main()
+SourceCapture = _mod.SourceCapture
+
+
+class TestSourceCaptureJoin:
+    def test_join_after_natural_exit_does_not_raise(self):
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        host, port = server.getsockname()
+
+        def _accept_then_close():
+            conn, _ = server.accept()
+            conn.close()
+
+        acceptor = threading.Thread(target=_accept_then_close, daemon=True)
+        acceptor.start()
+
+        stop_event = threading.Event()
+        capture = SourceCapture(
+            host=host,
+            port=port,
+            source_tag="1090",
+            output_lock=threading.Lock(),
+            output_file=io.StringIO(),
+            stop_event=stop_event,
+        )
+        capture.start()
+
+        # Server closes the connection immediately -> recv() returns b"" ->
+        # _capture_1090 breaks out -> run() finishes naturally, same as the
+        # "Duration reached" shutdown path in the bug report.
+        capture.join(timeout=5)
+        acceptor.join(timeout=5)
+
+        assert not capture.is_alive()
+        assert capture.error is None
+
+    def test_join_after_stop_event_set_does_not_raise(self):
+        """Covers the actual reported scenario: main() sets stop_event, then
+        joins every thread."""
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        host, port = server.getsockname()
+
+        def _accept_and_hold():
+            conn, _ = server.accept()
+            stop_event.wait(5)
+            conn.close()
+
+        stop_event = threading.Event()
+        acceptor = threading.Thread(target=_accept_and_hold, daemon=True)
+        acceptor.start()
+
+        capture = SourceCapture(
+            host=host,
+            port=port,
+            source_tag="1090",
+            output_lock=threading.Lock(),
+            output_file=io.StringIO(),
+            stop_event=stop_event,
+        )
+        capture.start()
+
+        stop_event.set()
+        capture.join(timeout=5)
+        acceptor.join(timeout=5)
+
+        assert not capture.is_alive()


### PR DESCRIPTION
## Summary
- `SourceCapture` (a `threading.Thread` subclass) stored its stop `Event` as `self._stop`, which shadows `threading.Thread`'s own private `_stop()` method — `Thread.join()` calls that internally once a thread has actually finished. So joining any `SourceCapture` after a clean exit (duration reached, or `stop_event` set) always raised `TypeError: 'Event' object is not callable` instead of exiting cleanly — exactly the traceback in the bug report.
- Fix: renamed the attribute to `self._stop_event` throughout the class.

## Test plan
- [x] Added `tools/traffic-recorder/tests/test_source_capture.py` — two regression tests exercising both real shutdown paths (thread exits naturally on connection close; `stop_event` set externally, matching `main()`'s shutdown sequence)
- [x] Confirmed against Python 3.12 (the version in the bug report, via `docker run python:3.12-slim` — `Thread._stop()`/`_wait_for_tstate_lock` still exist there) that these tests **fail with the exact reported traceback** on the old code and **pass** with the fix
- [x] Python 3.13+ removed that private method entirely during a threading-module refactor, so this couldn't be reproduced on this machine's local Python (3.14) without pinning to 3.12 — noting this in case CI runs on a newer Python where the underlying collision wouldn't manifest even without the fix
- [x] Ran full test file on both Python 3.14 (local `.venv`) and Python 3.12 (Docker) — passes on both post-fix

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)