### PR TITLE
Upgrade all container base images to python:3.14-slim

### DIFF
--- a/archive-processor/Dockerfile
+++ b/archive-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS base
+FROM python:3.14-slim AS base
 
 WORKDIR /app
 

--- a/data-runners/at-austrocontrol/Dockerfile
+++ b/data-runners/at-austrocontrol/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/au-casa/Dockerfile
+++ b/data-runners/au-casa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/bg-caa/Dockerfile
+++ b/data-runners/bg-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/bg-caa/requirements.txt .

--- a/data-runners/br-anac/Dockerfile
+++ b/data-runners/br-anac/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/bs-caa/Dockerfile
+++ b/data-runners/bs-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/bz-bdca/Dockerfile
+++ b/data-runners/bz-bdca/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/bz-bdca/requirements.txt .

--- a/data-runners/ca-transport-canada/Dockerfile
+++ b/data-runners/ca-transport-canada/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/ch-bazl/Dockerfile
+++ b/data-runners/ch-bazl/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/cy-dca/Dockerfile
+++ b/data-runners/cy-dca/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/cy-dca/requirements.txt .

--- a/data-runners/cz-caa/Dockerfile
+++ b/data-runners/cz-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/cz-caa/requirements.txt .

--- a/data-runners/ee-transpordiamet/Dockerfile
+++ b/data-runners/ee-transpordiamet/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/ee-transpordiamet/requirements.txt .

--- a/data-runners/es-aesa/Dockerfile
+++ b/data-runners/es-aesa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/es-aesa/requirements.txt .

--- a/data-runners/fr-dgac/Dockerfile
+++ b/data-runners/fr-dgac/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/ge-gcaa/Dockerfile
+++ b/data-runners/ge-gcaa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/ge-gcaa/requirements.txt .

--- a/data-runners/gg-2reg/Dockerfile
+++ b/data-runners/gg-2reg/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/gg-2reg/requirements.txt .

--- a/data-runners/hr-ccaa/Dockerfile
+++ b/data-runners/hr-ccaa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/hr-ccaa/requirements.txt .

--- a/data-runners/hu-kozhaf/Dockerfile
+++ b/data-runners/hu-kozhaf/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/hu-kozhaf/requirements.txt .

--- a/data-runners/im-ardis/Dockerfile
+++ b/data-runners/im-ardis/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/im-ardis/requirements.txt .

--- a/data-runners/is-samgongustofa/Dockerfile
+++ b/data-runners/is-samgongustofa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/is-samgongustofa/requirements.txt .

--- a/data-runners/kg-caa/Dockerfile
+++ b/data-runners/kg-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/kg-caa/requirements.txt .

--- a/data-runners/kr-koca/Dockerfile
+++ b/data-runners/kr-koca/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/kr-koca/requirements.txt .

--- a/data-runners/ky-caa/Dockerfile
+++ b/data-runners/ky-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/lu-dac/Dockerfile
+++ b/data-runners/lu-dac/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/lu-dac/requirements.txt .

--- a/data-runners/lv-caa/Dockerfile
+++ b/data-runners/lv-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/lv-caa/requirements.txt .

--- a/data-runners/md-caa/Dockerfile
+++ b/data-runners/md-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/md-caa/requirements.txt .

--- a/data-runners/me-caa/Dockerfile
+++ b/data-runners/me-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/me-caa/requirements.txt .

--- a/data-runners/mictronics/Dockerfile
+++ b/data-runners/mictronics/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/mk-caa/Dockerfile
+++ b/data-runners/mk-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/mk-caa/requirements.txt .

--- a/data-runners/mv-caa/Dockerfile
+++ b/data-runners/mv-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/mv-caa/requirements.txt .

--- a/data-runners/nl-ilt/Dockerfile
+++ b/data-runners/nl-ilt/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/no-caa/Dockerfile
+++ b/data-runners/no-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/nz-caa/Dockerfile
+++ b/data-runners/nz-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/ourairports/Dockerfile
+++ b/data-runners/ourairports/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/pg-casapng/Dockerfile
+++ b/data-runners/pg-casapng/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/pg-casapng/requirements.txt .

--- a/data-runners/rs-cad/Dockerfile
+++ b/data-runners/rs-cad/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/rs-cad/requirements.txt .

--- a/data-runners/sg-caas/Dockerfile
+++ b/data-runners/sg-caas/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/sg-caas/requirements.txt .

--- a/data-runners/sk-nsat/Dockerfile
+++ b/data-runners/sk-nsat/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/sk-nsat/requirements.txt .

--- a/data-runners/tc-caa/Dockerfile
+++ b/data-runners/tc-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 WORKDIR /app
 COPY shared/requirements.txt shared_requirements.txt
 COPY data-runners/tc-caa/requirements.txt .

--- a/data-runners/uk-caa/Dockerfile
+++ b/data-runners/uk-caa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/data-runners/us-faa/Dockerfile
+++ b/data-runners/us-faa/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS base
+FROM python:3.14-slim AS base
 
 WORKDIR /app
 

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS base
+FROM python:3.14-slim AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- All 43 `Dockerfile`s (`receiver`, `processor`, `archive-processor`, all 40 `data-runners/*`) now pull `python:3.14-slim` instead of `python:3.11-slim`. Purely the `FROM` line — no other changes; `requirements.txt` floors are already loose enough for pip to resolve current-compatible versions on its own.

## Test plan
- [x] Full local test suite (`shared/`, every `data-runners/*/tests`, `tools/traffic-recorder/tests`) run under Python 3.14 — same results as before this change: everything passes except the two pre-existing, unrelated failures in `at-austrocontrol` (glider-type wording) and four in `ourairports` (stale test expectations), both confirmed present on `main` beforehand
- [x] Built `receiver/Dockerfile` (core component) for both `linux/amd64` and `linux/arm64`, ran `python3 -c "import receiver.main"` in each — imports cleanly, `sys.version` confirms 3.14.6
- [x] Built `data-runners/us-faa/Dockerfile` for both platforms, loaded and executed its `main.py` module in each — imports cleanly
- [x] Also attempted `processor/Dockerfile` as the original core-component target — found `processor/requirements.txt` is missing `pika` even though `processor/main.py` imports it, causing a runtime `ModuleNotFoundError`. Confirmed this is **pre-existing on `main`**, unrelated to the Python version bump (its `requirements.txt` never had `pika`, unlike `receiver`/`archive-processor` which do). Filed separately as #315 and used `receiver` for the core-component smoke test instead, since fixing it isn't in scope here ("no other functional changes")

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)