### PR TITLE
Add missing pika dependency to processor

### DIFF
--- a/processor/requirements.txt
+++ b/processor/requirements.txt
@@ -1,6 +1,7 @@
 pydantic>=2.0
 uuid7>=0.1.0
 pyModeS>=2.11
+pika>=1.3
 redis>=5.0
 paho-mqtt>=2.0
 shapely>=2.0


### PR DESCRIPTION
## Summary
- `processor/main.py` imports `pika` at module level, but `processor/requirements.txt` never listed it — a freshly built image crashed with `ModuleNotFoundError: No module named 'pika'` as soon as `processor.main` was imported.
- `receiver/requirements.txt` and `archive-processor/requirements.txt` both already had `pika>=1.3`; this was a processor-specific oversight.
- Found while smoke-testing #314's Python 3.14 upgrade.

## Test plan
- [x] Built `processor/Dockerfile` for both `linux/amd64` and `linux/arm64`, ran `python3 -c "import processor.main"` in each — imports cleanly on both (previously failed on both)
- [x] `processor` test suite — 99 passed

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)