### PR TITLE
traffic-recorder: show per-interval message count in status output

### DIFF
--- a/tools/traffic-recorder/main.py
+++ b/tools/traffic-recorder/main.py
@@ -286,6 +286,7 @@ def main() -> None:
         deadline = (start + args.duration) if args.duration else None
         print("Receiving data...")
 
+        last_total = 0
         try:
             while not stop_event.is_set():
                 stop_event.wait(30)
@@ -300,7 +301,8 @@ def main() -> None:
 
                 counts = ", ".join(f"{t.source_tag}={t.count}" for t in threads)
                 total = sum(t.count for t in threads)
-                print(f"[{int(elapsed):5d}s] {total} messages captured  ({counts})", flush=True)
+                print(f"[{int(elapsed):5d}s] {total - last_total} messages captured  ({counts})", flush=True)
+                last_total = total
         except KeyboardInterrupt:
             stop_event.set()
 


### PR DESCRIPTION
## Summary
- The 30s periodic status line printed the cumulative message total, making it hard to eyeball capture rate/gaps during a live capture
- Now prints the count received since the last print as the headline number, keeping per-source cumulative totals in parentheses

## Before / after
```
# before
[  30s] 50 messages captured  (978=50)
[  60s] 75 messages captured  (978=75)
[  90s] 179 messages captured  (978=179)

# after
[  30s] 50 messages captured  (978=50)
[  60s] 25 messages captured  (978=75)
[  90s] 104 messages captured  (978=179)
```

Fixes #318

## Test plan
- [x] Existing `tests/test_source_capture.py` suite passes (`pytest`)
- [x] Verified delta arithmetic against the issue's exact example sequence (50/75/179 → 50/25/104)